### PR TITLE
fill loot crate, compatible magazines with exceptions

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -73,6 +73,7 @@ class CfgFunctions
             class categoryOverrides {};
             class checkRadiosUnlocked {};
             class configSort {};
+            class compatibleMagazinesWithExceptions {};
             class dress {};
             class empty {};
             class equipmentClassToCategories {};

--- a/A3A/addons/core/functions/Ammunition/fn_compatibleMagazinesWithExceptions.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_compatibleMagazinesWithExceptions.sqf
@@ -1,0 +1,66 @@
+/*
+	Author:
+	Zets
+
+	Description:
+	Get all compatibile magazines except forbidden ones for selected weapons. Function looks both for magazines listed in "magazines" array & compatibile magazineWells.
+	
+	Params:
+		0: (String) :
+			Weapon class name
+		1: (Array) [Optional] :
+			List of magazines to be excluded from result
+		2: (Bool) [Optional] :
+			Decide if magazines with scope 1 should be also returned
+
+	Output:
+		Array of magazines (strings)
+
+	Usage:
+		[_weapon] call A3U_fnc_compatibleMagazinesWithExceptions;
+		[_weapon, _forbiddenList] call A3U_fnc_compatibleMagazinesWithExceptions;
+*/
+
+params [
+	["_weapon","",[""]],
+	["_forbiddenList",[],[[]]],
+	["_showHidden",false,[false]]
+];
+
+private _weaponCfg = configFile >> "CfgWeapons" >> _weapon;
+
+
+if (isClass _weaponCfg) then
+{
+	private _compatibleMagazines = [];
+
+	// Go through all available muzzles
+	{
+		_muzzle = if (_x == "this") then {_weaponCfg} else {_weaponCfg >> _x};
+
+		// Get magazines from "magazines" array
+		_magazinesList = getarray (_muzzle >> "magazines");
+
+		// Add magazines from magazine wells
+		{
+			{
+				_magazinesList append (getArray _x);
+			}foreach  configproperties [configFile >> "CfgMagazineWells" >> _x,"isArray _x"];
+		} foreach getArray (_muzzle >> "magazineWell");
+
+		// Add only unique entries to output
+		{
+			private _magazine		= _x;
+			private _magazineCfg	= configfile >> "cfgMagazines" >> _magazine;
+
+			if ( ((getnumber (_magazineCfg >> "scope") isEqualTo 2) || _showHidden) && !(_magazine in _forbiddenList) ) then {
+				_compatibleMagazines pushBackUnique _magazine;
+			};
+		} foreach _magazinesList;
+	} foreach getarray (_weaponCfg >> "muzzles");
+
+	_compatibleMagazines
+} else {
+	if (_weapon != "") then {["'%1' not found in CfgWeapons",_weapon] call bis_fnc_error;};
+	[]
+};

--- a/A3A/addons/core/functions/Ammunition/fn_fillLootCrate.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_fillLootCrate.sqf
@@ -173,7 +173,7 @@ if (_crateWepTypeMax != 0) then {
 			_crate addWeaponWithAttachmentsCargoGlobal [[ _loot, "", "", "", [], [], ""], _amount];
             Verbose_2("Adding %1 weapons of type %2", _amount, _loot);
 
-			private _magazines = compatibleMagazines _loot;
+			private _magazines = [_loot, A3U_forbiddenItems] call A3A_fnc_compatibleMagazinesWithExceptions;
 			if (count _magazines < 1) exitWith {};
 			if (_loot in allShotguns) then { _magazines = [_magazines select 0] };		// prevent doomsday
 
@@ -220,6 +220,7 @@ if (_crateItemTypeMax != 0) then {
 if (_crateAmmoTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateAmmoTypeMax do {
 		_available = (lootMagazine - _unlocks - itemCargo _crate);
+		_available = _available - A3U_forbiddenItems;
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Ammo Left in Loot List");
@@ -235,6 +236,7 @@ if (_crateAmmoTypeMax != 0) then {
 if (_crateExplosiveTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateExplosiveTypeMax do {
 		_available = (lootExplosive - _unlocks - itemCargo _crate);
+		_available = _available - A3U_forbiddenItems;
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Explosives Left in Loot List");
@@ -250,6 +252,7 @@ if (_crateExplosiveTypeMax != 0) then {
 if (_crateAttachmentTypeMax != 0) then {
 	for "_i" from 0 to (_crateAttachmentTypeMax call _fnc_pickNumberOfTypes) do {
 		_available = (lootAttachment - _unlocks - itemCargo _crate);
+		_available = _available - A3U_forbiddenItems;
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Attachment Left in Loot List");
@@ -264,7 +267,7 @@ if (_crateAttachmentTypeMax != 0) then {
 //Backpacks Loot
 if (_crateBackpackTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateBackpackTypeMax do {
-		_available = (lootBackpack - _unlocks - itemCargo _crate);
+		_available = (lootBackpack - _unlocks - itemCargo _crate - A3U_forbiddenItems);
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Backpacks Left in Loot List");
@@ -279,7 +282,7 @@ if (_crateBackpackTypeMax != 0) then {
 //Helmets Loot
 if (_crateHelmetTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateHelmetTypeMax do {
-		_available = (lootHelmet - _unlocks - itemCargo _crate);
+		_available = (lootHelmet - _unlocks - itemCargo _crate - A3U_forbiddenItems);
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Helmets Left in Loot List");
@@ -294,7 +297,7 @@ if (_crateHelmetTypeMax != 0) then {
 //Vests Loot
 if (_crateVestTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateVestTypeMax do {
-		_available = (lootVest - _unlocks - itemCargo _crate);
+		_available = (lootVest - _unlocks - itemCargo _crate - A3U_forbiddenItems);
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Vests Left in Loot List");
@@ -309,7 +312,7 @@ if (_crateVestTypeMax != 0) then {
 //Device Loot
 if (_crateDeviceTypeMax != 0) then {
 	for "_i" from 0 to floor random _crateDeviceTypeMax do {
-		_available = (lootDevice - _unlocks - itemCargo _crate);
+		_available = (lootDevice - _unlocks - itemCargo _crate - A3U_forbiddenItems);
 		_loot = selectRandom _available;
 		if (isNil "_loot") then {
             Debug("No Device Bags Left in Loot List");


### PR DESCRIPTION
## What type of PR is this.
1. [ ] Bug
2. [x] Change
3. [x] Enhancement

### What have you changed and why?
Information:
    Extended forbiddenItems logic with an extra check for compatible magazines so that they don't spawn in loot crates.

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 

********************************************************
Notes:
