### PR TITLE
Save/load revealed zones

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -61,6 +61,9 @@ if (isServer) then {
 	["constructionsX"] call A3A_fnc_getStatVariable;
 	["isRivalsDiscoveryQuestAssigned"] call A3A_fnc_getStatVariable;
 
+	//Antistasi Ultimate variables
+	["revealedZones"] call A3A_fnc_getStatVariable; publicVariable "revealedZones";
+
 	//===========================================================================
 
 	//RESTORE THE STATE OF THE 'UNLOCKED' VARIABLES USING JNA_DATALIST

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -42,7 +42,7 @@ if (isNil "specialVarLoads") then {
         "destroyedMilAdmins",
         "rebelLoadouts", "randomizeRebelLoadoutUniforms",
         "areRivalsDefeated", "areRivalsDiscovered", "inactivityRivals", "rivalsLocationsMap", "rivalsExcludedLocations",
-        "nextRivalsLocationReveal", "isRivalsDiscoveryQuestAssigned"
+        "nextRivalsLocationReveal", "isRivalsDiscoveryQuestAssigned", "revealedZones"
     ] createHashMapFromArray [];
 };
 
@@ -657,11 +657,21 @@ if (_varName in specialVarLoads) then {
 		};
 
         case 'isRivalsDiscoveryQuestAssigned': {
-            isRivalsDiscoveryQuestAssigned = _varvalue;  
+            isRivalsDiscoveryQuestAssigned = _varValue;  
             publicVariable "isRivalsDiscoveryQuestAssigned";
             if (isRivalsDiscoveryQuestAssigned && {!areRivalsDiscovered}) then {
                 [] call SCRT_fnc_rivals_prepareQuest;
             };
+        };
+
+        case 'revealedZones': {
+            revealedZones = _varValue;
+
+            if (isNil "revealedZones") then {
+                revealedZones = [];
+            };
+
+            publicVariable "revealedZones";
         };
     };
 } else {

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -113,6 +113,22 @@ private _milAdminPositions = [];
 { _milAdminPositions pushBack getPos _x; } forEach A3A_destroyedMilAdministrations;
 ["destroyedMilAdmins", _milAdminPositions] call A3A_fnc_setStatVariable;
 
+//Antistasi Ultimate variables
+private _revealedZones = [];
+
+{
+    private _markerSide = sidesX getVariable [_x, sideUnknown];
+    if (_markerSide isNotEqualTo sideUnknown && {_markerSide isNotEqualTo resistance} && {!(_x in markersImmune)}) then 
+    {
+		private _dummyMarker = "Dum"+_x;
+        if (markerAlpha _dummyMarker isNotEqualTo 0) then {_revealedZones pushBack _x};
+    };
+} forEach markersX;
+
+["revealedZones", _revealedZones] call A3A_fnc_setStatVariable;
+
+diag_log format["Saving revealed zones: %1", _revealedZones];
+//Antistasi Ultimate variables ^
 
 private ["_hrBackground","_resourcesBackground","_veh","_typeVehX","_weaponsX","_ammunition","_items","_backpcks","_containers","_arrayEst","_posVeh","_dierVeh","_prestigeOPFOR","_prestigeBLUFOR","_city","_dataX","_markersX","_garrison","_arrayMrkMF","_positionOutpost","_typeMine","_posMine","_detected","_typesX","_exists","_friendX"];
 

--- a/A3A/addons/ultimate/functions/init/fn_initZones.sqf
+++ b/A3A/addons/ultimate/functions/init/fn_initZones.sqf
@@ -12,12 +12,26 @@ markersImmune = markersX select {
     {(_x in airportsX)}
 }; // this var should in theory only be seen by the server
 
+private _revealedZones = revealedZones;
+
+if (isNil "revealedZones") then {
+    revealedZones = [];
+};
+
+diag_log _revealedZones;
+
 {
     private _markerSide = sidesX getVariable [_x, sideUnknown];
+
+    if (_x in _revealedZones) then {
+        [_x] call A3U_fnc_revealZone;
+        continue;
+    };
+
     if (_markerSide isNotEqualTo sideUnknown && {_markerSide isNotEqualTo resistance}) then 
     {
-        if (_x in airportsX || {_x in citiesX}) then {} else {
-            "Dum"+_x setMarkerAlpha 0; // "Dum" is for dummy marker, the actual one you see in-game. The editor one is hidden
-        };
+        if (_x in airportsX || {_x in citiesX}) then {continue};
+
+        "Dum"+_x setMarkerAlpha 0; // "Dum" is for dummy marker, the actual one you see in-game. The editor one is hidden
     };
 } forEach _markersX;

--- a/A3A/addons/ultimate/functions/init/fn_initZones.sqf
+++ b/A3A/addons/ultimate/functions/init/fn_initZones.sqf
@@ -18,8 +18,6 @@ if (isNil "revealedZones") then {
     revealedZones = [];
 };
 
-diag_log _revealedZones;
-
 {
     private _markerSide = sidesX getVariable [_x, sideUnknown];
 


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
Added saving/loading support for revealed zones

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Enable hide zone markers, reveal a few zones using `[5, "A developer has revealed some zones."] call A3U_fnc_revealRandomZones;`.

Capture an outpost/resource/etc, save, check rpt to make sure it has logged the saved zones

Load the save again, check if the zones are still revealed

********************************************************
Notes:
