### PR TITLE
add confirmation message for rebel training

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAskillAdd.sqf
@@ -21,8 +21,19 @@ if (skillFIA >= SKILL_CAP) exitWith {
     ] spawn SCRT_fnc_ui_showMessage;
 };
 
-_resourcesFIA = server getVariable "resourcesFIA";
-_costs = 1000 + (1.5*(skillFIA *750));
+private _resourcesFIA = server getVariable "resourcesFIA";
+private _costs = 1000 + (1.5*(skillFIA *750));
+
+private _result = [(format["Are you sure? Price will be %2%1", _costs, A3A_faction_civ get "currencySymbol"]), "Confirm", true, true] call BIS_fnc_guiMessage;
+
+if (_result isEqualTo false) exitWith {
+    [
+        localize "STR_notifiers_fail_type",
+        format [localize "STR_notifiers_skill_header", FactionGet(reb, "name")],
+        parseText localize "STR_notifiers_skill_cancelled",
+        30
+    ] spawn SCRT_fnc_ui_showMessage;
+};
 
 if (_resourcesFIA < _costs) exitWith {
     [

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -3276,6 +3276,12 @@
                 <Chinesesimp>%2技能等级已升级。&lt;br/&gt;当前等级为%1。</Chinesesimp>
                 <Korean>%2의 숙련도 레벨이 업그레이드되었습니다.&lt;br/&gt;현재 레벨은 %1입니다.</Korean>
             </Key>
+            <Key ID="STR_notifiers_skill_cancelled">
+                <Original>Confirmation was cancelled.</Original>
+                <Russian>Placeholder</Russian>
+                <Chinesesimp>Placeholder</Chinesesimp>
+                <Korean>Placeholder</Korean>
+            </Key>
             <Key ID="STR_notifiers_disband_header">
                 <Original>Disband</Original>
                 <Russian>Роспуск</Russian>

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -3278,7 +3278,7 @@
             </Key>
             <Key ID="STR_notifiers_skill_cancelled">
                 <Original>Price was not confirmed.</Original>
-                <Russian>цена не была подтверждена.</Russian>
+                <Russian>Цена не была подтверждена.</Russian>
             </Key>
             <Key ID="STR_notifiers_disband_header">
                 <Original>Disband</Original>

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -3277,10 +3277,8 @@
                 <Korean>%2의 숙련도 레벨이 업그레이드되었습니다.&lt;br/&gt;현재 레벨은 %1입니다.</Korean>
             </Key>
             <Key ID="STR_notifiers_skill_cancelled">
-                <Original>Confirmation was cancelled.</Original>
-                <Russian>Placeholder</Russian>
-                <Chinesesimp>Placeholder</Chinesesimp>
-                <Korean>Placeholder</Korean>
+                <Original>Price was not confirmed.</Original>
+                <Russian>цена не была подтверждена.</Russian>
             </Key>
             <Key ID="STR_notifiers_disband_header">
                 <Original>Disband</Original>

--- a/A3A/addons/scrt/UILayouts/commanderMenu.hpp
+++ b/A3A/addons/scrt/UILayouts/commanderMenu.hpp
@@ -475,7 +475,7 @@ class commanderMenu
 					h = "3 * pixelGridNoUIScale * pixelH";	
 					sizeEx = "((pixelH * (pixelGridNoUIScale) * 2) * 1.25) * 0.5";	
 					shadow = 2;	
-					action = "[] call A3A_fnc_FIAskillAdd";		
+					action = "[] spawn A3A_fnc_FIAskillAdd";		
 				};
 
 				class rebelLoadoutButton: ButtonBase


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
Added a confirmation message when you train rebel troops, to show price and give user a chance to back out

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Go in commander menu, find "Train Rebel Troops", click it

********************************************************
Notes:
