### PR TITLE
Added and Fixed some strings (Psycool3695)

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -5329,11 +5329,13 @@
                 <Original>Hide Enemy Zone Markers</Original>
                 <English>Hide Enemy Zone Markers</English>
                 <Russian>Спрятать маркеры вражеских баз</Russian>
+                <Korean>적 구역 마커 숨기기</Korean>
             </Key>
             <Key ID="STR_A3AU_hide_enemy_markers_recon_plane_distance">
                 <Original>Recon Plane Zone Reveal Distance</Original>
                 <English>Recon Plane Zone Reveal Distance</English>
                 <Russian>Дистанция открытыя маркеров самолётом разведки</Russian>
+                <Korean>정찰기의 정찰 거리</Korean>
             </Key>
             <Key ID="STR_A3AU_stamina_enabled">
                 <Original>Enable Stamina (Vanilla)</Original>

--- a/A3A/addons/hals/Stringtable.xml
+++ b/A3A/addons/hals/Stringtable.xml
@@ -506,6 +506,7 @@
                 <Original>CSLA</Original>
                 <English>CSLA</English>
                 <Russian>CSLA</Russian>
+                <Korean>CSLA</Korean>
             </Key>
             <Key ID="STR_A3AU_RF">
                 <Original>Reaction Force</Original>
@@ -597,7 +598,7 @@
                 <Russian>IFA</Russian>
                 <Korean>IFA</Korean>
             </Key>
-			<Key ID="STR_A3AU_fow">
+            <Key ID="STR_A3AU_fow">
                 <Original>FoW</Original>
                 <English>FoW</English>
                 <Russian>FoW</Russian>

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -5870,11 +5870,13 @@
             <Key ID="STR_antistasi_dialogs_moveout_crew_title">
                 <Original>Moveout vehicle crew</Original>
                 <Russian>Выгнать экипаж их техники</Russian>
+                <Korean>차량 승무원 내보내기</Korean>
             </Key>
             <Key ID="STR_antistasi_dialogs_moveout_crew_tooltip">
                 <Original>Moves out crew from vehicle you loking at.</Original>
                 <Russian>Выгоняет экипаж из техники на которую вы смотрите.</Russian>
-            </Key>>
+                <Korean>현재 보고 있는 차량의 승무원을 내보냅니다.</Korean>
+            </Key>
             <Key ID="STR_antistasi_dialogs_arsenal_limits_title">
                 <Original>Arsenal Limits</Original>
                 <Russian>Лимиты арсенала</Russian>
@@ -6221,7 +6223,7 @@
                 <Original>Antistasi Ultimate - %1, Version: %2, Unlock Weapon Number: %3, Limited Fast Travel: %4, Rivals: %5, Time since GC: %6</Original>
                 <Russian>Antistasi Ultimate - %1, Версия: %2, Кол-во орудий для разблок-ки: %3, Ограниченное быстрое перемещение по карте: %4, Инсургенты: %5, Прошло времени с момента сборки мусора: %6</Russian>
                 <Chinesesimp>Antistasi Ultimate - %1, 版本: %2, 解锁武器数量: %3, 是否限制快速旅行: %4, 对手: %5, GC之后经过的时间: %6</Chinesesimp>
-                <Korean>안티스타시 플러스 - %1, 버전: %2, 무기 언락 수: 53, 빠른 이동 제한: %4 라이벌: %5, 쓰레기 청소 이후 지난 시간:%6</Korean>
+                <Korean>안티스타시 플러스 - %1, 버전: %2, 무기 언락 수: %3, 빠른 이동 제한: %4 라이벌: %5, 쓰레기 청소 이후 지난 시간:%6</Korean>
             </Key>
             <Key ID="STR_commander_menu_skill_level_title">
                 <Original>%1 Skill Level: %2/%3</Original>
@@ -8072,6 +8074,7 @@
             </Key>
             <Key ID="STR_antistasi_actions_unconscious_action_prompt_withstand">
                 <Original>&lt;br/&gt;Press H to Withstand.</Original>
+                <Korean>&lt;br/&gt;H키를 눌러 스스로 일어나십시오.</Korean>
             </Key>
             <Key ID="STR_antistasi_actions_common_access_vehicle_marker_text">
                 <Original>Access Vehicle Market</Original>
@@ -10965,10 +10968,12 @@
             <Key ID="STR_A3A_Base_moveOutCrew_header">
                 <Original>Move out crew</Original>
                 <Russian>Выгнать экипаж из техники</Russian>
+                <Korean>승무원 내보내기</Korean>
             </Key>
             <Key ID="STR_A3A_Base_moveOutCrew_err0">
                 <Original>Vehicle must contain rebel crew or civillian crew.</Original>
                 <Russian>В транспортном средстве должен находиться экипаж повстанцев или гражданских.</Russian>
+                <Korean>차량에 반드시 반군 또는 민간인 승무원이 타고 있어야 합니다.</Korean>
             </Key>
             <Key ID="STR_A3A_Base_sellVehicle_err0">
                 <Original>Vehicle must be closer than 50 meters to the headquarters marker.</Original>
@@ -11009,6 +11014,7 @@
             <Key ID="STR_A3A_Base_moveOutCrew_success">
                 <Original>Crew moved out.</Original>
                 <Russian>Экипаж покинул технику.</Russian>
+                <Korean>승무원을 내보냈습니다.</Korean>
             </Key>
         </Container>
         <Container name="A3A_CREATE">


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information: Added missing Korean strings, fixed "<;/Key>>" to "<;/Key>" and improved some Koreans.
P.S: The semicolon was added intentionally so that this character would appear in this article. Of course, Stringtable doesn't have that.

This is a duplicate of [Psycool3695-unstable](https://github.com/Psycool3695/A3-Antistasi-Ultimate/tree/unstable) by [Psycool3695](https://github.com/Psycool3695) that resolves the merge issues of the original PR (#164)

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Just change the language of the game to Korean and run it.

********************************************************
Notes: I didn't test as a dedicated server. After all, there is meaningless in testing the dedicated server because it runs only with the Original string, not the language of the server's country.
