### PR TITLE
Alternate Save Reimplementation

### DIFF
--- a/A3A/addons/gui/dialogues/setupDialog.hpp
+++ b/A3A/addons/gui/dialogues/setupDialog.hpp
@@ -205,14 +205,32 @@ class A3A_SetupDialog : A3A_TabbedDialog
                     w = 26 * GRID_W;
                     h = 4 * GRID_H;
                 };
+                class NewNamespaceCheck: A3A_Checkbox {
+                    idc = A3A_IDC_SETUP_NAMESPACECHECKBOX;
+                    onCheckedChanged = "['newNamespaceCheck'] call A3A_fnc_setupLoadgameTab";
+                    x = 126 * GRID_W;
+                    y = 30 * GRID_H;
+                    w = 4 * GRID_W;
+                    h = 4 * GRID_H;
+                };
+                class NewNamespaceText: A3A_text {
+                    idc = A3A_IDC_SETUP_NAMESPACETEXT;
+                    text = $STR_antistasi_dialogs_setup_use_new_namespace;
+                    x = 130 * GRID_W;
+                    y = 30 * GRID_H;
+                    w = 26 * GRID_W;
+                    h = 4 * GRID_H;
+                };
                 class SetHQPosButton: A3A_Button {
                     idc = A3A_IDC_SETUP_HQPOSBUTTON;
                     text = $STR_antistasi_dialogs_setup_set_hq_position;
                     onButtonClick = "['setHQPos'] call A3A_fnc_setupLoadgameTab";
                     x = 126 * GRID_W;
-                    y = 30 * GRID_H;
+                    y = 36 * GRID_H;
                     w = 30 * GRID_W;
-                    h = 6 * GRID_H;
+                    h = 5 * GRID_H;
+                    // w = 36 * GRID_W;
+                    // h = 6 * GRID_H;
                 };
 
                 class DeleteButton: A3A_Button {

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
@@ -31,6 +31,7 @@ private _startCtrl = _display displayCtrl A3A_IDC_SETUP_STARTBUTTON;
 private _newGameCtrl = _display displayCtrl A3A_IDC_SETUP_NEWGAMECHECKBOX;
 private _copyGameCtrl = _display displayCtrl A3A_IDC_SETUP_COPYGAMECHECKBOX;
 private _oldParamsCtrl = _display displayCtrl A3A_IDC_SETUP_OLDPARAMSCHECKBOX;
+private _newSaveCtrl = _display displayCtrl A3A_IDC_SETUP_NAMESPACECHECKBOX;
 
 private _saveBoxColumns = [
     ["gameID", "ID", 0, 9],
@@ -76,8 +77,10 @@ switch (_mode) do
         _startCtrl ctrlEnable (_sameMap or _newGame);
         _copyGameCtrl ctrlShow _newGame;
         _oldParamsCtrl ctrlShow _newGame;
+        _newSaveCtrl ctrlShow _newGame;
         (_display displayCtrl A3A_IDC_SETUP_COPYGAMETEXT) ctrlShow _newGame;
         (_display displayCtrl A3A_IDC_SETUP_OLDPARAMSTEXT) ctrlShow _newGame;
+        (_display displayCtrl A3A_IDC_SETUP_NAMESPACETEXT) ctrlShow _newGame;
         (_display displayCtrl A3A_IDC_SETUP_HQPOSBUTTON) ctrlShow (_newGame && !cbChecked _copyGameCtrl);
 
         // If we're selecting a game to load, load factions if available
@@ -191,7 +194,7 @@ switch (_mode) do
         if (_saveData get "name" != "") then {
             _confirmText = _confirmText + format [localize "STR_antistasi_dialogs_setup_confirm_game_name", _saveData get "name"];
         };
-        _saveData set ["useNewNamespace", true];
+        _saveData set ["useNewNamespace", cbChecked (_display displayCtrl A3A_IDC_SETUP_NAMESPACECHECKBOX)];
 
         // Factions tab: [factions, addonvics, DLC]
         private _factions = ["getFactions"] call A3A_fnc_setupFactionsTab;

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
@@ -78,6 +78,7 @@ switch (_mode) do
         _copyGameCtrl ctrlShow _newGame;
         _oldParamsCtrl ctrlShow _newGame;
         _newSaveCtrl ctrlShow _newGame;
+        _newSaveCtrl cbSetChecked true;
         (_display displayCtrl A3A_IDC_SETUP_COPYGAMETEXT) ctrlShow _newGame;
         (_display displayCtrl A3A_IDC_SETUP_OLDPARAMSTEXT) ctrlShow _newGame;
         (_display displayCtrl A3A_IDC_SETUP_NAMESPACETEXT) ctrlShow _newGame;
@@ -194,7 +195,7 @@ switch (_mode) do
         if (_saveData get "name" != "") then {
             _confirmText = _confirmText + format [localize "STR_antistasi_dialogs_setup_confirm_game_name", _saveData get "name"];
         };
-        _saveData set ["useNewNamespace", cbChecked (_display displayCtrl A3A_IDC_SETUP_NAMESPACECHECKBOX)];
+        _saveData set ["useNewNamespace", cbChecked _newSaveCtrl];
 
         // Factions tab: [factions, addonvics, DLC]
         private _factions = ["getFactions"] call A3A_fnc_setupFactionsTab;


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:
Added the "Use New Save" button to the setup dialog, should solve the issue for linux users being unable to save

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

Saves need to be extensively tested to make sure this change hasn't broken anything

### How can the changes be tested?
Steps:

Create new game, tick "Use New Save" to have default save behaviour. Leave it unchecked to test the old save file method

********************************************************
Notes:
Why this was removed from the GUI in the first place, I do not know. It seems that it was forced to use the new save file, I assume because Socrates wasn't aware of the issue with Linux.