### PR TITLE
Vehicle Market - Use diminishing returns approach on vehicle price

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -12,13 +12,15 @@ _costs = if (isNil "_costs") then {
 
 	0
 } else {
-	private _multiplier = if (count seaports > 0) then {
-		{sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports;
-	} else {
-		{sidesX getVariable [_x,sideUnknown] == teamPlayer} count resourcesX;
-	};
+	private _multiplierSeaport = {sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports;
+	private _multiplierResource = {sidesX getVariable [_x,sideUnknown] == teamPlayer} count resourcesX;
 
-	round (_costs - (_costs * (0.1 * _multiplier))) // This needs to be reworked, very OP for little to no reason.
+	private _reductionFactorSeaport = 0.1; // Base reduction per seaport
+	private _reductionFactorResource = 0.02; // Base reduction per resource
+
+	private _diminishingFactor = 1 / (1 + (_multiplierSeaport * _reductionFactorSeaport) + (_multiplierResource * _reductionFactorResource)); // Diminishing returns
+
+	round (_costs * _diminishingFactor) // Apply diminishing returns to reduce cost
 };
 
 

--- a/A3A/addons/ultimate/functions/REINF/fn_blackMarketVehiclePrice.sqf
+++ b/A3A/addons/ultimate/functions/REINF/fn_blackMarketVehiclePrice.sqf
@@ -23,13 +23,15 @@ _cost = if (isNil "_cost") then {
 
 	0
 } else {
-	private _multiplier = if (count seaports > 0) then {
-		{sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports;
-	} else {
-		{sidesX getVariable [_x,sideUnknown] == teamPlayer} count resourcesX;
-	};
+	private _multiplierSeaport = {sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports;
+	private _multiplierResource = {sidesX getVariable [_x,sideUnknown] == teamPlayer} count resourcesX;
 
-	round (_cost - (_cost * (0.1 * _multiplier))) // This needs to be reworked, very OP for little to no reason.
+	private _reductionFactorSeaport = 0.1; // Base reduction per seaport
+	private _reductionFactorResource = 0.02; // Base reduction per resource
+
+	private _diminishingFactor = 1 / (1 + (_multiplierSeaport * _reductionFactorSeaport) + (_multiplierResource * _reductionFactorResource)); // Diminishing returns
+
+	round (_cost * _diminishingFactor) // Apply diminishing returns to reduce cost
 };
 
 _cost


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [x] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
- Use diminishing returns approach on vehicle price to fix #350
![image](https://github.com/user-attachments/assets/7712c3cd-9af7-4625-adb8-a57ba033f0bb)
![image](https://github.com/user-attachments/assets/36d6d634-fee5-4329-8e9f-11500e32f7d3)

- The curve is like: (new price=`_defaultPrice`*`_diminishingFactor`)
![image](https://github.com/user-attachments/assets/9d560a74-5f27-42e8-8e5c-9d99cdb1edee)
The `_reductionFactorSeaport` and `_reductionFactorResource` could be changed to change this curve

- Benefits: 
1. fix #350
2. Seaports and resources are both considered to calculate discount by `_multiplierSeaport` and `_multiplierResource`
3. The more seaports/resources occupied, the less discount incremental

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #350!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Not Applicable.
********************************************************
Notes:
The `_reductionFactorSeaport` and `_reductionFactorResource` could be changed to change the price curve