### PR TITLE
Airdrop loot crate fix

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
@@ -291,13 +291,18 @@ switch(true) do {
 
         private _boxesCount = { _x distance (getMarkerPos respawnTeamPlayer) < 25 } count _boxes;
 
-        [0, 400 * _boxesCount] remoteExec ["A3A_fnc_resourcesFIA",2];
+        {
+            if ((typeOf _x) isEqualTo (_faction get "ammobox")) then {
+                [_x] remoteExec ["jn_fnc_arsenal_cargoToArsenal",2];
+            };
+        } forEach _boxes;
+
         { 
             [300 * _boxesCount,_x] call A3A_fnc_addMoneyPlayer;
             [10 * _boxesCount, _x] call A3A_fnc_addScorePlayer;
         } forEach (call SCRT_fnc_misc_getRebelPlayers);
-        [10,theBoss] call A3A_fnc_addScorePlayer;
-        [250,theBoss, true] call A3A_fnc_addMoneyPlayer;
+        [10, theBoss] call A3A_fnc_addScorePlayer;
+        [250, theBoss, true] call A3A_fnc_addMoneyPlayer;
 
         [_taskId, "LOG", "SUCCEEDED"] call A3A_fnc_taskSetState;
     };


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:
Made the loot crates auto-transfer loot upon airdrop mission completion, to prevent loot loss on GC/Mission cleanup

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Run the airdrop function with a marker name as argument, go to task, throw a smoke grenade, wait for crates to land, take back to HQ.

You will have to temporarily set WL to around 10 to ensure you get at least one loot crate;
`tierWar = 10;`

********************************************************
Notes:
