### PR TITLE
Rename saves from AntistasiPlus to AntistasiUltimate

### DIFF
--- a/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
+++ b/A3A/addons/core/functions/Save/fn_collectSaveData.sqf
@@ -13,7 +13,7 @@ private _campaignIDs = [];
 private _serverID = profileNameSpace getVariable ["ss_ServerID",""];
 
 // Old Plus saves
-private _saveList = [profileNamespace getVariable "antistasiPlus2SavedGames"] param [0, [], [[]]];
+private _saveList = [profileNamespace getVariable "antistasiUltimate2SavedGames"] param [0, [], [[]]];
 {
     _x params ["_cid", "_map", "_gameType"];
     _campaignIDs pushBack _cid;
@@ -36,7 +36,7 @@ if !(_oldCampaignID in _campaignIDs) then {
 };
 
 // missionProfileNamespace saves
-private _saveList2 = [missionProfileNamespace getVariable "antistasiPlus2SavedGames"] param [0, [], [[]]];
+private _saveList2 = [missionProfileNamespace getVariable "antistasiUltimate2SavedGames"] param [0, [], [[]]];
 {
     _x params ["_cid", "_map"];
     A3A_saveTarget = [false, _cid, _map];

--- a/A3A/addons/core/functions/Save/fn_deleteSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_deleteSave.sqf
@@ -55,9 +55,9 @@ private _savedPlayers = _namespace getVariable ["savedPlayers" + _postfix, []];
 
 
 // Remove this campaign from the save list, if present
-private _saveList = [_namespace getVariable "antistasiPlus2SavedGames"] param [0, [], [[]]];
+private _saveList = [_namespace getVariable "antistasiUltimate2SavedGames"] param [0, [], [[]]];
 _saveIndex = _saveList findIf { _x#0 == _campaignID };
 _saveList deleteAt _saveIndex;
-_namespace setVariable ["antistasiPlus2SavedGames", _saveList];
+_namespace setVariable ["antistasiUltimate2SavedGames", _saveList];
 
 if (_serverID isEqualType false) then { saveMissionProfileNamespace } else { saveProfileNamespace };

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -38,10 +38,10 @@ private _namespace = [profileNamespace, missionProfileNamespace] select _saveToN
 
 
 // Move this campaign to the end of the save list
-private _saveList = [_namespace getVariable "antistasiPlus2SavedGames"] param [0, [], [[]]];
+private _saveList = [_namespace getVariable "antistasiUltimate2SavedGames"] param [0, [], [[]]];
 _saveList deleteAt (_saveList findIf { _x select 0 == _campaignID });
 _saveList pushBack [_campaignID, worldName, "Greenfor"];
-_namespace setVariable ["antistasiPlus2SavedGames", _saveList];
+_namespace setVariable ["antistasiUltimate2SavedGames", _saveList];
 
 // Update the legacy campaign ID for backwards compatibility
 if (!_saveToNewNamespace) then { _namespace setVariable ["ss_campaignID", _campaignID] };

--- a/A3A/addons/maps/MissionDescription/master.hpp
+++ b/A3A/addons/maps/MissionDescription/master.hpp
@@ -7,7 +7,7 @@
 author = $STR_antistasi_credits_generic_author_text;
 Keys[] = {"A3-Antistasi-is-not-available-in-single-player"};
 KeysLimit = 2;  // Even if player tampers with his unlocked keys, this will never become true.
-missionGroup = "AntistasiPlus";
+missionGroup = "AntistasiUltimate";
 
 #ifndef CUSTOM_A3A_CLASS
 	class A3A {


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
Renamed the missionGroup to AntistasiUltimate, will allow us to ensure proper save functionality/sanitation (it also won't overwrite A+ saves, and vice versa)

This will essentially wipe all saves, so inform accordingly

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [ ] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

Ensure saves still work correctly

### How can the changes be tested?
Steps:
Try and save using new and old save file

********************************************************
Notes:
