### PR TITLE
Extend weather variables

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -129,8 +129,26 @@ if (_varName in specialVarLoads) then {
             // Avoid persisting potentially-broken fog values
             private _fogParams = _varValue select 0;
             0 setFog [_fogParams#0, (_fogParams#1) max 0, (_fogParams#2) max 0];
-            0 setRain (_varValue select 1);
-            forceWeatherChange;
+            0 setOvercast (_varValue select 1);
+
+            // Ensure compatibility with < v10.7.0
+            if(count _varValue == 12) then {
+                0 setGusts (_varValue select 2);
+                setHumidity (_varValue select 3);
+                0 setLightnings (_varValue select 4);
+                0 setRain (_varValue select 5);
+                private _rainParams = _varValue select 6;
+                0 setRainbow (_varValue select 7);
+                0 setWaves (_varValue select 8);
+                private _windParams = _varValue select 9;
+                setWind [_windParams#0, _windParams#1, _windParams#2];
+                0 setWindDir (_varValue select 10);
+                0 setWindStr (_varValue select 11);
+                forceWeatherChange;
+                _rainParams call BIS_fnc_setRain;
+            } else {
+                forceWeatherChange;
+            };
         };
 
         case 'resourcesFIA': {

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -84,7 +84,7 @@ private _antennasDeadPositions = [];
 ["distanceSPWN", distanceSPWN] call A3A_fnc_setStatVariable;		// backwards compatibility
 ["chopForest", chopForest] call A3A_fnc_setStatVariable;
 ["nextTick", nextTick - time] call A3A_fnc_setStatVariable;
-["weather",[fogParams,overcast]] call A3A_fnc_setStatVariable; //rrobably should be rain
+["weather",[fogParams,overcast,gusts,humidity,lightnings,rain,rainParams,rainbow,waves,wind,windDir,windStr]] call A3A_fnc_setStatVariable; //rrobably should be rain
 private _destroyedPositions = destroyedBuildings apply { getPosATL _x };
 ["destroyedBuildings",_destroyedPositions] call A3A_fnc_setStatVariable;
 


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

I have changed the saving of weather params because I got tired of having to manually set lightning / rain every time the server restarts (adds a lot of atmosphere for antistasi stalker). In the process, I thought why not add all weather params, so the weather environment at the time of saving is persisted 100%. So that's what I did.

1. Fix a bug where the value of `overcast` was used to call `setRain`, meaning overcast was not persisted and rain was incorrectly set. 
2. Added all missing weather parameters to the save game.
3. Ensured compatibility with old save game.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
4. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?

Steps:

Use stable branch to:
1. Create an old save game,
2. Change weather params (using Zeus Enhanced allows you to fine tune and test each of the params)
3. Save the game
4. (Optional) Load the saved game and verify (again, easier with Zeus enhanced) that the only the fog params are correctly restored

Next, use this branch to:
1. Load the old save game (verifies that old save games are compatible)
2. Change weather params (using Zeus Enhanced allows you to fine tune and test each of the params)
3. Save the game
4. Load the saved game and verify (again, easier with Zeus enhanced) that all parameters have been restored correctly (there are some issues with wind though, I think it is tied to other params somewhat).