### PR TITLE
Add support for weighted-list faction templates.

### DIFF
--- a/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
+++ b/A3A/addons/core/Templates/Templates/#Examples/FactionExample.sqf
@@ -227,7 +227,29 @@ _sfLoadoutData set ["vests", []];
 _sfLoadoutData set ["backpacks", []];
 _sfLoadoutData set ["helmets", []];
 _sfLoadoutData set ["binoculars", []];
+
 //["Weapon", "Muzzle", "Rail", "Sight", [], [], "Bipod"];
+
+// The two empty lists are for magazines - leave them empty for whatever the weapon's default mag is, or fill them for a given ratio (i.e. ["tracer", "regular", "regular"]). 
+// The second list is for underbarrel mags.
+
+// Note: muzzle, rail, sight, and bipod slots can be either a string for a specific item, or an array for a list of items. Arrays can be defined separately from weapons.
+// Arrays (both for attachments and for the larger lists of weapons) can either be a regular list or a weighted list that alternates between item and weight.
+// See https://community.bistudio.com/wiki/selectRandomWeighted for details.
+// If a given spawn list is made a weighted list, make sure that anything that adds to that list (e.g. optional DLC compatibility) is also a weighted list, or everything breaks.
+// Everything in this also applies to e.g. uniforms and equipment, but does NOT apply to vehicles.
+
+// Example of a weighted spawn list, with attachments and etc, using all possible methods of declaring lists:
+/*
+_sfM4Optics = ["optic_holo", 2, "optic_acog", 1, "", 1]; //weighted list - 50% chance holo, 25% chance acog, 25% chance nothing
+_sfM4Attachments = ["flashlight", ""]; //unweighted list, even distribution between flashlight or nothing
+_sfLoadoutData set ["rifles", [
+    ["rifle_m4a1", "suppressor_m4", _sfM4Attachments,  _sfM4Optics, [], [], ""], 2,
+    ["rifle_m4a1_camo", "suppressor_m4", _sfM4Attachments,  _sfM4Optics, [], [], ""], 1 //2:1 ratio of regular and camo M4s
+]]; 
+_sfM4Optics append ["optic_thermal", 0.1]; //this works even if done after the optics lists are applied since _sfM4Optics is stored as a reference, which is useful for DLC/mod compats
+
+*/
 
 _sfLoadoutData set ["rifles", []];
 _sfLoadoutData set ["carbines", []];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
@@ -1,7 +1,21 @@
-(_sfLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F", 1.5, "B_ViperHarness_oli_F", 1.5];
-
-(_eliteLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F", 0.75,"B_ViperHarness_oli_F", 0.75];
-
-_helmets append ["H_MilCap_gen_F", 10, "H_Beret_gen_F", 8];
-(_policeLoadoutData get "vests") append []"V_TacVest_gen_F", 6];
-(_policeLoadoutData get "uniforms") append ["U_B_GEN_Soldier_F", 10, "U_B_GEN_Commander_F", 8];
+(_sfLoadoutData get "backpacks") append [
+	"B_ViperLightHarness_oli_F", 1.5,
+	"B_ViperHarness_oli_F", 1.5
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "backpacks") append [
+	"B_ViperLightHarness_oli_F", 0.75,
+	"B_ViperHarness_oli_F", 0.75
+];
+//////////////////////////////////////////////////////
+_helmets append [ // Police helmets.
+	"H_MilCap_gen_F", 10, 
+	"H_Beret_gen_F", 8
+];
+(_policeLoadoutData get "vests") append [
+	"V_TacVest_gen_F", 6
+];
+(_policeLoadoutData get "uniforms") append [
+	"U_B_GEN_Soldier_F", 10,
+	"U_B_GEN_Commander_F", 8
+];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
@@ -13,7 +13,7 @@ _helmets append [ // Police helmets.
 	"H_Beret_gen_F", 8
 ];
 (_policeLoadoutData get "vests") append [
-	"V_TacVest_gen_F", 6
+	"V_TacVest_gen_F", 4
 ];
 (_policeLoadoutData get "uniforms") append [
 	"U_B_GEN_Soldier_F", 10,

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Apex/Vanilla_AAF.sqf
@@ -1,7 +1,7 @@
-(_sfLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F","B_ViperHarness_oli_F"];
+(_sfLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F", 1.5, "B_ViperHarness_oli_F", 1.5];
 
-(_eliteLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F","B_ViperHarness_oli_F"];
+(_eliteLoadoutData get "backpacks") append ["B_ViperLightHarness_oli_F", 0.75,"B_ViperHarness_oli_F", 0.75];
 
-_helmets append ["H_MilCap_gen_F","H_Beret_gen_F"];
-(_policeLoadoutData get "vests") pushBack "V_TacVest_gen_F";
-(_policeLoadoutData get "uniforms") append ["U_B_GEN_Soldier_F", "U_B_GEN_Commander_F"];
+_helmets append ["H_MilCap_gen_F", 10, "H_Beret_gen_F", 8];
+(_policeLoadoutData get "vests") append []"V_TacVest_gen_F", 6];
+(_policeLoadoutData get "uniforms") append ["U_B_GEN_Soldier_F", 10, "U_B_GEN_Commander_F", 8];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Artofwar/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Artofwar/Vanilla_AAF.sqf
@@ -1,3 +1,3 @@
-_loadoutData set ["officerUniforms", ["U_I_ParadeUniform_01_AAF_F","U_I_ParadeUniform_01_AAF_decorated_F","U_I_OfficerUniform"]];
-_loadoutData set ["officerVests", ["V_TacVest_oli"]];
-_loadoutData set ["officerHats", ["H_ParadeDressCap_01_AAF_F", "H_Beret_grn"]];
+_loadoutData set ["officerUniforms", ["U_I_ParadeUniform_01_AAF_F", 1, "U_I_ParadeUniform_01_AAF_decorated_F", 1, "U_I_OfficerUniform", 2]];
+_loadoutData set ["officerVests", ["V_Rangemaster_belt", 1]];
+_loadoutData set ["officerHats", ["H_ParadeDressCap_01_AAF_F", 1, "H_Beret_grn", 2]];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
@@ -1,10 +1,10 @@
-(_sfLoadoutData get "backpacks") append ["US85_bpAlice", 0.5,"US85_bpSf", 1];
+(_sfLoadoutData get "backpacks") append ["US85_bpAlice", 1, "US85_bpSf", 2.5];
 
-(_eliteLoadoutData get "backpacks") append ["US85_bpAlice", 0.5, "US85_bpSf", 1];
+(_eliteLoadoutData get "backpacks") append ["US85_bpAlice", 1, "US85_bpSf", 2];
 
 (_militaryLoadoutData get "backpacks") append ["US85_bpAlice", 2.5,"US85_bpSf", 1];
 
-(_crewLoadoutData get "helmets") append ["US85_helmetDH132", 0.33, "US85_helmetDH132G", 0.33, "US85_helmetDH132G_on", 0.33];
+(_crewLoadoutData get "helmets") append ["US85_helmetDH132", 3, "US85_helmetDH132G", 3, "US85_helmetDH132G_on", 3];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
@@ -1,12 +1,20 @@
-(_sfLoadoutData get "backpacks") append ["US85_bpAlice", 1, "US85_bpSf", 2.5];
-
-(_eliteLoadoutData get "backpacks") append ["US85_bpAlice", 1, "US85_bpSf", 2];
-
-(_militaryLoadoutData get "backpacks") append ["US85_bpAlice", 2.5,"US85_bpSf", 1];
-
-(_crewLoadoutData get "helmets") append ["US85_helmetDH132", 3, "US85_helmetDH132G", 3, "US85_helmetDH132G_on", 3];
-
-
-
-
-
+(_sfLoadoutData get "backpacks") append [
+	"US85_bpAlice", 1,
+	"US85_bpSf", 2.5
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "backpacks") append [
+	"US85_bpAlice", 1,
+	"US85_bpSf", 2
+];
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "backpacks") append [
+	"US85_bpAlice", 2.5,
+	"US85_bpSf", 1
+];
+//////////////////////////////////////////////////////
+(_crewLoadoutData get "helmets") append [
+	"US85_helmetDH132", 3,
+	"US85_helmetDH132G", 3,
+	"US85_helmetDH132G_on", 3
+];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
@@ -2,7 +2,7 @@
 
 (_eliteLoadoutData get "backpacks") append ["US85_bpAlice", 0.5, "US85_bpSf", 1];
 
-(_militaryLoadoutData get "backpacks") append ["US85_bpAlice", 1,"US85_bpSf", 0.5];
+(_militaryLoadoutData get "backpacks") append ["US85_bpAlice", 2.5,"US85_bpSf", 1];
 
 (_crewLoadoutData get "helmets") append ["US85_helmetDH132", 0.33, "US85_helmetDH132G", 0.33, "US85_helmetDH132G_on", 0.33];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/CSLA/Vanilla_AAF.sqf
@@ -1,10 +1,10 @@
-(_sfLoadoutData get "backpacks") append ["US85_bpAlice","US85_bpSf"];
+(_sfLoadoutData get "backpacks") append ["US85_bpAlice", 0.5,"US85_bpSf", 1];
 
-(_eliteLoadoutData get "backpacks") append ["US85_bpAlice","US85_bpSf"];
+(_eliteLoadoutData get "backpacks") append ["US85_bpAlice", 0.5, "US85_bpSf", 1];
 
-(_militaryLoadoutData get "backpacks") append ["US85_bpAlice","US85_bpSf"];
+(_militaryLoadoutData get "backpacks") append ["US85_bpAlice", 1,"US85_bpSf", 0.5];
 
-(_crewLoadoutData get "helmets") append ["US85_helmetDH132","US85_helmetDH132G","US85_helmetDH132G_on"];
+(_crewLoadoutData get "helmets") append ["US85_helmetDH132", 0.33, "US85_helmetDH132G", 0.33, "US85_helmetDH132G_on", 0.33];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
@@ -1,21 +1,14 @@
 (_loadoutData get "goggles") append ["G_AirPurifyingRespirator_02_olive_F", 0.5, "G_RegulatorMask_F", 0.5];
 
-(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 1, "U_I_CBRN_Suit_01_AAF_F", 1];
-(_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 2, "V_CarrierRigKBT_01_Olive_F", 2,"V_SmershVest_01_F", 1, "V_SmershVest_01_radio_F", 1];
-(_sfLoadoutData get "Hvests") append ["V_CarrierRigKBT_01_heavy_Olive_F", 2];
-(_sfLoadoutData get "helmets") append ["H_HelmetHBK_F", 2, "H_HelmetHBK_ear_F", 2, "H_HelmetHBK_headset_F", 2, "H_HelmetHBK_chops_F", 1, "H_HelmetAggressor_F", 1, "H_HelmetAggressor_cover_F", 1];
+(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 3, "U_I_CBRN_Suit_01_AAF_F", 3];
+(_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 2, "V_CarrierRigKBT_01_Olive_F", 2,"V_SmershVest_01_F", 0.5, "V_SmershVest_01_radio_F", 0.5]; // The smersh vests have no armor so making them uncommon.
+(_sfLoadoutData get "Hvests") append ["V_CarrierRigKBT_01_heavy_Olive_F", 6];
+(_sfLoadoutData get "helmets") append ["H_HelmetHBK_F", 4, "H_HelmetHBK_ear_F", 0.25, "H_HelmetHBK_headset_F", 0.25, "H_HelmetHBK_chops_F", 0.25, "H_HelmetAggressor_F", 1.25, "H_HelmetAggressor_cover_F", 1.25];
 
-(_eliteLoadoutData get "uniforms") pushBack "U_O_R_Gorka_01_F";
-(_eliteLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F","V_CarrierRigKBT_01_Olive_F"];
-(_eliteLoadoutData get "Hvests") pushBack "V_CarrierRigKBT_01_heavy_Olive_F";
-(_eliteLoadoutData get "helmets") append ["H_HelmetHBK_F","H_HelmetHBK_ear_F","H_HelmetHBK_headset_F","H_HelmetHBK_chops_F","H_HelmetAggressor_F","H_HelmetAggressor_cover_F"];
+(_eliteLoadoutData get "uniforms") pushBack "U_O_R_Gorka_01_F", 2;
+(_eliteLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 3, "V_CarrierRigKBT_01_Olive_F", 3];
+(_eliteLoadoutData get "Hvests") pushBack "V_CarrierRigKBT_01_heavy_Olive_F", 4;
+(_eliteLoadoutData get "helmets") append ["H_HelmetHBK_F", 4.5, "H_HelmetHBK_ear_F", 0.5, "H_HelmetHBK_headset_F", 0.5, "H_HelmetHBK_chops_F", 0.5, "H_HelmetAggressor_F", 1.5, "H_HelmetAggressor_cover_F", 1.5];
 
-(_militaryLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F","V_CarrierRigKBT_01_Olive_F"];
-(_militaryLoadoutData get "helmets") append ["H_HelmetHBK_F","H_HelmetHBK_headset_F"];
-
-
-
-
-
-
-
+(_militaryLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 3, "V_CarrierRigKBT_01_Olive_F", 3];
+(_militaryLoadoutData get "helmets") append ["H_HelmetHBK_F", 3, "H_HelmetHBK_headset_F", 0.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
@@ -1,14 +1,54 @@
-(_loadoutData get "goggles") append ["G_AirPurifyingRespirator_02_olive_F", 0.5, "G_RegulatorMask_F", 0.5];
-
-(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 3, "U_I_CBRN_Suit_01_AAF_F", 1];
-(_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 2, "V_CarrierRigKBT_01_Olive_F", 2,"V_SmershVest_01_F", 0.5, "V_SmershVest_01_radio_F", 0.5]; // The smersh vests have no armor so making them uncommon.
-(_sfLoadoutData get "Hvests") append ["V_CarrierRigKBT_01_heavy_Olive_F", 6];
-(_sfLoadoutData get "helmets") append ["H_HelmetHBK_F", 4, "H_HelmetHBK_ear_F", 0.25, "H_HelmetHBK_headset_F", 0.25, "H_HelmetHBK_chops_F", 0.25, "H_HelmetAggressor_F", 1.25, "H_HelmetAggressor_cover_F", 1.25];
-
-(_eliteLoadoutData get "uniforms") pushBack "U_O_R_Gorka_01_F", 2;
-(_eliteLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 3, "V_CarrierRigKBT_01_Olive_F", 3];
-(_eliteLoadoutData get "Hvests") pushBack "V_CarrierRigKBT_01_heavy_Olive_F", 4;
-(_eliteLoadoutData get "helmets") append ["H_HelmetHBK_F", 4.5, "H_HelmetHBK_ear_F", 0.5, "H_HelmetHBK_headset_F", 0.5, "H_HelmetHBK_chops_F", 0.5, "H_HelmetAggressor_F", 1.5, "H_HelmetAggressor_cover_F", 1.5];
-
-(_militaryLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 3, "V_CarrierRigKBT_01_Olive_F", 3];
-(_militaryLoadoutData get "helmets") append ["H_HelmetHBK_F", 3, "H_HelmetHBK_headset_F", 0.5];
+(_loadoutData get "goggles") append [
+	"G_AirPurifyingRespirator_02_olive_F", 1,
+	"G_RegulatorMask_F", 1
+];
+//////////////////////////////////////////////////////
+(_sfLoadoutData get "uniforms") append [
+	"U_O_R_Gorka_01_F", 3,
+	"U_I_CBRN_Suit_01_AAF_F", 1
+];
+(_sfLoadoutData get "vests") append [
+	"V_CarrierRigKBT_01_light_Olive_F", 2,
+	"V_CarrierRigKBT_01_Olive_F", 2,
+	"V_SmershVest_01_F", 0.5, // The smersh vests have no armor so making them uncommon.
+	"V_SmershVest_01_radio_F", 0.5
+];
+(_sfLoadoutData get "Hvests") append [
+	"V_CarrierRigKBT_01_heavy_Olive_F", 6
+];
+(_sfLoadoutData get "helmets") append [
+	"H_HelmetHBK_F", 4, 
+	"H_HelmetHBK_ear_F", 0.25, 
+	"H_HelmetHBK_headset_F", 0.25, 
+	"H_HelmetHBK_chops_F", 0.25, 
+	"H_HelmetAggressor_F", 1.25, 
+	"H_HelmetAggressor_cover_F", 1.25
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "uniforms") append [
+	"U_O_R_Gorka_01_F", 2
+];
+(_eliteLoadoutData get "vests") append [
+	"V_CarrierRigKBT_01_light_Olive_F", 3, 
+	"V_CarrierRigKBT_01_Olive_F", 3
+];
+(_eliteLoadoutData get "Hvests") append [
+	"V_CarrierRigKBT_01_heavy_Olive_F", 4
+];
+(_eliteLoadoutData get "helmets") append [
+	"H_HelmetHBK_F", 4.5,
+	"H_HelmetHBK_ear_F", 0.5,
+	"H_HelmetHBK_headset_F", 0.5,
+	"H_HelmetHBK_chops_F", 0.5,
+	"H_HelmetAggressor_F", 1.5,
+	"H_HelmetAggressor_cover_F", 1.5
+];
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "vests") append [
+	"V_CarrierRigKBT_01_light_Olive_F", 3,
+	"V_CarrierRigKBT_01_Olive_F", 3
+];
+(_militaryLoadoutData get "helmets") append [
+	"H_HelmetHBK_F", 3, 
+	"H_HelmetHBK_headset_F", 0.5
+];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
@@ -1,9 +1,9 @@
-(_loadoutData get "goggles") append ["G_Combat", "G_Lowprofile", "G_AirPurifyingRespirator_02_olive_F", "G_RegulatorMask_F"];
+(_loadoutData get "goggles") append ["G_AirPurifyingRespirator_02_olive_F", 0.5, "G_RegulatorMask_F", 0.5];
 
-(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", "U_I_CBRN_Suit_01_AAF_F"];
-(_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F","V_CarrierRigKBT_01_Olive_F","V_SmershVest_01_F","V_SmershVest_01_radio_F"];
-(_sfLoadoutData get "Hvests") pushBack "V_CarrierRigKBT_01_heavy_Olive_F";
-(_sfLoadoutData get "helmets") append ["H_HelmetHBK_F","H_HelmetHBK_ear_F","H_HelmetHBK_headset_F","H_HelmetHBK_chops_F","H_HelmetAggressor_F","H_HelmetAggressor_cover_F"];
+(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 1, "U_I_CBRN_Suit_01_AAF_F", 1];
+(_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 2, "V_CarrierRigKBT_01_Olive_F", 2,"V_SmershVest_01_F", 1, "V_SmershVest_01_radio_F", 1];
+(_sfLoadoutData get "Hvests") append ["V_CarrierRigKBT_01_heavy_Olive_F", 2];
+(_sfLoadoutData get "helmets") append ["H_HelmetHBK_F", 2, "H_HelmetHBK_ear_F", 2, "H_HelmetHBK_headset_F", 2, "H_HelmetHBK_chops_F", 1, "H_HelmetAggressor_F", 1, "H_HelmetAggressor_cover_F", 1];
 
 (_eliteLoadoutData get "uniforms") pushBack "U_O_R_Gorka_01_F";
 (_eliteLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F","V_CarrierRigKBT_01_Olive_F"];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Contact/Vanilla_AAF.sqf
@@ -1,6 +1,6 @@
 (_loadoutData get "goggles") append ["G_AirPurifyingRespirator_02_olive_F", 0.5, "G_RegulatorMask_F", 0.5];
 
-(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 3, "U_I_CBRN_Suit_01_AAF_F", 3];
+(_sfLoadoutData get "uniforms") append ["U_O_R_Gorka_01_F", 3, "U_I_CBRN_Suit_01_AAF_F", 1];
 (_sfLoadoutData get "vests") append ["V_CarrierRigKBT_01_light_Olive_F", 2, "V_CarrierRigKBT_01_Olive_F", 2,"V_SmershVest_01_F", 0.5, "V_SmershVest_01_radio_F", 0.5]; // The smersh vests have no armor so making them uncommon.
 (_sfLoadoutData get "Hvests") append ["V_CarrierRigKBT_01_heavy_Olive_F", 6];
 (_sfLoadoutData get "helmets") append ["H_HelmetHBK_F", 4, "H_HelmetHBK_ear_F", 0.25, "H_HelmetHBK_headset_F", 0.25, "H_HelmetHBK_chops_F", 0.25, "H_HelmetAggressor_F", 1.25, "H_HelmetAggressor_cover_F", 1.25];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -1,15 +1,70 @@
-(_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 1.5, "gm_ge_army_backpack_90_oli", 2, "gm_ge_army_backpack_80_oli", 1];
-(_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 1.5, "gm_ge_headgear_m92_cover_oli", 1.5, "gm_ge_headgear_psh77_oli", 1, "gm_ge_headgear_psh77_up_oli", 1, "gm_ge_headgear_psh77_down_oli", 2, "gm_ge_headgear_hat_beanie_crew_blk", 0.25,  "gm_ge_headgear_headset_crew_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_grn", 0.25, "gm_ge_headgear_hat_beanie_crew_blk", 0.25];
-
-(_eliteLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 1, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
-(_eliteLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1.5, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 1.5, "gm_ge_headgear_m92_cover_oli", 1.5, "gm_ge_headgear_psh77_oli", 1, "gm_ge_headgear_psh77_up_oli", 1.5, "gm_ge_headgear_psh77_down_oli", 1.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5, "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_grn", 0.25 ];
-
-(_militaryLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 2, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 1.5];
-(_militaryLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 5, "gm_ge_headgear_beret_crew_blk", 1, "gm_ge_headgear_m92_cover_glasses_oli", 2.5, "gm_ge_headgear_m92_cover_oli", 2.5, "gm_ge_headgear_psh77_oli", 0.75, "gm_ge_headgear_psh77_up_oli", 0.75, "gm_ge_headgear_psh77_down_oli", 0.75, "gm_ge_headgear_hat_beanie_crew_blk", 0.5,  "gm_ge_headgear_headset_crew_oli", 0.1, "gm_xx_headgear_headwrap_crew_01_oli", 0.1];
-
-(_militiaLoadoutData get "uniforms") append ["gm_ge_uniform_soldier_tshirt_90_oli", 3.5];
-(_militiaLoadoutData get "vests") append ["gm_ge_vest_sov_80_oli", 4];
-(_militiaLoadoutData get "Hvests") append ["gm_ge_vest_sov_armor_80_oli", 5, "gm_ge_bgs_vest_type3a1_oli", 7.5];
+(_sfLoadoutData get "backpacks") append [
+    "gm_dk_army_backpack_73_oli", 1.5,
+    "gm_ge_army_backpack_90_oli", 2,
+    "gm_ge_army_backpack_80_oli", 1
+];
+(_sfLoadoutData get "helmets") append [
+    "gm_dk_headgear_m96_oli", 1,
+    "gm_ge_headgear_beret_crew_blk", 1.5,
+    "gm_ge_headgear_m92_cover_glasses_oli", 1.5,
+    "gm_ge_headgear_m92_cover_oli", 1.5,
+    "gm_ge_headgear_psh77_oli", 1,
+    "gm_ge_headgear_psh77_up_oli", 1,
+    "gm_ge_headgear_psh77_down_oli", 2,
+    "gm_ge_headgear_hat_beanie_crew_blk", 0.25,
+    "gm_ge_headgear_headset_crew_oli", 0.25,
+    "gm_xx_headgear_headwrap_crew_01_oli", 0.25,
+    "gm_xx_headgear_headwrap_crew_01_grn", 0.25,
+    "gm_ge_headgear_hat_beanie_crew_blk", 0.25
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "backpacks") append [
+    "gm_dk_army_backpack_73_oli", 1,
+    "gm_ge_army_backpack_90_oli", 1,
+    "gm_ge_army_backpack_80_oli", 0.5
+];
+(_eliteLoadoutData get "helmets") append [
+    "gm_dk_headgear_m96_oli", 1.5,
+    "gm_ge_headgear_beret_crew_blk", 1.5,
+    "gm_ge_headgear_m92_cover_glasses_oli", 1.5,
+    "gm_ge_headgear_m92_cover_oli", 1.5,
+    "gm_ge_headgear_psh77_oli", 1,
+    "gm_ge_headgear_psh77_up_oli", 1.5,
+    "gm_ge_headgear_psh77_down_oli", 1.5,
+    "gm_ge_headgear_hat_beanie_crew_blk", 0.5,
+    "gm_ge_headgear_headset_crew_oli", 0.5,
+    "gm_xx_headgear_headwrap_crew_01_oli", 0.25,
+    "gm_xx_headgear_headwrap_crew_01_grn", 0.25
+];
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "backpacks") append [
+    "gm_dk_army_backpack_73_oli", 2,
+    "gm_ge_army_backpack_90_oli", 1,
+    "gm_ge_army_backpack_80_oli", 1.5
+];
+(_militaryLoadoutData get "helmets") append [
+    "gm_dk_headgear_m96_oli", 5,
+    "gm_ge_headgear_beret_crew_blk", 1,
+    "gm_ge_headgear_m92_cover_glasses_oli", 2.5,
+    "gm_ge_headgear_m92_cover_oli", 2.5,
+    "gm_ge_headgear_psh77_oli", 0.75,
+    "gm_ge_headgear_psh77_up_oli", 0.75,
+    "gm_ge_headgear_psh77_down_oli", 0.75,
+    "gm_ge_headgear_hat_beanie_crew_blk", 0.5,
+    "gm_ge_headgear_headset_crew_oli", 0.1,
+    "gm_xx_headgear_headwrap_crew_01_oli", 0.1
+];
+//////////////////////////////////////////////////////
+(_militiaLoadoutData get "uniforms") append [
+    "gm_ge_uniform_soldier_tshirt_90_oli", 3.5
+];
+(_militiaLoadoutData get "vests") append [
+    "gm_ge_vest_sov_80_oli", 4
+];
+(_militiaLoadoutData get "Hvests") append [
+    "gm_ge_vest_sov_armor_80_oli", 5,
+    "gm_ge_bgs_vest_type3a1_oli", 7.5
+];
 (_militiaLoadoutData get "helmets") append [
     "gm_ge_headgear_headset_crew_oli", 2,
     "gm_xx_headgear_headwrap_crew_01_oli", 2,
@@ -18,10 +73,15 @@
     "gm_ge_headgear_m92_cover_glasses_oli", 2.5,
     "gm_ge_headgear_m92_cover_oli", 2.5
 ];
+//////////////////////////////////////////////////////
+(crewLoadoutData get "helmets") append [
+    "gm_ge_headgear_crewhat_80_blk", 8
+];
 
-(crewLoadoutData get "helmets") append ["gm_ge_headgear_crewhat_80_blk", 8];
-
-(_pilotLoadoutData get "uniforms") append ["gm_ge_uniform_pilot_commando_oli", 2.5, "gm_ge_uniform_pilot_commando_rolled_oli", 2.5];
+(_pilotLoadoutData get "uniforms") append [
+    "gm_ge_uniform_pilot_commando_oli", 2.5,
+    "gm_ge_uniform_pilot_commando_rolled_oli", 2.5
+];
 
      
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -1,5 +1,5 @@
-(_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 0.75, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
-(_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 0.5, "gm_ge_headgear_m92_cover_oli", 0.5, "gm_ge_headgear_psh77_oli", 0.5, "gm_ge_headgear_psh77_up_oli", 1.25, "gm_ge_headgear_psh77_down_oli", 1.25, "gm_ge_headgear_hat_beanie_crew_blk", 0.5,  "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_grn", 0.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5];
+(_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 1.5, "gm_ge_army_backpack_90_oli", 2, "gm_ge_army_backpack_80_oli", 1];
+(_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 1.5, "gm_ge_headgear_m92_cover_oli", 1.5, "gm_ge_headgear_psh77_oli", 1, "gm_ge_headgear_psh77_up_oli", 1, "gm_ge_headgear_psh77_down_oli", 2, "gm_ge_headgear_hat_beanie_crew_blk", 0.25,  "gm_ge_headgear_headset_crew_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_grn", 0.25, "gm_ge_headgear_hat_beanie_crew_blk", 0.25];
 
 (_eliteLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 1, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
 (_eliteLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1.5, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 1.5, "gm_ge_headgear_m92_cover_oli", 1.5, "gm_ge_headgear_psh77_oli", 1, "gm_ge_headgear_psh77_up_oli", 1.5, "gm_ge_headgear_psh77_down_oli", 1.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5, "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_grn", 0.25 ];
@@ -19,9 +19,9 @@
     "gm_ge_headgear_m92_cover_oli", 2.5
 ];
 
-(crewLoadoutData get "helmets") append ["gm_ge_headgear_crewhat_80_blk", 1];
+(crewLoadoutData get "helmets") append ["gm_ge_headgear_crewhat_80_blk", 8];
 
-(_pilotLoadoutData get "uniforms") append ["gm_ge_uniform_pilot_commando_oli", 0.5, "gm_ge_uniform_pilot_commando_rolled_oli", 0.5];
+(_pilotLoadoutData get "uniforms") append ["gm_ge_uniform_pilot_commando_oli", 2.5, "gm_ge_uniform_pilot_commando_rolled_oli", 2.5];
 
      
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -1,15 +1,5 @@
-(_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli","gm_ge_army_backpack_90_oli","gm_ge_army_backpack_80_oli"];
-(_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli","gm_ge_headgear_beret_crew_blk","gm_ge_headgear_m92_cover_glasses_oli","gm_ge_headgear_m92_cover_oli","gm_ge_headgear_psh77_oli","gm_ge_headgear_psh77_up_oli","gm_ge_headgear_psh77_down_oli","gm_ge_headgear_hat_beanie_crew_blk"];
-(_sfLoadoutData get "helmets") append [
-    "gm_ge_headgear_headset_crew_oli",
-    "gm_xx_headgear_headwrap_crew_01_oli",
-    "gm_ge_headgear_beret_crew_blk",
-    "gm_xx_headgear_headwrap_crew_01_grn",
-    "gm_ge_headgear_hat_beanie_crew_blk",
-    "gm_ge_headgear_psh77_oli",
-    "gm_ge_headgear_psh77_up_oli",
-    "gm_ge_headgear_psh77_down_oli"
-];
+(_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 0.75, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
+(_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 0.5, "gm_ge_headgear_m92_cover_oli", 0.5, "gm_ge_headgear_psh77_oli", 0.5, "gm_ge_headgear_psh77_up_oli", 1.25, "gm_ge_headgear_psh77_down_oli", 1.25, "gm_ge_headgear_hat_beanie_crew_blk", 0.5,  "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_grn", 0.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5];
 
 (_eliteLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli","gm_ge_army_backpack_90_oli","gm_ge_army_backpack_80_oli"];
 (_eliteLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli","gm_ge_headgear_beret_crew_blk","gm_ge_headgear_m92_cover_glasses_oli","gm_ge_headgear_m92_cover_oli","gm_ge_headgear_psh77_oli","gm_ge_headgear_psh77_up_oli","gm_ge_headgear_psh77_down_oli","gm_ge_headgear_hat_beanie_crew_blk"];
@@ -24,31 +14,24 @@
     "gm_ge_headgear_psh77_down_oli"
 ];
 
-(_militaryLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli","gm_ge_army_backpack_90_oli","gm_ge_army_backpack_80_oli"];
-(_militaryLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli","gm_ge_headgear_beret_crew_blk","gm_ge_headgear_m92_cover_glasses_oli","gm_ge_headgear_m92_cover_oli","gm_ge_headgear_psh77_oli","gm_ge_headgear_psh77_up_oli","gm_ge_headgear_psh77_down_oli","gm_ge_headgear_hat_beanie_crew_blk"];
-(_militaryLoadoutData get "helmets") append [
-    "gm_ge_headgear_headset_crew_oli",
-    "gm_xx_headgear_headwrap_crew_01_oli",
-    "gm_ge_headgear_hat_beanie_crew_blk",
-    "gm_ge_headgear_m92_cover_glasses_oli",
-    "gm_ge_headgear_m92_cover_oli"
-];
+(_militaryLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 0.75, "gm_ge_army_backpack_90_oli", 0.75, "gm_ge_army_backpack_80_oli", 0.5];
+(_militaryLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 2, "gm_ge_headgear_beret_crew_blk", 0.5, "gm_ge_headgear_m92_cover_glasses_oli", 1, "gm_ge_headgear_m92_cover_oli", 1, "gm_ge_headgear_psh77_oli", 0.25, "gm_ge_headgear_psh77_up_oli", 0.25, "gm_ge_headgear_psh77_down_oli", 0.25, "gm_ge_headgear_hat_beanie_crew_blk", 1,  "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.5];
 
-(_militiaLoadoutData get "uniforms") pushBack "gm_ge_uniform_soldier_tshirt_90_oli";
-(_militiaLoadoutData get "vests") pushBack "gm_ge_vest_sov_80_oli";
-(_militiaLoadoutData get "Hvests") append ["gm_ge_vest_sov_armor_80_oli","gm_ge_bgs_vest_type3a1_oli"];
+(_militiaLoadoutData get "uniforms") append ["gm_ge_uniform_soldier_tshirt_90_oli", 1.5];
+(_militiaLoadoutData get "vests") append ["gm_ge_vest_sov_80_oli", 2];
+(_militiaLoadoutData get "Hvests") append ["gm_ge_vest_sov_armor_80_oli", 0.5, "gm_ge_bgs_vest_type3a1_oli", 0.75];
 (_militiaLoadoutData get "helmets") append [
-    "gm_ge_headgear_headset_crew_oli",
-    "gm_xx_headgear_headwrap_crew_01_oli",
-    "gm_ge_headgear_hat_beanie_crew_blk",
-    "gm_gc_headgear_fjh_model4_oli",
-    "gm_ge_headgear_m92_cover_glasses_oli",
-    "gm_ge_headgear_m92_cover_oli"
+    "gm_ge_headgear_headset_crew_oli", 0.5,
+    "gm_xx_headgear_headwrap_crew_01_oli", 0.5,
+    "gm_ge_headgear_hat_beanie_crew_blk", 0.5,
+    "gm_gc_headgear_fjh_model4_oli", 1.5,
+    "gm_ge_headgear_m92_cover_glasses_oli", 1,
+    "gm_ge_headgear_m92_cover_oli", 1
 ];
 
-(_crewLoadoutData get "helmets") pushBack "gm_ge_headgear_crewhat_80_blk";
+(crewLoadoutData get "helmets") append ["gm_ge_headgear_crewhat_80_blk", 1];
 
-(_pilotLoadoutData get "uniforms") append ["gm_ge_uniform_pilot_commando_oli","gm_ge_uniform_pilot_commando_rolled_oli"];
+(_pilotLoadoutData get "uniforms") append ["gm_ge_uniform_pilot_commando_oli", 0.5, "gm_ge_uniform_pilot_commando_rolled_oli", 0.5];
 
      
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -74,7 +74,7 @@
     "gm_ge_headgear_m92_cover_oli", 2.5
 ];
 //////////////////////////////////////////////////////
-(crewLoadoutData get "helmets") append [
+(_crewLoadoutData get "helmets") append [
     "gm_ge_headgear_crewhat_80_blk", 8
 ];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -4,13 +4,13 @@
     "gm_ge_army_backpack_80_oli", 1
 ];
 (_sfLoadoutData get "helmets") append [
-    "gm_dk_headgear_m96_oli", 1,
+    "gm_dk_headgear_m96_oli", 2,
     "gm_ge_headgear_beret_crew_blk", 1.5,
     "gm_ge_headgear_m92_cover_glasses_oli", 1.5,
     "gm_ge_headgear_m92_cover_oli", 1.5,
-    "gm_ge_headgear_psh77_oli", 1,
-    "gm_ge_headgear_psh77_up_oli", 1,
-    "gm_ge_headgear_psh77_down_oli", 2,
+    "gm_ge_headgear_psh77_oli", 2,
+    "gm_ge_headgear_psh77_up_oli", 1.5,
+    "gm_ge_headgear_psh77_down_oli", 1.5,
     "gm_ge_headgear_hat_beanie_crew_blk", 0.25,
     "gm_ge_headgear_headset_crew_oli", 0.25,
     "gm_xx_headgear_headwrap_crew_01_oli", 0.25,
@@ -24,13 +24,13 @@
     "gm_ge_army_backpack_80_oli", 0.5
 ];
 (_eliteLoadoutData get "helmets") append [
-    "gm_dk_headgear_m96_oli", 1.5,
+    "gm_dk_headgear_m96_oli", 2,
     "gm_ge_headgear_beret_crew_blk", 1.5,
-    "gm_ge_headgear_m92_cover_glasses_oli", 1.5,
-    "gm_ge_headgear_m92_cover_oli", 1.5,
-    "gm_ge_headgear_psh77_oli", 1,
-    "gm_ge_headgear_psh77_up_oli", 1.5,
-    "gm_ge_headgear_psh77_down_oli", 1.5,
+    "gm_ge_headgear_m92_cover_glasses_oli", 3,
+    "gm_ge_headgear_m92_cover_oli", 3,
+    "gm_ge_headgear_psh77_oli", 0.5,
+    "gm_ge_headgear_psh77_up_oli", 0.25,
+    "gm_ge_headgear_psh77_down_oli", 0.25,
     "gm_ge_headgear_hat_beanie_crew_blk", 0.5,
     "gm_ge_headgear_headset_crew_oli", 0.5,
     "gm_xx_headgear_headwrap_crew_01_oli", 0.25,

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/GM/Vanilla_AAF.sqf
@@ -1,32 +1,22 @@
 (_sfLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 0.75, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
 (_sfLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 0.5, "gm_ge_headgear_m92_cover_oli", 0.5, "gm_ge_headgear_psh77_oli", 0.5, "gm_ge_headgear_psh77_up_oli", 1.25, "gm_ge_headgear_psh77_down_oli", 1.25, "gm_ge_headgear_hat_beanie_crew_blk", 0.5,  "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_grn", 0.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5];
 
-(_eliteLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli","gm_ge_army_backpack_90_oli","gm_ge_army_backpack_80_oli"];
-(_eliteLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli","gm_ge_headgear_beret_crew_blk","gm_ge_headgear_m92_cover_glasses_oli","gm_ge_headgear_m92_cover_oli","gm_ge_headgear_psh77_oli","gm_ge_headgear_psh77_up_oli","gm_ge_headgear_psh77_down_oli","gm_ge_headgear_hat_beanie_crew_blk"];
-(_eliteLoadoutData get "helmets") append [
-    "gm_ge_headgear_headset_crew_oli",
-    "gm_xx_headgear_headwrap_crew_01_oli",
-    "gm_ge_headgear_beret_crew_blk",
-    "gm_xx_headgear_headwrap_crew_01_grn",
-    "gm_ge_headgear_hat_beanie_crew_blk",
-    "gm_ge_headgear_psh77_oli",
-    "gm_ge_headgear_psh77_up_oli",
-    "gm_ge_headgear_psh77_down_oli"
-];
+(_eliteLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 1, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 0.5];
+(_eliteLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 1.5, "gm_ge_headgear_beret_crew_blk", 1.5, "gm_ge_headgear_m92_cover_glasses_oli", 1.5, "gm_ge_headgear_m92_cover_oli", 1.5, "gm_ge_headgear_psh77_oli", 1, "gm_ge_headgear_psh77_up_oli", 1.5, "gm_ge_headgear_psh77_down_oli", 1.5, "gm_ge_headgear_hat_beanie_crew_blk", 0.5, "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.25, "gm_xx_headgear_headwrap_crew_01_grn", 0.25 ];
 
-(_militaryLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 0.75, "gm_ge_army_backpack_90_oli", 0.75, "gm_ge_army_backpack_80_oli", 0.5];
-(_militaryLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 2, "gm_ge_headgear_beret_crew_blk", 0.5, "gm_ge_headgear_m92_cover_glasses_oli", 1, "gm_ge_headgear_m92_cover_oli", 1, "gm_ge_headgear_psh77_oli", 0.25, "gm_ge_headgear_psh77_up_oli", 0.25, "gm_ge_headgear_psh77_down_oli", 0.25, "gm_ge_headgear_hat_beanie_crew_blk", 1,  "gm_ge_headgear_headset_crew_oli", 0.5, "gm_xx_headgear_headwrap_crew_01_oli", 0.5];
+(_militaryLoadoutData get "backpacks") append ["gm_dk_army_backpack_73_oli", 2, "gm_ge_army_backpack_90_oli", 1, "gm_ge_army_backpack_80_oli", 1.5];
+(_militaryLoadoutData get "helmets") append ["gm_dk_headgear_m96_oli", 5, "gm_ge_headgear_beret_crew_blk", 1, "gm_ge_headgear_m92_cover_glasses_oli", 2.5, "gm_ge_headgear_m92_cover_oli", 2.5, "gm_ge_headgear_psh77_oli", 0.75, "gm_ge_headgear_psh77_up_oli", 0.75, "gm_ge_headgear_psh77_down_oli", 0.75, "gm_ge_headgear_hat_beanie_crew_blk", 0.5,  "gm_ge_headgear_headset_crew_oli", 0.1, "gm_xx_headgear_headwrap_crew_01_oli", 0.1];
 
-(_militiaLoadoutData get "uniforms") append ["gm_ge_uniform_soldier_tshirt_90_oli", 1.5];
-(_militiaLoadoutData get "vests") append ["gm_ge_vest_sov_80_oli", 2];
-(_militiaLoadoutData get "Hvests") append ["gm_ge_vest_sov_armor_80_oli", 0.5, "gm_ge_bgs_vest_type3a1_oli", 0.75];
+(_militiaLoadoutData get "uniforms") append ["gm_ge_uniform_soldier_tshirt_90_oli", 3.5];
+(_militiaLoadoutData get "vests") append ["gm_ge_vest_sov_80_oli", 4];
+(_militiaLoadoutData get "Hvests") append ["gm_ge_vest_sov_armor_80_oli", 5, "gm_ge_bgs_vest_type3a1_oli", 7.5];
 (_militiaLoadoutData get "helmets") append [
-    "gm_ge_headgear_headset_crew_oli", 0.5,
-    "gm_xx_headgear_headwrap_crew_01_oli", 0.5,
-    "gm_ge_headgear_hat_beanie_crew_blk", 0.5,
-    "gm_gc_headgear_fjh_model4_oli", 1.5,
-    "gm_ge_headgear_m92_cover_glasses_oli", 1,
-    "gm_ge_headgear_m92_cover_oli", 1
+    "gm_ge_headgear_headset_crew_oli", 2,
+    "gm_xx_headgear_headwrap_crew_01_oli", 2,
+    "gm_ge_headgear_hat_beanie_crew_blk", 2,
+    "gm_gc_headgear_fjh_model4_oli", 2,
+    "gm_ge_headgear_m92_cover_glasses_oli", 2.5,
+    "gm_ge_headgear_m92_cover_oli", 2.5
 ];
 
 (crewLoadoutData get "helmets") append ["gm_ge_headgear_crewhat_80_blk", 1];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Lawsofwar/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Lawsofwar/Vanilla_AAF.sqf
@@ -1,15 +1,31 @@
-(_sfLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1;
-(_sfLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 1;
-
-(_eliteLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1;
-(_eliteLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 3;
-
-(_militaryLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1.5;
-(_militaryLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 2;
-
-_helmets append ["H_PASGT_basic_blue_F", 2.5];  //police
-
-(_militiaLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 4;
+(_sfLoadoutData get "Hvests") append [
+	"V_EOD_olive_F", 1
+];
+(_sfLoadoutData get "helmets") append [
+	"H_PASGT_basic_olive_F", 1
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "Hvests") append [
+	"V_EOD_olive_F", 1
+];
+(_eliteLoadoutData get "helmets") append [
+	"H_PASGT_basic_olive_F", 3
+];
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "Hvests") append [
+	"V_EOD_olive_F", 1.5
+];
+(_militaryLoadoutData get "helmets") append [
+	"H_PASGT_basic_olive_F", 2
+];
+//////////////////////////////////////////////////////
+_helmets append [ // police
+	"H_PASGT_basic_blue_F", 2.5
+];  
+//////////////////////////////////////////////////////
+(_militiaLoadoutData get "helmets") append [
+	"H_PASGT_basic_olive_F", 4
+];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/Lawsofwar/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/Lawsofwar/Vanilla_AAF.sqf
@@ -1,15 +1,15 @@
-(_sfLoadoutData get "Hvests") pushBack "V_EOD_olive_F";
-(_sfLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F";
+(_sfLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1;
+(_sfLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 1;
 
-(_eliteLoadoutData get "Hvests") pushBack "V_EOD_olive_F";
-(_eliteLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F";
+(_eliteLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1;
+(_eliteLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 3;
 
-(_militaryLoadoutData get "Hvests") pushBack "V_EOD_olive_F";
-(_militaryLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F";
+(_militaryLoadoutData get "Hvests") pushBack "V_EOD_olive_F", 1.5;
+(_militaryLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 2;
 
-_helmets pushBack "H_PASGT_basic_blue_F";  //police
+_helmets append ["H_PASGT_basic_blue_F", 2.5];  //police
 
-(_militiaLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F";
+(_militiaLoadoutData get "helmets") pushBack "H_PASGT_basic_olive_F", 4;
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
@@ -1,5 +1,5 @@
 (_sfLoadoutData get "backpacks") pushBack "B_DuffleBag_Olive_NoLogo_RF";
-(_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF","H_HelmetHeavy_Olive_RF","H_HelmetHeavy_Simple_Olive_RF","H_HelmetHeavy_VisorUp_Olive_RF"];
+(_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 2, "H_HelmetHeavy_Olive_RF", 2, "H_HelmetHeavy_Simple_Olive_RF", 2,"H_HelmetHeavy_VisorUp_Olive_RF", 2];
 
 (_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF","I_CommandoMortar_weapon_RF"];
 (_eliteLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF","H_HelmetHeavy_Olive_RF","H_HelmetHeavy_Simple_Olive_RF","H_HelmetHeavy_VisorUp_Olive_RF"];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
@@ -1,14 +1,15 @@
-(_sfLoadoutData get "backpacks") pushBack "B_DuffleBag_Olive_NoLogo_RF";
-(_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 2, "H_HelmetHeavy_Olive_RF", 2, "H_HelmetHeavy_Simple_Olive_RF", 2,"H_HelmetHeavy_VisorUp_Olive_RF", 2];
+(_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5,"I_CommandoMortar_weapon_RF", 0.75];
+(_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 5, "H_HelmetHeavy_Olive_RF", 2, "H_HelmetHeavy_Simple_Olive_RF", 1.25, "H_HelmetHeavy_VisorUp_Olive_RF", 1.25];
 
-(_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF","I_CommandoMortar_weapon_RF"];
-(_eliteLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF","H_HelmetHeavy_Olive_RF","H_HelmetHeavy_Simple_Olive_RF","H_HelmetHeavy_VisorUp_Olive_RF"];
+(_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5,"I_CommandoMortar_weapon_RF", 0.25];
+(_eliteLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 5, "H_HelmetHeavy_Olive_RF", 1.34, "H_HelmetHeavy_Simple_Olive_RF", 1.33, "H_HelmetHeavy_VisorUp_Olive_RF", 1.33];
 
-(_militaryLoadoutData get "Hvests") pushBack "V_TacVest_rig_oli_RF";
-(_militaryLoadoutData get "helmets") pushBack "H_HelmetIA_sb_digital_RF";
+(_militaryLoadoutData get "vests") append ["V_TacVest_rig_oli_RF", 1];
+(_militaryLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 4.5];
 
-(_militiaLoadoutData get "Hvests") pushBack "V_TacVest_rig_oli_RF";
-(_militiaLoadoutData get "helmets") pushBack "H_HelmetIA_sb_digital_RF";
+(_militiaLoadoutData get "vests") append ["V_TacVest_rig_oli_RF", 1.75];
+(_militiaLoadoutData get "Hvests") append ["V_TacVest_rig_oli_RF", 7.5];
+(_militiaLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 0.5];
 
-(_pilotLoadoutData get "uniforms") pushBack "U_C_HeliPilotCoveralls_Green_RF";
+(_pilotLoadoutData get "uniforms") append ["U_C_HeliPilotCoveralls_Green_RF", 2.5];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
@@ -1,4 +1,4 @@
-(_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5,"I_CommandoMortar_weapon_RF", 0.75];
+(_sfLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5];
 (_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 5, "H_HelmetHeavy_Olive_RF", 2, "H_HelmetHeavy_Simple_Olive_RF", 1.25, "H_HelmetHeavy_VisorUp_Olive_RF", 1.25];
 
 (_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5,"I_CommandoMortar_weapon_RF", 0.25];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
@@ -37,3 +37,10 @@
 	"U_C_HeliPilotCoveralls_Green_RF", 2.5
 ];
 
+//Gendarmerie vest w/holster only makes sense to add if Apex also enabled
+if (_hasApex) then {
+	(_policeLoadoutData get "vests") append [
+		"V_TacVest_gen_holster_RF", 4
+	];
+};
+

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/RF/Vanilla_AAF.sqf
@@ -1,15 +1,39 @@
-(_sfLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5];
-(_sfLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 5, "H_HelmetHeavy_Olive_RF", 2, "H_HelmetHeavy_Simple_Olive_RF", 1.25, "H_HelmetHeavy_VisorUp_Olive_RF", 1.25];
-
+(_sfLoadoutData get "backpacks") append [
+	"B_DuffleBag_Olive_NoLogo_RF", 1.5
+];
+(_sfLoadoutData get "helmets") append [
+	"H_HelmetIA_sb_digital_RF", 5,
+	"H_HelmetHeavy_Olive_RF", 2,
+	"H_HelmetHeavy_Simple_Olive_RF", 1.25,
+	"H_HelmetHeavy_VisorUp_Olive_RF", 1.25
+];
+//////////////////////////////////////////////////////
 (_eliteLoadoutData get "backpacks") append ["B_DuffleBag_Olive_NoLogo_RF", 1.5,"I_CommandoMortar_weapon_RF", 0.25];
-(_eliteLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 5, "H_HelmetHeavy_Olive_RF", 1.34, "H_HelmetHeavy_Simple_Olive_RF", 1.33, "H_HelmetHeavy_VisorUp_Olive_RF", 1.33];
-
-(_militaryLoadoutData get "vests") append ["V_TacVest_rig_oli_RF", 1];
-(_militaryLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 4.5];
-
-(_militiaLoadoutData get "vests") append ["V_TacVest_rig_oli_RF", 1.75];
-(_militiaLoadoutData get "Hvests") append ["V_TacVest_rig_oli_RF", 7.5];
-(_militiaLoadoutData get "helmets") append ["H_HelmetIA_sb_digital_RF", 0.5];
-
-(_pilotLoadoutData get "uniforms") append ["U_C_HeliPilotCoveralls_Green_RF", 2.5];
+(_eliteLoadoutData get "helmets") append [
+	"H_HelmetIA_sb_digital_RF", 5,
+	"H_HelmetHeavy_Olive_RF", 1.34,
+	"H_HelmetHeavy_Simple_Olive_RF", 1.33,
+	"H_HelmetHeavy_VisorUp_Olive_RF", 1.33
+];
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "vests") append [
+	"V_TacVest_rig_oli_RF", 1
+];
+(_militaryLoadoutData get "helmets") append [
+	"H_HelmetIA_sb_digital_RF", 4.5
+];
+//////////////////////////////////////////////////////
+(_militiaLoadoutData get "vests") append [
+	"V_TacVest_rig_oli_RF", 1.75
+];
+(_militiaLoadoutData get "Hvests") append [
+	"V_TacVest_rig_oli_RF", 7.5
+];
+(_militiaLoadoutData get "helmets") append [
+	"H_HelmetIA_sb_digital_RF", 0.5
+];
+//////////////////////////////////////////////////////
+(_pilotLoadoutData get "uniforms") append [
+	"U_C_HeliPilotCoveralls_Green_RF", 2.5
+];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -4,7 +4,7 @@
     // "vn_b_squares_tinted",
     // "vn_b_squares", 1,
     "vn_g_spectacles_01", 1.5,
-    "vn_g_spectacles_02", 2,
+    "vn_g_spectacles_02", 2
     // "vn_b_spectacles",
     // "vn_b_aviator"
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -23,8 +23,11 @@
 ];
 //////////////////////////////////////////////////////
 (_militaryLoadoutData get "Hvests") append [
-    "vn_b_vest_usarmy_14", 2.5,
-    "vn_b_vest_usarmy_13", 2.5
+    "vn_b_vest_usarmy_14", 0.5,
+    "vn_b_vest_usarmy_13", 0.5,
+    "vn_b_vest_usmc_02", 1,
+    "vn_b_vest_usmc_01", 1,
+    "vn_b_vest_usmc_06", 1
 ];
 (_militaryLoadoutData get "vests") append [ // These freqs together should make the SOG vests have a cumulative spawn weight of 3.9.
     "vn_b_vest_anzac_09", 0.65,
@@ -57,7 +60,14 @@
     "vn_b_pack_m41_01", 0.5
 ];
 //////////////////////////////////////////////////////
-(_militiaLoadoutData get "Hvests") append ["vn_b_vest_usmc_02", 1,"vn_b_vest_usmc_01", 1,"vn_b_vest_usmc_06", 1]; // USMC body armor is significantly better than tactical rig defense wise, so make it a bit rarer.
+(_militiaLoadoutData get "Hvests") append [
+    "vn_b_vest_usarmy_13", 1,
+    "vn_b_vest_usarmy_14", 1,
+    "vn_b_vest_usmc_02", 0.75,
+    "vn_b_vest_usmc_01", 0.75,
+    "vn_b_vest_usmc_06", 0.75
+];
+
 (_militiaLoadoutData get "vests") append [ // While individual spawn chance is low, as a whole this should make all the SOG rigging slightly more common than the vanilla chest rig.
     "vn_b_vest_sog_04", 0.5,
     "vn_b_vest_sog_01", 0.5,

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -22,17 +22,17 @@
     "vn_b_bandana_a"
 ];
 
-(_militaryLoadoutData get "Hvests") append ["vn_b_vest_usarmy_14","vn_b_vest_usarmy_13"];
-(_militaryLoadoutData get "vests") append ["vn_b_vest_anzac_09","vn_b_vest_anzac_08","vn_b_vest_usarmy_11","vn_b_vest_usarmy_12","vn_b_vest_usmc_02","vn_b_vest_usmc_01","vn_b_vest_usmc_06","vn_b_vest_usmc_03","vn_b_vest_usmc_04","vn_b_vest_usmc_05"];
-(_militaryLoadoutData get "backpacks") append ["vn_b_pack_pfield_02","vn_b_pack_p08_02","vn_b_pack_p44_02","vn_b_pack_01","vn_b_pack_02","vn_b_pack_03","vn_b_pack_04","vn_b_pack_05","vn_b_pack_trp_03","vn_b_pack_trp_01","vn_b_pack_trp_04","vn_b_pack_trp_02","vn_b_pack_m41_04","vn_b_pack_m41_03","vn_b_pack_m41_02","vn_b_pack_m41_01"];
+(_militaryLoadoutData get "Hvests") append ["vn_b_vest_usarmy_14", 2.5, "vn_b_vest_usarmy_13", 2.5];
+(_militaryLoadoutData get "vests") append ["vn_b_vest_anzac_09", 0.65,"vn_b_vest_anzac_08", 0.65,"vn_b_vest_usarmy_11", 0.65,"vn_b_vest_usarmy_12", 0.65,"vn_b_vest_usmc_02", 0.22,"vn_b_vest_usmc_01", 0.22,"vn_b_vest_usmc_06", 0.22,"vn_b_vest_usmc_03", 0.22,"vn_b_vest_usmc_04", 0.22,"vn_b_vest_usmc_05", 0.22]; // These freqs together should make the SOG vests have a spawn weight of 3.9.
+(_militaryLoadoutData get "backpacks") append ["vn_b_pack_pfield_02", 1,"vn_b_pack_p08_02", 1.25,"vn_b_pack_p44_02", 1.25,"vn_b_pack_01", 0.4,"vn_b_pack_02", 0.4,"vn_b_pack_03", 0.4,"vn_b_pack_04", 0.4,"vn_b_pack_05", 0.4,"vn_b_pack_trp_03", 0.5,"vn_b_pack_trp_01", 0.5,"vn_b_pack_trp_04", 0.5,"vn_b_pack_trp_02, 0.5","vn_b_pack_m41_04", 0.5,"vn_b_pack_m41_03", 0.5,"vn_b_pack_m41_02", 0.5,"vn_b_pack_m41_01", 0.5];
 
-(_militiaLoadoutData get "Hvests") append ["vn_b_vest_usmc_02","vn_b_vest_usmc_01","vn_b_vest_usmc_06"];
-(_militiaLoadoutData get "vests") append ["vn_b_vest_sog_04","vn_b_vest_sog_01","vn_b_vest_sog_02","vn_b_vest_sog_06","vn_b_vest_sog_05","vn_b_vest_sog_03","vn_b_vest_seal_05","vn_b_vest_seal_03","vn_b_vest_sas_01","vn_b_vest_sas_04","vn_b_vest_sas_03","vn_b_vest_sas_02"];
-(_militiaLoadoutData get "backpacks") append ["vn_b_pack_p08_02","vn_b_pack_p44_01","vn_b_pack_trp_03_02","vn_b_pack_m41_01"];
+(_militiaLoadoutData get "Hvests") append ["vn_b_vest_usmc_02", 1,"vn_b_vest_usmc_01", 1,"vn_b_vest_usmc_06", 1]; // USMC body armor is significantly better than tactical rig defense wise, so make it a bit rarer.
+(_militiaLoadoutData get "vests") append ["vn_b_vest_sog_04", 0.5,"vn_b_vest_sog_01", 0.5,"vn_b_vest_sog_02", 0.5, 0.5,"vn_b_vest_sog_06", 0.5,"vn_b_vest_sog_05", 0.5,"vn_b_vest_sog_03", 0.5,"vn_b_vest_seal_05", 0.5,"vn_b_vest_seal_03", 0.5,"vn_b_vest_sas_01", 0.5,"vn_b_vest_sas_04", 0.5,"vn_b_vest_sas_03", 0.5,"vn_b_vest_sas_02", 0.5]; // While individual spawn chance is low, as a whole this should make all the SOG rigging slightly more common than the vanilla chest rig.
+(_militiaLoadoutData get "backpacks") append ["vn_b_pack_p08_02", 2, "vn_b_pack_p44_01", 2, "vn_b_pack_trp_03_02", 1,"vn_b_pack_m41_01", 1];
 
-(_crewLoadoutData get "vests") append ["vn_b_vest_usarmy_11","vn_b_vest_usarmy_12","vn_b_vest_usarmy_13","vn_b_vest_usarmy_14"];
+(_crewLoadoutData get "vests") append ["vn_b_vest_usarmy_11", 1.25, "vn_b_vest_usarmy_12", 1.25, "vn_b_vest_usarmy_13", 1.25, "vn_b_vest_usarmy_14", 1.25];
 
-(_pilotLoadoutData get "vests") append ["vn_b_vest_aircrew_01","vn_b_vest_anzac_08"];
+(_pilotLoadoutData get "vests") append ["vn_b_vest_aircrew_01", 10, "vn_b_vest_anzac_08", 5];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -1,12 +1,7 @@
 (_loadoutData get "glasses") append [
-    // "vn_b_spectacles_tinted", Anything commented out has models, textures, and for some even names as vanilla items. Thus they are redundant.
     "vn_g_glasses_01", 2.5,
-    // "vn_b_squares_tinted",
-    // "vn_b_squares", 1,
     "vn_g_spectacles_01", 1.5,
     "vn_g_spectacles_02", 2
-    // "vn_b_spectacles",
-    // "vn_b_aviator"
 ];
 (_loadoutData get "goggles") append [
     "vn_b_acc_towel_02", 1,

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -1,25 +1,25 @@
 (_loadoutData get "glasses") append [
-    "vn_b_spectacles_tinted",
-    "vn_g_glasses_01",
-    "vn_b_squares_tinted",
-    "vn_b_squares",
-    "vn_g_spectacles_01",
-    "vn_g_spectacles_02",
-    "vn_b_spectacles",
-    "vn_b_aviator"
+    // "vn_b_spectacles_tinted", Anything commented out has models, textures, and for some even names as vanilla items. Thus they are redundant.
+    "vn_g_glasses_01", 2.5,
+    // "vn_b_squares_tinted",
+    // "vn_b_squares", 1,
+    "vn_g_spectacles_01", 1.5,
+    "vn_g_spectacles_02", 2,
+    // "vn_b_spectacles",
+    // "vn_b_aviator"
 ];
 (_loadoutData get "goggles") append [
-    "vn_b_acc_towel_02",
-    "vn_b_acc_towel_01",
-    "vn_b_acc_rag_02",
-    "vn_b_acc_rag_01",
-    "vn_o_poncho_01_01",
-    "vn_o_acc_goggles_02",
-    "vn_b_acc_goggles_01",
-    "vn_b_acc_m17_01",
-    "vn_o_bandana_g",
-    "vn_o_bandana_b",
-    "vn_b_bandana_a"
+    "vn_b_acc_towel_02", 1,
+    "vn_b_acc_towel_01", 1,
+    "vn_b_acc_rag_02", 1,
+    "vn_b_acc_rag_01", 1,
+    "vn_o_poncho_01_01", 2,
+    "vn_o_acc_goggles_02", 3,
+    "vn_b_acc_goggles_01", 3,
+    "vn_b_acc_m17_01", 1,
+    "vn_o_bandana_g", 1.5, // These bandanas are identical to vanilla items but the latter aren't included in the base AAF file so they get to stay for now.
+    "vn_o_bandana_b", 1.5,
+    "vn_b_bandana_a", 1
 ];
 
 (_militaryLoadoutData get "Hvests") append ["vn_b_vest_usarmy_14", 2.5, "vn_b_vest_usarmy_13", 2.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SOG/Vanilla_AAF.sqf
@@ -21,18 +21,75 @@
     "vn_o_bandana_b", 1.5,
     "vn_b_bandana_a", 1
 ];
-
-(_militaryLoadoutData get "Hvests") append ["vn_b_vest_usarmy_14", 2.5, "vn_b_vest_usarmy_13", 2.5];
-(_militaryLoadoutData get "vests") append ["vn_b_vest_anzac_09", 0.65,"vn_b_vest_anzac_08", 0.65,"vn_b_vest_usarmy_11", 0.65,"vn_b_vest_usarmy_12", 0.65,"vn_b_vest_usmc_02", 0.22,"vn_b_vest_usmc_01", 0.22,"vn_b_vest_usmc_06", 0.22,"vn_b_vest_usmc_03", 0.22,"vn_b_vest_usmc_04", 0.22,"vn_b_vest_usmc_05", 0.22]; // These freqs together should make the SOG vests have a spawn weight of 3.9.
-(_militaryLoadoutData get "backpacks") append ["vn_b_pack_pfield_02", 1,"vn_b_pack_p08_02", 1.25,"vn_b_pack_p44_02", 1.25,"vn_b_pack_01", 0.4,"vn_b_pack_02", 0.4,"vn_b_pack_03", 0.4,"vn_b_pack_04", 0.4,"vn_b_pack_05", 0.4,"vn_b_pack_trp_03", 0.5,"vn_b_pack_trp_01", 0.5,"vn_b_pack_trp_04", 0.5,"vn_b_pack_trp_02, 0.5","vn_b_pack_m41_04", 0.5,"vn_b_pack_m41_03", 0.5,"vn_b_pack_m41_02", 0.5,"vn_b_pack_m41_01", 0.5];
-
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "Hvests") append [
+    "vn_b_vest_usarmy_14", 2.5,
+    "vn_b_vest_usarmy_13", 2.5
+];
+(_militaryLoadoutData get "vests") append [ // These freqs together should make the SOG vests have a cumulative spawn weight of 3.9.
+    "vn_b_vest_anzac_09", 0.65,
+    "vn_b_vest_anzac_08", 0.65,
+    "vn_b_vest_usarmy_11", 0.65,
+    "vn_b_vest_usarmy_12", 0.65,
+    "vn_b_vest_usmc_02", 0.22,
+    "vn_b_vest_usmc_01", 0.22,
+    "vn_b_vest_usmc_06", 0.22,
+    "vn_b_vest_usmc_03", 0.22,
+    "vn_b_vest_usmc_04", 0.22,
+    "vn_b_vest_usmc_05", 0.22
+]; 
+(_militaryLoadoutData get "backpacks") append [
+    "vn_b_pack_pfield_02", 1,
+    "vn_b_pack_p08_02", 1.25,
+    "vn_b_pack_p44_02", 1.25,
+    "vn_b_pack_01", 0.4,
+    "vn_b_pack_02", 0.4,
+    "vn_b_pack_03", 0.4,
+    "vn_b_pack_04", 0.4,
+    "vn_b_pack_05", 0.4,
+    "vn_b_pack_trp_03", 0.5,
+    "vn_b_pack_trp_01", 0.5,
+    "vn_b_pack_trp_04", 0.5,
+    "vn_b_pack_trp_02", 0.5,
+    "vn_b_pack_m41_04", 0.5,
+    "vn_b_pack_m41_03", 0.5,
+    "vn_b_pack_m41_02", 0.5,
+    "vn_b_pack_m41_01", 0.5
+];
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "Hvests") append ["vn_b_vest_usmc_02", 1,"vn_b_vest_usmc_01", 1,"vn_b_vest_usmc_06", 1]; // USMC body armor is significantly better than tactical rig defense wise, so make it a bit rarer.
-(_militiaLoadoutData get "vests") append ["vn_b_vest_sog_04", 0.5,"vn_b_vest_sog_01", 0.5,"vn_b_vest_sog_02", 0.5, 0.5,"vn_b_vest_sog_06", 0.5,"vn_b_vest_sog_05", 0.5,"vn_b_vest_sog_03", 0.5,"vn_b_vest_seal_05", 0.5,"vn_b_vest_seal_03", 0.5,"vn_b_vest_sas_01", 0.5,"vn_b_vest_sas_04", 0.5,"vn_b_vest_sas_03", 0.5,"vn_b_vest_sas_02", 0.5]; // While individual spawn chance is low, as a whole this should make all the SOG rigging slightly more common than the vanilla chest rig.
-(_militiaLoadoutData get "backpacks") append ["vn_b_pack_p08_02", 2, "vn_b_pack_p44_01", 2, "vn_b_pack_trp_03_02", 1,"vn_b_pack_m41_01", 1];
+(_militiaLoadoutData get "vests") append [ // While individual spawn chance is low, as a whole this should make all the SOG rigging slightly more common than the vanilla chest rig.
+    "vn_b_vest_sog_04", 0.5,
+    "vn_b_vest_sog_01", 0.5,
+    "vn_b_vest_sog_02", 0.5,
+    "vn_b_vest_sog_06", 0.5,
+    "vn_b_vest_sog_05", 0.5,
+    "vn_b_vest_sog_03", 0.5,
+    "vn_b_vest_seal_05", 0.5,
+    "vn_b_vest_seal_03", 0.5,
+    "vn_b_vest_sas_01", 0.5,
+    "vn_b_vest_sas_04", 0.5,
+    "vn_b_vest_sas_03", 0.5,
+    "vn_b_vest_sas_02", 0.5
+];
+(_militiaLoadoutData get "backpacks") append [
+    "vn_b_pack_p08_02", 2,
+    "vn_b_pack_p44_01", 2,
+    "vn_b_pack_trp_03_02", 1,
+    "vn_b_pack_m41_01", 1
+];
+//////////////////////////////////////////////////////
+(_crewLoadoutData get "vests") append [
+    "vn_b_vest_usarmy_11", 1.25,
+    "vn_b_vest_usarmy_12", 1.25,
+    "vn_b_vest_usarmy_13", 1.25,
+    "vn_b_vest_usarmy_14", 1.25
+];
 
-(_crewLoadoutData get "vests") append ["vn_b_vest_usarmy_11", 1.25, "vn_b_vest_usarmy_12", 1.25, "vn_b_vest_usarmy_13", 1.25, "vn_b_vest_usarmy_14", 1.25];
-
-(_pilotLoadoutData get "vests") append ["vn_b_vest_aircrew_01", 10, "vn_b_vest_anzac_08", 5];
+(_pilotLoadoutData get "vests") append [
+    "vn_b_vest_aircrew_01", 10,
+    "vn_b_vest_anzac_08", 5
+];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
@@ -19,5 +19,8 @@
     "G_SPE_Cigar_Moza", 2,
     "G_SPE_Binoculars", 2
 ];
-
-(_crewLoadoutData get "helmets") append ["H_SPE_US_Helmet_Tank_M1_OS", 2.5,"H_SPE_US_Helmet_Tank_M1_NS", 2.5];
+//////////////////////////////////////////////////////
+(_crewLoadoutData get "helmets") append [
+    "H_SPE_US_Helmet_Tank_M1_OS", 2.5,
+    "H_SPE_US_Helmet_Tank_M1_NS", 2.5
+];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
@@ -20,4 +20,4 @@
     "G_SPE_Binoculars"
 ];
 
-(_crewLoadoutData get "helmets") append ["H_SPE_US_Helmet_Tank_M1_OS","H_SPE_US_Helmet_Tank_M1_NS"];
+(_crewLoadoutData get "helmets") append ["H_SPE_US_Helmet_Tank_M1_OS", 2.5,"H_SPE_US_Helmet_Tank_M1_NS", 2.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
@@ -1,23 +1,23 @@
 (_loadoutData get "glasses") append [
-    "G_SPE_Sunglasses_US_Yellow",
-    "G_SPE_Sunglasses_US_Red",
-    "G_SPE_Sunglasses_GER_Red",
-    "G_SPE_Sunglasses_GER_Brown",
-    "G_SPE_Ful_Vue_Reinforced",
-    "G_SPE_Ful_Vue",
-    "G_SPE_Dust_Goggles_2",
-    "G_SPE_Dienst_Brille"
+    "G_SPE_Sunglasses_US_Yellow", 1,
+    "G_SPE_Sunglasses_US_Red", 1,
+    "G_SPE_Sunglasses_GER_Red", 1,
+    "G_SPE_Sunglasses_GER_Brown", 1,
+    "G_SPE_Ful_Vue_Reinforced", 0.75,
+    "G_SPE_Ful_Vue", 1.25,
+    "G_SPE_Dust_Goggles_2", 1,
+    "G_SPE_Dienst_Brille",  1.5
 ];
 (_loadoutData get "goggles") append [
-    "G_SPE_GER_Headset",
-    "G_SPE_Polar_Goggles",
-    "G_SPE_Pipe_Sir_Winston",
-    "G_SPE_SWDG_Goggles",
-    "G_SPE_Cigarette_Strike_Outs",
-    "G_SPE_Cigarette_Grundstein",
-    "G_SPE_Cigarette_Belomorkanal",
-    "G_SPE_Cigar_Moza",
-    "G_SPE_Binoculars"
+    "G_SPE_GER_Headset", 2,
+    "G_SPE_Polar_Goggles", 3,
+    "G_SPE_Pipe_Sir_Winston", 0.5, // Considering it's a bit silly, making it rare so it's a fun surprise when it appears.
+    "G_SPE_SWDG_Goggles", 3,
+    "G_SPE_Cigarette_Strike_Outs", 1.5,
+    "G_SPE_Cigarette_Grundstein", 1.5,
+    "G_SPE_Cigarette_Belomorkanal", 1.5,
+    "G_SPE_Cigar_Moza", 2,
+    "G_SPE_Binoculars", 2
 ];
 
 (_crewLoadoutData get "helmets") append ["H_SPE_US_Helmet_Tank_M1_OS", 2.5,"H_SPE_US_Helmet_Tank_M1_NS", 2.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/SPE/Vanilla_AAF.sqf
@@ -21,6 +21,6 @@
 ];
 //////////////////////////////////////////////////////
 (_crewLoadoutData get "helmets") append [
-    "H_SPE_US_Helmet_Tank_M1_OS", 2.5,
-    "H_SPE_US_Helmet_Tank_M1_NS", 2.5
+    "H_SPE_US_Helmet_Tank_M1_OS", 0.5,
+    "H_SPE_US_Helmet_Tank_M1_NS", 0.5
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
@@ -14,7 +14,6 @@
 	"lxWS_H_PASGT_goggles_olive_F", 1.5,
 	"H_Beret_Headset_lxWS", 0.25
 ];
-// (_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS"; // Isn't this a duplicate?
 //////////////////////////////////////////////////////
 (_militaryLoadoutData get "helmets") append [
 	"lxWS_H_bmask_camo02", 0.5,

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
@@ -1,10 +1,10 @@
-(_sfLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 1,"lxWS_H_Headset", 1,"lxWS_H_PASGT_goggles_olive_F", 1.5, "H_Beret_Headset_lxWS", 1];
+(_sfLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 3,"lxWS_H_Headset", 0.25,"lxWS_H_PASGT_goggles_olive_F", 0.5, "H_Beret_Headset_lxWS", 0.25];
 
-(_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS";
-(_eliteLoadoutData get "helmets") append ["lxWS_H_bmask_camo02","lxWS_H_Headset","lxWS_H_PASGT_goggles_olive_F","H_Beret_Headset_lxWS"];
-(_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS";
+(_eliteLoadoutData get "backpacks") append ["I_shield_backpack_lxWS", 1];
+(_eliteLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 2, "lxWS_H_Headset", 0.25, "lxWS_H_PASGT_goggles_olive_F", 1.5, "H_Beret_Headset_lxWS", 0.25];
+// (_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS"; // Isn't this a duplicate?
 
-(_militaryLoadoutData get "helmets") append ["lxWS_H_bmask_camo02","lxWS_H_Headset","lxWS_H_PASGT_goggles_olive_F"];
+(_militaryLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 0.5, "lxWS_H_Headset", 0.25, "lxWS_H_PASGT_goggles_olive_F", 1];
 
-(_militiaLoadoutData get "vests") pushBack "V_lxWS_HarnessO_oli";
-(_militiaLoadoutData get "Hvests") pushBack "V_lxWS_TacVestIR_oli";
+(_militiaLoadoutData get "vests") pushBack "V_lxWS_HarnessO_oli", 4;
+(_militiaLoadoutData get "Hvests") pushBack "V_lxWS_TacVestIR_oli", 7.5;

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
@@ -1,4 +1,4 @@
-(_sfLoadoutData get "helmets") append ["lxWS_H_bmask_camo02","lxWS_H_Headset","lxWS_H_PASGT_goggles_olive_F","H_Beret_Headset_lxWS"];
+(_sfLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 1,"lxWS_H_Headset", 1,"lxWS_H_PASGT_goggles_olive_F", 1.5, "H_Beret_Headset_lxWS", 1];
 
 (_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS";
 (_eliteLoadoutData get "helmets") append ["lxWS_H_bmask_camo02","lxWS_H_Headset","lxWS_H_PASGT_goggles_olive_F","H_Beret_Headset_lxWS"];
@@ -8,11 +8,3 @@
 
 (_militiaLoadoutData get "vests") pushBack "V_lxWS_HarnessO_oli";
 (_militiaLoadoutData get "Hvests") pushBack "V_lxWS_TacVestIR_oli";
-
-
-
-
-
-
-
-

--- a/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/gear/WS/Vanilla_AAF.sqf
@@ -1,10 +1,30 @@
-(_sfLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 3,"lxWS_H_Headset", 0.25,"lxWS_H_PASGT_goggles_olive_F", 0.5, "H_Beret_Headset_lxWS", 0.25];
-
-(_eliteLoadoutData get "backpacks") append ["I_shield_backpack_lxWS", 1];
-(_eliteLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 2, "lxWS_H_Headset", 0.25, "lxWS_H_PASGT_goggles_olive_F", 1.5, "H_Beret_Headset_lxWS", 0.25];
+(_sfLoadoutData get "helmets") append [
+	"lxWS_H_bmask_camo02", 3,
+	"lxWS_H_Headset", 0.25,
+	"lxWS_H_PASGT_goggles_olive_F", 0.5,
+	"H_Beret_Headset_lxWS", 0.25
+];
+//////////////////////////////////////////////////////
+(_eliteLoadoutData get "backpacks") append [
+	"I_shield_backpack_lxWS", 1
+];
+(_eliteLoadoutData get "helmets") append [
+	"lxWS_H_bmask_camo02", 2,
+	"lxWS_H_Headset", 0.25,
+	"lxWS_H_PASGT_goggles_olive_F", 1.5,
+	"H_Beret_Headset_lxWS", 0.25
+];
 // (_eliteLoadoutData get "backpacks") pushBack "I_shield_backpack_lxWS"; // Isn't this a duplicate?
-
-(_militaryLoadoutData get "helmets") append ["lxWS_H_bmask_camo02", 0.5, "lxWS_H_Headset", 0.25, "lxWS_H_PASGT_goggles_olive_F", 1];
-
-(_militiaLoadoutData get "vests") pushBack "V_lxWS_HarnessO_oli", 4;
-(_militiaLoadoutData get "Hvests") pushBack "V_lxWS_TacVestIR_oli", 7.5;
+//////////////////////////////////////////////////////
+(_militaryLoadoutData get "helmets") append [
+	"lxWS_H_bmask_camo02", 0.5,
+	"lxWS_H_Headset", 0.25,
+	"lxWS_H_PASGT_goggles_olive_F", 1
+];
+//////////////////////////////////////////////////////
+(_militiaLoadoutData get "vests") append [
+	"V_lxWS_HarnessO_oli", 4
+];
+(_militiaLoadoutData get "Hvests") append [
+	"V_lxWS_TacVestIR_oli", 7.5
+];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -1,12 +1,15 @@
 _sfMGOptics append ["optic_ERCO_blk_F", 2.5];
+_sfTlOptics append  ["optic_ERCO_blk_F", 4];
+_sfRifleOptics append  ["optic_ERCO_blk_F", 2.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 5
+    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 3
 ];
 (_sfLoadoutData get "SMGs") append [
      ["SMG_05_F","muzzle_snds_L",_sfAccessories, _sfSMGoptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
+_eliteSlOptics append ["optic_ERCO_blk_F", 3];
 // (_eliteLoadoutData get "marksmanRifles") append [
 //     ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
 //     ["srifle_DMR_03_F", "", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
@@ -14,10 +17,10 @@ _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
 // ]; // Why are Marksman DLC items defined in the Apex file?
 _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 5
+    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 2
 ];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
+    ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
 // (_militaryLoadoutData get "marksmanRifles") append [
@@ -26,22 +29,24 @@ _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 //     ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
 // ]; // Why are Marksman DLC items defined in the Apex file?
 _militaryMGSights append ["optic_ERCO_blk_F", 1];
+_militaryRifleSights append ["optic_ERCO_blk_F", 0.5];
+_militarySlRifleSights append ["optic_ERCO_blk_F", 1.5];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", _militaryAttachment, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 10
+    ["LMG_03_F", "", _militaryAttachment, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
 ];
 (_militaryLoadoutData get "SMGs") append [
     ["SMG_05_F","", _militaryAttachment, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
-    ["SMG_05_F","","", _policeSMGSights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
+    ["SMG_05_F","","", _policeSMGSights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 6
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", "acc_flashlight", _militiaMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
+    ["LMG_03_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["SMG_05_F","","acc_flashlight", _militiaSMGsights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 6
+    ["SMG_05_F","",_militiaAttachments, _militiaSMGsights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 7.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -5,7 +5,7 @@ _sfMGOptics append ["optic_ERCO_blk_F", 2.5];
 (_sfLoadoutData get "SMGs") append [
      ["SMG_05_F","muzzle_snds_L",_sfAccessories, _sfSMGoptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
-
+//////////////////////////////////////////////////////
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
 // (_eliteLoadoutData get "marksmanRifles") append [
 //     ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
@@ -19,7 +19,7 @@ _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "SMGs") append [
     ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
 ];
-
+//////////////////////////////////////////////////////
 // (_militaryLoadoutData get "marksmanRifles") append [
 //     ["srifle_DMR_03_khaki_F", "", "acc_flashlight", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
 //     ["srifle_DMR_03_F", "", "acc_flashlight", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
@@ -32,11 +32,11 @@ _militaryMGSights append ["optic_ERCO_blk_F", 1];
 (_militaryLoadoutData get "SMGs") append [
     ["SMG_05_F","", _militaryAttachment, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
-
+//////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
     ["SMG_05_F","","", _policeSMGSights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "machineGuns") append [
     ["LMG_03_F", "", "acc_flashlight", _militiaMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -6,43 +6,32 @@ _sfMGOptics append ["optic_ERCO_blk_F", 2.5];
      ["SMG_05_F","muzzle_snds_L",_sfAccessories,"optic_Holosight_smg_blk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 
-(_eliteLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_03_F", "", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
-];
+_eliteRifleOptics append ["optic_ERCO_blk_F", 1];
+_eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", "acc_pointer_IR", "optic_ERCO_blk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "", "acc_pointer_IR", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "", "acc_pointer_IR", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""]
+    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 8
 ];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_05_F","","acc_pointer_IR","optic_Holosight_smg_khk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""]
+    ["SMG_05_F","", _eliteAccessories, _eliteSMGoptic,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
 ];
 
-(_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "", "acc_flashlight", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_03_F", "", "acc_flashlight", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
-];
+_militaryMGSights append ["optic_ERCO_blk_F", 1];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", "acc_flashlight", "optic_ERCO_blk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "", "acc_flashlight", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""]
+    ["LMG_03_F", "", _militaryAttachment, `_militaryMGSights`, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 10
 ];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_05_F","","acc_flashlight","optic_Holosight_smg_khk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""]
+    ["SMG_05_F","", _militaryAttachment, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 
 (_policeLoadoutData get "SMGs") append [
-    ["SMG_05_F","","","optic_Aco_smg",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""]
+    ["SMG_05_F","","", _policeSMGSights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 
 (_militiaLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", "acc_flashlight", "", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""]
+    ["LMG_03_F", "", "acc_flashlight", _militiaMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["SMG_05_F","","acc_flashlight","",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""]
+    ["SMG_05_F","","acc_flashlight", _militiaSMGsights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 6
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -10,11 +10,6 @@ _sfRifleOptics append  ["optic_ERCO_blk_F", 2.5];
 //////////////////////////////////////////////////////
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
 _eliteSlOptics append ["optic_ERCO_blk_F", 3];
-// (_eliteLoadoutData get "marksmanRifles") append [
-//     ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-//     ["srifle_DMR_03_F", "", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-//     ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
-// ]; // Why are Marksman DLC items defined in the Apex file?
 _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
     ["LMG_03_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 2
@@ -23,11 +18,6 @@ _eliteMGOptics append ["optic_ERCO_blk_F", 2];
     ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
-// (_militaryLoadoutData get "marksmanRifles") append [
-//     ["srifle_DMR_03_khaki_F", "", "acc_flashlight", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-//     ["srifle_DMR_03_F", "", "acc_flashlight", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-//     ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
-// ]; // Why are Marksman DLC items defined in the Apex file?
 _militaryMGSights append ["optic_ERCO_blk_F", 1];
 _militaryRifleSights append ["optic_ERCO_blk_F", 0.5];
 _militarySlRifleSights append ["optic_ERCO_blk_F", 1.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -35,7 +35,7 @@ _militarySlRifleSights append ["optic_ERCO_blk_F", 1.5];
     ["LMG_03_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
 ];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_05_F","", _militaryAttachments, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
+    ["SMG_05_F","", _militaryAttachments, _militarySMGSights,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -5,7 +5,7 @@ _sfRifleOptics append  ["optic_ERCO_blk_F", 2.5];
     ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 3
 ];
 (_sfLoadoutData get "SMGs") append [
-     ["SMG_05_F","muzzle_snds_L",_sfAccessories, _sfSMGoptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
+     ["SMG_05_F","muzzle_snds_L",_sfAccessories, _sfSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
@@ -18,25 +18,25 @@ _eliteMGOptics append ["optic_ERCO_blk_F", 2];
     ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
-_militaryMGSights append ["optic_ERCO_blk_F", 1];
-_militaryRifleSights append ["optic_ERCO_blk_F", 0.5];
-_militarySlRifleSights append ["optic_ERCO_blk_F", 1.5];
+_militaryMGOptics append ["optic_ERCO_blk_F", 1];
+_militaryRifleOptics append ["optic_ERCO_blk_F", 0.5];
+_militarySlRifleOptics append ["optic_ERCO_blk_F", 1.5];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
+    ["LMG_03_F", "", _militaryAttachments, _militaryMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
 ];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_05_F","", _militaryAttachments, _militarySMGSights,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
+    ["SMG_05_F","", _militaryAttachments, _militarySMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
-    ["SMG_05_F","","", _policeSMGSights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 6
+    ["SMG_05_F","","", _policeSMGOptics, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 6
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
+    ["LMG_03_F", "", _militiaAttachments, _militiaMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 14
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["SMG_05_F","",_militiaAttachments, _militiaSMGsights, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 7.5
+    ["SMG_05_F","",_militiaAttachments, _militiaSMGOptics, ["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 7.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -1,23 +1,23 @@
 _sfMGOptics append ["optic_ERCO_blk_F", 2.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 1
+    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 5
 ];
 (_sfLoadoutData get "SMGs") append [
-     ["SMG_05_F","muzzle_snds_L",_sfAccessories,"optic_Holosight_smg_blk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
+     ["SMG_05_F","muzzle_snds_L",_sfAccessories, _sfSMGoptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
 _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 8
+    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 5
 ];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_05_F","", _eliteAccessories, _eliteSMGoptic,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
+    ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
 ];
 
 _militaryMGSights append ["optic_ERCO_blk_F", 1];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", _militaryAttachment, `_militaryMGSights`, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 10
+    ["LMG_03_F", "", _militaryAttachment, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 10
 ];
 (_militaryLoadoutData get "SMGs") append [
     ["SMG_05_F","", _militaryAttachment, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -17,7 +17,7 @@ _eliteSlOptics append ["optic_ERCO_blk_F", 3];
 // ]; // Why are Marksman DLC items defined in the Apex file?
 _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 2
+    ["LMG_03_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 2
 ];
 (_eliteLoadoutData get "SMGs") append [
     ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
@@ -32,10 +32,10 @@ _militaryMGSights append ["optic_ERCO_blk_F", 1];
 _militaryRifleSights append ["optic_ERCO_blk_F", 0.5];
 _militarySlRifleSights append ["optic_ERCO_blk_F", 1.5];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "", _militaryAttachment, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
+    ["LMG_03_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 7.5
 ];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_05_F","", _militaryAttachment, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
+    ["SMG_05_F","", _militaryAttachments, _militarySMGSight,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 4
 ];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -1,10 +1,9 @@
+_sfMGOptics append ["optic_ERCO_blk_F", 2.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", "acc_pointer_IR", "optic_ERCO_blk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", "acc_pointer_IR", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
-    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", "acc_pointer_IR", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""]
+    ["LMG_03_F", "muzzle_snds_H_MG_khk_F", _sfAccessories, _sfMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 1
 ];
 (_sfLoadoutData get "SMGs") append [
-    ["SMG_05_F","muzzle_snds_L","acc_pointer_IR","optic_Holosight_smg_khk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""]
+     ["SMG_05_F","muzzle_snds_L",_sfAccessories,"optic_Holosight_smg_blk_F",["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 1
 ];
 
 (_eliteLoadoutData get "marksmanRifles") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Apex/Vanilla_AAF.sqf
@@ -7,6 +7,11 @@ _sfMGOptics append ["optic_ERCO_blk_F", 2.5];
 ];
 
 _eliteRifleOptics append ["optic_ERCO_blk_F", 1];
+// (_eliteLoadoutData get "marksmanRifles") append [
+//     ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
+//     ["srifle_DMR_03_F", "", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
+//     ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
+// ]; // Why are Marksman DLC items defined in the Apex file?
 _eliteMGOptics append ["optic_ERCO_blk_F", 2];
 (_eliteLoadoutData get "machineGuns") append [
     ["LMG_03_F", "", eliteAccessories, _eliteMGOptics, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 5
@@ -15,6 +20,11 @@ _eliteMGOptics append ["optic_ERCO_blk_F", 2];
     ["SMG_05_F","", _eliteAccessories, _eliteSMGOptics,["30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02","30Rnd_9x21_Mag_SMG_02_Tracer_Green"], [], ""], 3
 ];
 
+// (_militaryLoadoutData get "marksmanRifles") append [
+//     ["srifle_DMR_03_khaki_F", "", "acc_flashlight", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
+//     ["srifle_DMR_03_F", "", "acc_flashlight", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
+//     ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
+// ]; // Why are Marksman DLC items defined in the Apex file?
 _militaryMGSights append ["optic_ERCO_blk_F", 1];
 (_militaryLoadoutData get "machineGuns") append [
     ["LMG_03_F", "", _militaryAttachment, _militaryMGSights, ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""], 10

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
@@ -1,56 +1,56 @@
 (_militaryLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 1,
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 1
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 3,
+    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 3
 ];
 (_militaryLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
-];
-(_militaryLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
-];
-(_militaryLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 0.5,
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 0.5
-];
-(_militaryLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1
-];
-
-(_militiaLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 1.5,
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 1.5
-];
-(_militiaLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
-];
-(_militiaLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
     ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1,
     ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1
 ];
+(_militaryLoadoutData get "rifles") append [
+    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2.5,
+    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2.5,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2.5,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2.5
+];
+(_militaryLoadoutData get "grenadeLaunchers") append [
+    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2.5,
+    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2.5
+];
+(_militaryLoadoutData get "carbines") append [
+    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 5
+];
+
+(_militiaLoadoutData get "machineGuns") append [
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 12,
+    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12
+];
+(_militiaLoadoutData get "slRifles") append [
+    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1.5,
+    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1.5,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1.5,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1.5
+];
+(_militiaLoadoutData get "rifles") append [
+    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
+    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4
+];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1,
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1
+    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4,
+    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2
+    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 8
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 1,
-    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 1
+    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 15,
+    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 10
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""], 1.5
+    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""], 8
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
@@ -1,64 +1,64 @@
-_cslaMilitaryMGSights = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 2];
+_cslaMilitaryMGOptics = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 2];
 _cslaMilitaryM16Attachments = ["US85_M16fl", 1, "", 2];
-_cslaMilitaryM16Sights = ["US85_sc2000_M16", 1, "", 2];
-_cslaMilitaryM16SlSights = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 1];
-_cslaMilitaryFALSights = ["US85_scFAL", 1, "", 4];
+_cslaMilitaryM16Optics = ["US85_sc2000_M16", 1, "", 2];
+_cslaMilitaryM16SlOptics = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 1];
+_cslaMilitaryFALOptics = ["US85_scFAL", 1, "", 4];
 _cslaFALBipods = ["US85_FALbpd", 1, "", 8];
 
 (_militaryLoadoutData get "machineGuns") append [
     ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 2,
-    ["US85_M249","","",_cslaMilitaryMGSights,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 4
+    ["US85_M249","","",_cslaMilitaryMGOptics,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 4
 ];
 (_militaryLoadoutData get "slRifles") append [
-    ["US85_M16A2","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
-    ["US85_M16A1","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
-    ["US85_FALf","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3,
+    ["US85_M16A2","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlOptics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
+    ["US85_M16A1","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlOptics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_FALf","","",_cslaMilitaryFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3,
     ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 2
 ];
 (_militaryLoadoutData get "rifles") append [
     ["US85_M16A2","",_cslaMilitaryM16Attachments,"US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
     ["US85_M16A1","",_cslaMilitaryM16Attachments,"US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.75,
-    ["US85_FALf","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1,
-    ["US85_FAL","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1.5
+    ["US85_FALf","","",_cslaMilitaryFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1,
+    ["US85_FAL","","",_cslaMilitaryFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1.5
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","",_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2,
-    ["US85_M16A2CARGL","","",_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1
+    ["US85_M16A2GL","","",_cslaMilitaryM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2,
+    ["US85_M16A2CARGL","","",_cslaMilitaryM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1
 ];
 (_militaryLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","",_cslaMilitaryM16Attachments,_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3
+    ["US85_M16A2CAR","",_cslaMilitaryM16Attachments,_cslaMilitaryM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3
 ];
 //////////////////////////////////////////////////////
-_cslaMilitiaMGSights = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 8];
+_cslaMilitiaMGOptics = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 8];
 (_militiaLoadoutData get "machineGuns") append [
     ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 6,
-    ["US85_M249","","",_cslaMilitiaMGSights,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12
+    ["US85_M249","","",_cslaMilitiaMGOptics,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12
 ];
 
 _cslaMilitiaM16Attachments = ["US85_M16fl", 1, "", 4];
-_cslaMilitiaM16Sights = ["US85_sc2000_M16", 1, "", 5];
-_cslaMilitaM16SlSights = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 3];
-_cslaMilitiaFALSights = ["US85_scFAL", 1, "", 7];
+_cslaMilitiaM16Optics = ["US85_sc2000_M16", 1, "", 5];
+_cslaMilitaM16SlOptics = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 3];
+_cslaMilitiaFALOptics = ["US85_scFAL", 1, "", 7];
 
 
 (_militiaLoadoutData get "slRifles") append [
-    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 6,
-    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
-    ["US85_FALf","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 6,
-    ["US85_FAL","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3
+    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlOptics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 6,
+    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlOptics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
+    ["US85_FALf","","",_cslaMilitiaFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 6,
+    ["US85_FAL","","",_cslaMilitiaFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 8,
-    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
-    ["US85_FALf","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2,
-    ["US85_FAL","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4
+    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 8,
+    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
+    ["US85_FALf","","",_cslaMilitiaFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2,
+    ["US85_FAL","","",_cslaMilitiaFALOptics,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","",_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 8,
-    ["US85_M16A2CARGL","","",_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4
+    ["US85_M16A2GL","","",_cslaMilitiaM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 8,
+    ["US85_M16A2CARGL","","",_cslaMilitiaM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 10
+    ["US85_M16A2CAR","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Optics,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 10
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
     ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 12,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
@@ -21,7 +21,7 @@
 (_militaryLoadoutData get "carbines") append [
     ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 5
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "machineGuns") append [
     ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 12,
     ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
@@ -1,56 +1,56 @@
 (_militaryLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""],
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""]
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 1,
+    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 1
 ];
 (_militaryLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"],
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"]
+    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"],
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"]
+    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""],
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""]
+    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 0.5,
+    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 0.5
 ];
 (_militaryLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""]
+    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1
 ];
 
 (_militiaLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""],
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""]
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 1.5,
+    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 1.5
 ];
 (_militiaLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"],
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"]
+    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.5,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 0.5
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""],
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"],
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"]
+    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""],
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""]
+    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1,
+    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""]
+    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"],
-    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"]
+    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 1,
+    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 1
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""]
+    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""], 1.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/CSLA/Vanilla_AAF.sqf
@@ -1,56 +1,71 @@
+_cslaMilitaryMGSights = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 2];
+_cslaMilitaryM16Attachments = ["US85_M16fl", 1, "", 2];
+_cslaMilitaryM16Sights = ["US85_sc2000_M16", 1, "", 2];
+_cslaMilitaryM16SlSights = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 1];
+_cslaMilitaryFALSights = ["US85_scFAL", 1, "", 4];
+_cslaFALBipods = ["US85_FALbpd", 1, "", 8];
+
 (_militaryLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 3,
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 3
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 2,
+    ["US85_M249","","",_cslaMilitaryMGSights,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 4
 ];
 (_militaryLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1
+    ["US85_M16A2","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
+    ["US85_M16A1","",_cslaMilitaryM16Attachments,_cslaMilitaryM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1,
+    ["US85_FALf","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3,
+    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 2
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2.5,
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 2.5,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2.5,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2.5
+    ["US85_M16A2","",_cslaMilitaryM16Attachments,"US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
+    ["US85_M16A1","",_cslaMilitaryM16Attachments,"US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 0.75,
+    ["US85_FALf","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1,
+    ["US85_FAL","","",_cslaMilitaryFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 1.5
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2.5,
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2.5
+    ["US85_M16A2GL","","",_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 2,
+    ["US85_M16A2CARGL","","",_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 1
 ];
 (_militaryLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 5
+    ["US85_M16A2CAR","",_cslaMilitaryM16Attachments,_cslaMilitaryM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3
 ];
 //////////////////////////////////////////////////////
+_cslaMilitiaMGSights = ["US85_sc4x20M249", 1, "US85_sc2000M249", 2, "", 8];
 (_militiaLoadoutData get "machineGuns") append [
-    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 12,
-    ["US85_M249","","","US85_sc4x20M249",["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12
+    ["US85_M60","","","",["US85_100Rnd_762x51","US85_100Rnd_762x51","US85_100Rnd_762x51"],[],""], 6,
+    ["US85_M249","","",_cslaMilitiaMGSights,["US85_200Rnd_556x45","US85_200Rnd_556x45","US85_200Rnd_556x45"],[],""], 12
 ];
+
+_cslaMilitiaM16Attachments = ["US85_M16fl", 1, "", 4];
+_cslaMilitiaM16Sights = ["US85_sc2000_M16", 1, "", 5];
+_cslaMilitaM16SlSights = ["US85_sc2000_M16", 1, "US85_sc4x20_M16", 2, "", 3];
+_cslaMilitiaFALSights = ["US85_scFAL", 1, "", 7];
+
+
 (_militiaLoadoutData get "slRifles") append [
-    ["US85_M16A2","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1.5,
-    ["US85_M16A1","","","US85_sc4x20_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 1.5,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1.5,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 1.5
+    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 6,
+    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitaM16SlSights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 3,
+    ["US85_FALf","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 6,
+    ["US85_FAL","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],_cslaFALBipods], 3
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["US85_M16A2","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
-    ["US85_M16A1","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
-    ["US85_FALf","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4,
-    ["US85_FAL","","","US85_scFAL",["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4
+    ["US85_M16A2","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 8,
+    ["US85_M16A1","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 4,
+    ["US85_FALf","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 2,
+    ["US85_FAL","","",_cslaMilitiaFALSights,["US85_20Rnd_762M61","US85_20Rnd_762M61","US85_20Rnd_762x51"],[],"US85_FALbpd"], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["US85_M16A2GL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4,
-    ["US85_M16A2CARGL","","","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4
+    ["US85_M16A2GL","","",_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 8,
+    ["US85_M16A2CARGL","","",_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],["US85_M406","US85_M406","US85_M406","US85_M583A1"],""], 4
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["US85_M16A2CAR","","US85_M16fl","US85_sc2000_M16",["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 8
+    ["US85_M16A2CAR","",_cslaMilitiaM16Attachments,_cslaMilitiaM16Sights,["US85_30Rnd_556x45","US85_30Rnd_556x45","US85_30Rnd_556x45"],[],""], 10
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 15,
-    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 10
+    ["US85_M14","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 12,
+    ["US85_M21","","","US85_scM21",["US85_20Rnd_762x51","US85_20Rnd_762x51","US85_20Rnd_762M61"],[],"US85_M14bpd"], 8
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""], 8
+    ["CSLA_HuntingRifle","","","",["CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt","CSLA_10Rnd_762hunt"],[],""], 4
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
@@ -23,7 +23,7 @@ _sfMGOptics append ["optic_DMS_weathered_Kir_F", 0.5];
 (_sfLoadoutData get "machineGuns") append [
     ["LMG_Mk200_black_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_03_F_oli"], 5
 ];
-
+//////////////////////////////////////////////////////
 (_eliteLoadoutData get "slRifles") append [
     ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
     ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5
@@ -48,11 +48,11 @@ _eliteMGOptics append ["optic_DMS_weathered_Kir_F", 0.5]
 (_eliteLoadoutData get "machineGuns") append [
     ["LMG_Mk200_black_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5,
 ];
-
+//////////////////////////////////////////////////////
 _militaryMGSights append ["optic_DMS_weathered_Kir_F", 0.5]
 (_militaryLoadoutData get "machineGuns") append [
     ["LMG_Mk200_black_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_06_hunter_F", "", "", _militiaMarksmanSights,["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""], 15
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
@@ -49,16 +49,16 @@ _eliteMGOptics append ["optic_DMS_weathered_F", 0.5];
     ["LMG_Mk200_black_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
 ];
 //////////////////////////////////////////////////////
-_militaryMGSights append ["optic_DMS_weathered_F", 0.5];
+_militaryMGOptics append ["optic_DMS_weathered_F", 0.5];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
+    ["LMG_Mk200_black_F", "", _militaryAttachments, _militaryMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_hunter_F", "", "", _militiaMarksmanSights,["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""], 15
+    ["srifle_DMR_06_hunter_F", "", "", _militiaMarksmanOptics,["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""], 15
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], ""], 2.5
+    ["LMG_Mk200_black_F", "", _militiaAttachments, _militiaMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], ""], 2.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
@@ -14,44 +14,45 @@
     ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 2,
     ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 5.5
 ];
-_sfMarksmanOptics append ["optic_DMS_weathered_F", 1.75];
+_sfMarksmanOptics append ["optic_DMS_weathered_F", 1.5];
 (_sfLoadoutData get "marksmanRifles") append [
     ["arifle_MSBS65_Mark_F", "muzzle_snds_H", _sfAccessories, _sfMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_03_F_oli"], 10
 ];
 
-_sfMGOptics append ["optic_DMS_weathered_Kir_F", 0.5];
+_sfMGOptics append ["optic_DMS_weathered_F", 0.5];
 (_sfLoadoutData get "machineGuns") append [
     ["LMG_Mk200_black_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_03_F_oli"], 5
 ];
 //////////////////////////////////////////////////////
 (_eliteLoadoutData get "slRifles") append [
-    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
-    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 4,
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 10
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
-    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5.5
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 4,
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 10
 ];
 (_eliteLoadoutData get "grenadeLaunchers") append [
-    ["arifle_MSBS65_GL_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 2,
-    ["arifle_MSBS65_GL_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 5.5
+    ["arifle_MSBS65_GL_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 4,
+    ["arifle_MSBS65_GL_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 10
 ];
 (_eliteLoadoutData get "carbines") append [
-    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 2,
-    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 5.5
+    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 4,
+    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 10
 ];
-_eliteMarksmanOptics append ["optic_DMS_weathered_F", 2 ]
+_eliteMarksmanOptics append ["optic_DMS_weathered_F", 2];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["arifle_MSBS65_Mark_F", "", _eliteAccessories, _eliteMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
+    ["arifle_MSBS65_Mark_F", "", _eliteAccessories, _eliteMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 4
 ];
-_eliteMGOptics append ["optic_DMS_weathered_Kir_F", 0.5]
+_eliteMGOptics append ["optic_DMS_weathered_F", 0.5];
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5,
+    ["LMG_Mk200_black_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
 ];
 //////////////////////////////////////////////////////
-_militaryMGSights append ["optic_DMS_weathered_Kir_F", 0.5]
+_militaryMGSights append ["optic_DMS_weathered_F", 0.5];
 (_militaryLoadoutData get "machineGuns") append [
     ["LMG_Mk200_black_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
+];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_06_hunter_F", "", "", _militiaMarksmanSights,["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""], 15

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
@@ -1,26 +1,27 @@
 (_sfLoadoutData get "slRifles") append [
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""],
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""]
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfTlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2
 ];
 (_sfLoadoutData get "rifles") append [
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""],
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", "acc_pointer_IR", "optic_MRCO",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""]
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["arifle_MSBS65_GL_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"],
-    ["arifle_MSBS65_GL_F", "muzzle_snds_H", "acc_pointer_IR", "optic_MRCO",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"]
+    ["arifle_MSBS65_GL_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], ""], 2,
+    ["arifle_MSBS65_GL_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], ""], 2 ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"]
 ];
 (_sfLoadoutData get "carbines") append [
-    ["arifle_MSBS65_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"],
-    ["arifle_MSBS65_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Holosight_blk_F",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
+    ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 2,
+    ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 2
 ];
+_sfMarksmanOptics append ["optic_DMS_weathered_F", 1];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_MSBS65_Mark_F", "muzzle_snds_H", "acc_pointer_IR", "optic_DMS_weathered_F",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
+    ["arifle_MSBS65_Mark_F", "muzzle_snds_H", _sfAccessories, _sfMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_03_F_oli"], 2
 ];
+
+_sfMGOptics append ["optic_DMS_weathered_Kir_F", 2.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "muzzle_snds_H", "acc_pointer_IR", "optic_DMS_weathered_Kir_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "muzzle_snds_H", "acc_pointer_IR", "optic_MRCO", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"]
+    ["LMG_Mk200_black_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_03_F_oli"], 1
 ];
 
 (_eliteLoadoutData get "slRifles") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Contact/Vanilla_AAF.sqf
@@ -1,65 +1,63 @@
 (_sfLoadoutData get "slRifles") append [
     ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfTlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfTlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5.5
 ];
 (_sfLoadoutData get "rifles") append [
     ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
-    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2
+    ["arifle_MSBS65_UBS_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5.5
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
     ["arifle_MSBS65_GL_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], ""], 2,
-    ["arifle_MSBS65_GL_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], ""], 2 ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"]
+    ["arifle_MSBS65_GL_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], ""], 5.5
 ];
 (_sfLoadoutData get "carbines") append [
     ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 2,
-    ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 2
+    ["arifle_MSBS65_F", "muzzle_snds_H", _sfAccessories, _sfRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], ""], 5.5
 ];
-_sfMarksmanOptics append ["optic_DMS_weathered_F", 1];
+_sfMarksmanOptics append ["optic_DMS_weathered_F", 1.75];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["arifle_MSBS65_Mark_F", "muzzle_snds_H", _sfAccessories, _sfMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_03_F_oli"], 2
+    ["arifle_MSBS65_Mark_F", "muzzle_snds_H", _sfAccessories, _sfMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_03_F_oli"], 10
 ];
 
-_sfMGOptics append ["optic_DMS_weathered_Kir_F", 2.5];
+_sfMGOptics append ["optic_DMS_weathered_Kir_F", 0.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_03_F_oli"], 1
+    ["LMG_Mk200_black_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_03_F_oli"], 5
 ];
 
 (_eliteLoadoutData get "slRifles") append [
-    ["arifle_MSBS65_UBS_F", "", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""],
-    ["arifle_MSBS65_UBS_F", "", "acc_pointer_IR", "optic_Hamr",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""]
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["arifle_MSBS65_UBS_F", "", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""],
-    ["arifle_MSBS65_UBS_F", "", "acc_pointer_IR", "optic_MRCO",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""]
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2,
+    ["arifle_MSBS65_UBS_F", "", _eliteAccessories, _eliteSlOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 5.5
 ];
 (_eliteLoadoutData get "grenadeLaunchers") append [
-    ["arifle_MSBS65_GL_F", "", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"],
-    ["arifle_MSBS65_GL_F", "", "acc_pointer_IR", "optic_MRCO",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"]
+    ["arifle_MSBS65_GL_F", "", _eliteAccessories, "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 2,
+    ["arifle_MSBS65_GL_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell"], "bipod_02_F_lush"], 5.5
 ];
 (_eliteLoadoutData get "carbines") append [
-    ["arifle_MSBS65_F", "", "acc_pointer_IR", "optic_ico_01_f",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"],
-    ["arifle_MSBS65_F", "", "acc_pointer_IR", "optic_Holosight_blk_F",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
+    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 2,
+    ["arifle_MSBS65_F", "", _eliteAccessories, _eliteRifleOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"], 5.5
 ];
+_eliteMarksmanOptics append ["optic_DMS_weathered_F", 2 ]
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["arifle_MSBS65_Mark_F", "", "acc_pointer_IR", "optic_DMS_weathered_F",["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
+    ["arifle_MSBS65_Mark_F", "", _eliteAccessories, _eliteMarksmanOptics,["30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag","30Rnd_65x39_caseless_msbs_mag_Tracer"], [], "bipod_02_F_lush"]
 ];
+_eliteMGOptics append ["optic_DMS_weathered_Kir_F", 0.5]
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", "acc_pointer_IR", "optic_DMS_weathered_Kir_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "", "acc_pointer_IR", "optic_MRCO", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "", "acc_pointer_IR", "optic_Hamr", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"]
+    ["LMG_Mk200_black_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5,
 ];
 
+_militaryMGSights append ["optic_DMS_weathered_Kir_F", 0.5]
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", "acc_flashlight", "optic_DMS_weathered_Kir_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"],
-    ["LMG_Mk200_black_F", "", "acc_flashlight", "optic_Hamr", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"]
-];
+    ["LMG_Mk200_black_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_02_F_lush"], 5
 
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_hunter_F", "", "", "optic_MRCO",["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""]
+    ["srifle_DMR_06_hunter_F", "", "", _militiaMarksmanSights,["10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag","10Rnd_Mk14_762x51_Mag"], [], ""], 15
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["LMG_Mk200_black_F", "", "acc_flashlight", "", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], ""]
+    ["LMG_Mk200_black_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], ""], 2.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -16,8 +16,8 @@
     ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5
 ];
 (_sfLoadoutData get "rifles") append [
-    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4,
-    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 4
+    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", _sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4,
+    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", _sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 4
 ];
 (_sfLoadoutData get "marksmanRifles") append [
     ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -57,40 +57,40 @@
     ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
-_militaryRifleSights append ["gm_c79a1_blk", 1, "gm_blits_ris_blk", 0.5, "gm_rv_ris_blk", 2];
+_militaryRifleOptics append ["gm_c79a1_blk", 1, "gm_blits_ris_blk", 0.5, "gm_rv_ris_blk", 2];
 (_militaryLoadoutData get "rifles") append [
     ["gm_c7a1_oli", "", "", "gm_c79a1_oli", ["gm_30Rnd_556x45mm_B_M855_stanag_gry", "gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""], 4,
     ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 2,
     ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 6,
-    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], ""], 3,
-    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 2
+    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleOptics, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], ""], 3,
+    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleOptics, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 2
 ];
-_gmMilitaryMG8Sights = ["gm_rv_stanagHK_blk", 2, "gm_blits_StanagHK_blk", 4, "gm_feroz24_stanagHK_blk", 1, "", 1];
+_gmMilitaryMG8Optics = ["gm_rv_stanagHK_blk", 2, "gm_blits_StanagHK_blk", 4, "gm_feroz24_stanagHK_blk", 1, "", 1];
 (_militaryLoadoutData get "machineGuns") append [
     ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 4,
-    ["gm_mg8a2_blk", "", "", _gmMilitaryMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
+    ["gm_mg8a2_blk", "", "", _gmMilitaryMG8Optics, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
 ];
-_gmMilitaryMarksmanSights = ["gm_feroz24_stanagHK_blk", 3, "gm_blits_stanagHK_blk", 1];
+_gmMilitaryMarksmanOptics = ["gm_feroz24_stanagHK_blk", 3, "gm_blits_stanagHK_blk", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","", _gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1,
-    ["gm_msg90a1_blk","","", _gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 3
+    ["gm_msg90_blk","","", _gmMilitaryMarksmanOptics,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1,
+    ["gm_msg90a1_blk","","", _gmMilitaryMarksmanOptics,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 3
 ];
 (_militaryLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 //////////////////////////////////////////////////////
-_gmMilitiaMP5Sights = ["gm_rv_StanagClaw_blk", 1, "", 4];
+_gmMilitiaMP5Optics = ["gm_rv_StanagClaw_blk", 1, "", 4];
 (_militiaLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmMilitiaMP5Sights, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
-    ["gm_mp5a2_blk", "", "", _gmMilitiaMP5Sights, ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 6
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmMilitiaMP5Optics, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
+    ["gm_mp5a2_blk", "", "", _gmMilitiaMP5Optics, ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 6
 ];
-_gmMilitiaMG8Sights = ["gm_rv_stanagHK_blk", 3, "gm_blits_StanagHK_blk", 0.5, "gm_feroz24_stanagHK_blk", 1, "", 8];
+_gmMilitiaMG8Optics = ["gm_rv_stanagHK_blk", 3, "gm_blits_StanagHK_blk", 0.5, "gm_feroz24_stanagHK_blk", 1, "", 8];
 (_militiaLoadoutData get "machineGuns") append [
-    ["gm_mg8a1_blk", "", "", _gmMilitiaMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
+    ["gm_mg8a1_blk", "", "", _gmMilitiaMG8Optics, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","",_gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
-    ["gm_msg90a1_blk","","",_gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
+    ["gm_msg90_blk","","",_gmMilitaryMarksmanOptics,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
+    ["gm_msg90a1_blk","","",_gmMilitaryMarksmanOptics,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];
 (_militiaLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
@@ -106,11 +106,11 @@ _gmMilitiaMG8Sights = ["gm_rv_stanagHK_blk", 3, "gm_blits_StanagHK_blk", 0.5, "g
     ["gm_pm63_handgun_blk", "", "", "", ["gm_15Rnd_9x18mm_B_pst_pm63_blk","gm_25Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 0.25
 ];
 _gmPoliceShotgunAccessories = ["gm_surefire_l60_wht_hoseclamp_blk", 1, "", 1.5];
-_gmPoliceSMGSights = ["gm_rv_stanagClaw_blk", 1, "", 3];
+_gmPoliceSMGOptics = ["gm_rv_stanagClaw_blk", 1, "", 3];
 (_policeLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmPoliceSMGSights, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmPoliceSMGOptics, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
     ["gm_hk512_wud", "", _gmPoliceShotgunAccessories, "", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 1.5,
-    ["gm_hk512_ris_wud", "", _gmPoliceShotgunAccessories, _policeSMGSights, ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 3,
+    ["gm_hk512_ris_wud", "", _gmPoliceShotgunAccessories, _policeSMGOptics, ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 3,
     ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM51_mp2_blk","gm_32Rnd_9x19mm_B_DM11_mp2_blk","gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""], 3,
     ["gm_pm63_blk", "", "", "", ["gm_25Rnd_9x18mm_B_pst_pm63_blk","gm_15Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 0.5
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -10,6 +10,7 @@
 (_loadoutData get "AALaunchers") append [
     ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 7
 ];
+//////////////////////////////////////////////////////
 (_sfLoadoutData get "slRifles") append [
     ["gm_g11k2_ris_blk","", _sfAccessories, _sfTlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 7,
     ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5
@@ -29,6 +30,7 @@
     ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 7
     ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""] 3
 ];
+//////////////////////////////////////////////////////
 (_eliteLoadoutData get "slRifles") append [
     ["gm_g11k2_ris_blk","", _eliteAccessories, _eliteSlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 4,
     ["gm_sg551_swat_blk","", _eliteAccessories, _eliteSlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
@@ -52,6 +54,7 @@
     ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1,
     ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4
 ];
+//////////////////////////////////////////////////////
 (_militaryLoadoutData get "rifles") append [
     ["gm_c7a1_oli", "", "", _militaryRifleSights, ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""], 5,
     ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 3,
@@ -71,6 +74,7 @@
 (_militaryLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 15
 ];
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "SMGs") append [
     ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4.5,
     ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 5.5
@@ -84,6 +88,7 @@
 (_militiaLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
+//////////////////////////////////////////////////////
 (_policeLoadoutData get "sidearms") append [
     ["gm_m49_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM51_p210_blk","gm_8Rnd_9x19mm_B_DM11_p210_blk"], [], ""],
     ["gm_p1_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p1_blk","gm_8Rnd_9x19mm_B_DM51_p1_blk","gm_8Rnd_9x19mm_BSD_DM81_p1_blk"], [], ""],

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -1,26 +1,26 @@
 (_loadoutData get "lightATLaunchers") append [
-    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""],
-    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""],
-    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""]
+    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""], 3,
+    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""], 2,
+    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""], 2
 ];
 (_loadoutData get "ATLaunchers") append [
-    ["gm_pzf3_blk", "", "", "", ["gm_1Rnd_60mm_heat_dm22_pzf3", "gm_1Rnd_60mm_heat_dm32_pzf3", "gm_1Rnd_60mm_heat_dm12_pzf3"], [], ""],
-    ["gm_pzf84_oli", "", "", "gm_feroz2x17_pzf84_blk", ["gm_1Rnd_84x245mm_heat_t_DM32_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM22_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM12_carlgustaf"], [], ""]
+    ["gm_pzf3_blk", "", "", "", ["gm_1Rnd_60mm_heat_dm22_pzf3", "gm_1Rnd_60mm_heat_dm32_pzf3", "gm_1Rnd_60mm_heat_dm12_pzf3"], [], ""], 1,
+    ["gm_pzf84_oli", "", "", "gm_feroz2x17_pzf84_blk", ["gm_1Rnd_84x245mm_heat_t_DM32_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM22_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM12_carlgustaf"], [], ""], 1
 ];
 (_loadoutData get "AALaunchers") append [
-    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""]
+    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 1.5
 ];
 (_sfLoadoutData get "slRifles") append [
-    ["gm_g11k2_ris_blk","","acc_pointer_IR","optic_Nightstalker",["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""],
-    ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk","acc_pointer_IR","optic_Hamr",["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""]
+    ["gm_g11k2_ris_blk","", _sfAccessories, _sfTlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 2
+    ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""]
 ];
 (_sfLoadoutData get "rifles") append [
-    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","","optic_Hamr",["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""],
-    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","","optic_Hamr",["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""]
+    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""],
+    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""]
 ];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"],
-    ["gm_msg90a1_blk","gm_suppressor_atec150_762mm_long_blk","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 0.75,
+    ["gm_msg90a1_blk","gm_suppressor_atec150_762mm_long_blk","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 0.75
 ];
 (_sfLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]
@@ -53,31 +53,33 @@
     ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""]
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["gm_c7a1_oli", "", "", "optic_Hamr", ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""],
-    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""],
-    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""],
-    ["gm_g3a4a1_ris_oli", "", "", "optic_MRCO", ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""],
-    ["gm_g3ka4a1_ris_blk", "", "", "gm_c79a1_blk", ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""]
+    ["gm_c7a1_oli", "", "", _militaryRifleSights, ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""], 1,
+    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 0.5,
+    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 0.5,
+    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 0.3,
+    ["gm_g3a4a1_ris_oli", "", "", gm_c79a1_oli, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 0.2,
+    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 0.3,
+    ["gm_g3ka4a1_ris_blk", "", "", "gm_c79a1_blk", ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 0.2
 ];
 (_militaryLoadoutData get "machineGuns") append [
-    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""],
-    ["gm_mg8a2_blk", "", "", "gm_blits_stanagHK_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"]
+    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 0.75,
+    ["gm_mg8a2_blk", "", "", "gm_blits_stanagHK_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 1
 ];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1
 ];
 (_militaryLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 1
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""],
-    ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""]
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1.5,
+    ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 1.5
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["gm_mg8a1_blk", "", "", "gm_colt4x20_stanagClaw_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"]
+    ["gm_mg8a1_blk", "", "", "gm_colt4x20_stanagClaw_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 1.5
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1
 ];
 (_militiaLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -30,59 +30,59 @@
     ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""]
 ];
 (_eliteLoadoutData get "slRifles") append [
-    ["gm_g11k2_ris_blk","","acc_pointer_IR","optic_Nightstalker",["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""],
-    ["gm_sg551_swat_blk","","acc_pointer_IR","optic_Hamr",["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""]
+    ["gm_g11k2_ris_blk","", _eliteAccessories, _eliteSlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 4,
+    ["gm_sg551_swat_blk","", _eliteAccessories, _eliteSlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["gm_sg551_ris_blk", "","","optic_Hamr",["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""],
-    ["gm_sg542_ris_blk", "","","optic_Hamr",["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""]
+    ["gm_sg551_ris_blk", "","", _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5,
+    ["gm_sg542_ris_blk", "","", _eliteRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 5
 ];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"],
-    ["gm_msg90a1_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 3,
+    ["gm_msg90a1_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 (_eliteLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];   
 (_eliteLoadoutData get "designatedGrenadeLaunchers") append [
-    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""],
-    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""]
+    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,
+    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""], 2.5
 ];
 (_eliteLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""],
-    ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""]
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1,
+    ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["gm_c7a1_oli", "", "", _militaryRifleSights, ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""], 1,
-    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 0.5,
-    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 0.5,
-    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 0.3,
-    ["gm_g3a4a1_ris_oli", "", "", gm_c79a1_oli, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 0.2,
-    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 0.3,
-    ["gm_g3ka4a1_ris_blk", "", "", "gm_c79a1_blk", ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 0.2
+    ["gm_c7a1_oli", "", "", _militaryRifleSights, ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""], 5,
+    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 3,
+    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 3,
+    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 2.5,
+    ["gm_g3a4a1_ris_oli", "", "", gm_c79a1_oli, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 1.5,
+    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 2.5,
+    ["gm_g3ka4a1_ris_blk", "", "", "gm_c79a1_blk", ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 1.5
 ];
 (_militaryLoadoutData get "machineGuns") append [
-    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 0.75,
-    ["gm_mg8a2_blk", "", "", "gm_blits_stanagHK_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 1
+    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 4
+    ["gm_mg8a2_blk", "", "", "gm_blits_stanagHK_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
 ];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 8
 ];
 (_militaryLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 1
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 15
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1.5,
-    ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 1.5
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4.5,
+    ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 5.5
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["gm_mg8a1_blk", "", "", "gm_colt4x20_stanagClaw_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 1.5
+    ["gm_mg8a1_blk", "", "", "gm_colt4x20_stanagClaw_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
     ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 (_policeLoadoutData get "sidearms") append [
     ["gm_m49_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM51_p210_blk","gm_8Rnd_9x19mm_B_DM11_p210_blk"], [], ""],
@@ -94,9 +94,9 @@
     ["gm_pm63_handgun_blk", "", "", "", ["gm_15Rnd_9x18mm_B_pst_pm63_blk","gm_25Rnd_9x18mm_B_pst_pm63_blk"], [], ""]
 ];
 (_policeLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""],
-    ["gm_hk512_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", "", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""],
-    ["gm_hk512_ris_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", "optic_Aco", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""],
-    ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM51_mp2_blk","gm_32Rnd_9x19mm_B_DM11_mp2_blk","gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""],
-    ["gm_pm63_blk", "", "", "", ["gm_25Rnd_9x18mm_B_pst_pm63_blk","gm_15Rnd_9x18mm_B_pst_pm63_blk"], [], ""]
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4,
+    ["gm_hk512_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", "", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 1,
+    ["gm_hk512_ris_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", _policeSMGSights, ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 3,
+    ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM51_mp2_blk","gm_32Rnd_9x19mm_B_DM11_mp2_blk","gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""], 1.5,
+    ["gm_pm63_blk", "", "", "", ["gm_25Rnd_9x18mm_B_pst_pm63_blk","gm_15Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 1.5
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -16,7 +16,7 @@
     ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5
 ];
 (_sfLoadoutData get "rifles") append [
-    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
+    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4,
     ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 4
 ];
 (_sfLoadoutData get "marksmanRifles") append [
@@ -27,8 +27,8 @@
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 (_sfLoadoutData get "designatedGrenadeLaunchers") append [
-    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 7
-    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""] 3
+    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 7,
+    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""], 3
 ];
 //////////////////////////////////////////////////////
 
@@ -37,7 +37,7 @@
     ["gm_sg551_swat_blk","", _eliteAccessories, _eliteSlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["gm_sg551_swat_blk","", _eliteAccessories, _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 2
+    ["gm_sg551_swat_blk","", _eliteAccessories, _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 2,
     ["gm_sg551_ris_blk", "","", _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5,
     ["gm_sg542_ris_blk", "","", _eliteRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 2
 ];
@@ -67,7 +67,7 @@ _militaryRifleSights append ["gm_c79a1_blk", 1, "gm_blits_ris_blk", 0.5, "gm_rv_
 ];
 _gmMilitaryMG8Sights = ["gm_rv_stanagHK_blk", 2, "gm_blits_StanagHK_blk", 4, "gm_feroz24_stanagHK_blk", 1, "", 1];
 (_militaryLoadoutData get "machineGuns") append [
-    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 4
+    ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 4,
     ["gm_mg8a2_blk", "", "", _gmMilitaryMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
 ];
 _gmMilitaryMarksmanSights = ["gm_feroz24_stanagHK_blk", 3, "gm_blits_stanagHK_blk", 1];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -1,14 +1,14 @@
 (_loadoutData get "lightATLaunchers") append [
-    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""], 3,
-    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""], 2,
-    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""], 2
+    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""], 6,
+    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""], 4,
+    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""], 4
 ];
 (_loadoutData get "ATLaunchers") append [
-    ["gm_pzf3_blk", "", "", "", ["gm_1Rnd_60mm_heat_dm22_pzf3", "gm_1Rnd_60mm_heat_dm32_pzf3", "gm_1Rnd_60mm_heat_dm12_pzf3"], [], ""], 1,
-    ["gm_pzf84_oli", "", "", "gm_feroz2x17_pzf84_blk", ["gm_1Rnd_84x245mm_heat_t_DM32_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM22_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM12_carlgustaf"], [], ""], 1
+    ["gm_pzf3_blk", "", "", "", ["gm_1Rnd_60mm_heat_dm22_pzf3", "gm_1Rnd_60mm_heat_dm32_pzf3", "gm_1Rnd_60mm_heat_dm12_pzf3"], [], ""], 3,
+    ["gm_pzf84_oli", "", "", "gm_feroz2x17_pzf84_blk", ["gm_1Rnd_84x245mm_heat_t_DM32_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM22_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM12_carlgustaf"], [], ""], 3
 ];
 (_loadoutData get "AALaunchers") append [
-    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 1.5
+    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 7
 ];
 (_sfLoadoutData get "slRifles") append [
     ["gm_g11k2_ris_blk","", _sfAccessories, _sfTlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 7,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -11,23 +11,23 @@
     ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 1.5
 ];
 (_sfLoadoutData get "slRifles") append [
-    ["gm_g11k2_ris_blk","", _sfAccessories, _sfTlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 2
-    ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""]
+    ["gm_g11k2_ris_blk","", _sfAccessories, _sfTlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 7,
+    ["gm_sg551_swat_blk","gm_suppressor_atec150_556mm_blk", _sfAccessories, _sfTlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5
 ];
 (_sfLoadoutData get "rifles") append [
-    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""],
-    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""]
+    ["gm_sg551_ris_blk", "gm_suppressor_atec150_556mm_blk","", sfRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
+    ["gm_sg542_ris_blk", "gm_suppressor_atec150_762mm_blk","", sfRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 4
 ];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 0.75,
-    ["gm_msg90a1_blk","gm_suppressor_atec150_762mm_long_blk","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 0.75
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
+    ["gm_msg90a1_blk","gm_suppressor_atec150_762mm_long_blk","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];
 (_sfLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"]
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 (_sfLoadoutData get "designatedGrenadeLaunchers") append [
-    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""],
-    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""]
+    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 7
+    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""] 3
 ];
 (_eliteLoadoutData get "slRifles") append [
     ["gm_g11k2_ris_blk","", _eliteAccessories, _eliteSlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 4,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -89,8 +89,8 @@ _gmMilitiaMG8Sights = ["gm_rv_stanagHK_blk", 3, "gm_blits_StanagHK_blk", 0.5, "g
     ["gm_mg8a1_blk", "", "", _gmMilitiaMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","",gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
-    ["gm_msg90a1_blk","","",gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
+    ["gm_msg90_blk","","",_gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
+    ["gm_msg90a1_blk","","",_gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];
 (_militiaLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/GM/Vanilla_AAF.sqf
@@ -1,14 +1,14 @@
 (_loadoutData get "lightATLaunchers") append [
-    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""], 6,
-    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""], 4,
-    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""], 4
+    ["gm_m72a3_oli", "", "", "", ["gm_1Rnd_66mm_heat_m72a3"], [], ""], 8,
+    ["gm_rpg18_oli", "", "", "", ["gm_1Rnd_64mm_heat_pg18"], [], ""], 3,
+    ["gm_pzf44_2_oli", "", "", "gm_feroz2x17_pzf44_2_blk", ["gm_1Rnd_44x537mm_heat_dm32_pzf44_2"], [], ""], 3
 ];
 (_loadoutData get "ATLaunchers") append [
     ["gm_pzf3_blk", "", "", "", ["gm_1Rnd_60mm_heat_dm22_pzf3", "gm_1Rnd_60mm_heat_dm32_pzf3", "gm_1Rnd_60mm_heat_dm12_pzf3"], [], ""], 3,
     ["gm_pzf84_oli", "", "", "gm_feroz2x17_pzf84_blk", ["gm_1Rnd_84x245mm_heat_t_DM32_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM22_carlgustaf", "gm_1Rnd_84x245mm_heat_t_DM12_carlgustaf"], [], ""], 3
 ];
 (_loadoutData get "AALaunchers") append [
-    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 7
+    ["gm_fim43_oli", "", "", "", ["gm_1Rnd_70mm_he_m585_fim43"], [], ""], 3
 ];
 //////////////////////////////////////////////////////
 (_sfLoadoutData get "slRifles") append [
@@ -31,77 +31,86 @@
     ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""] 3
 ];
 //////////////////////////////////////////////////////
+
 (_eliteLoadoutData get "slRifles") append [
-    ["gm_g11k2_ris_blk","", _eliteAccessories, _eliteSlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 4,
+    ["gm_g11k2_ris_blk","", _eliteAccessories, _eliteSlOptics, ["gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk","gm_50Rnd_473x33mm_B_DM11_g11_blk"], [], ""], 3,
     ["gm_sg551_swat_blk","", _eliteAccessories, _eliteSlOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 4
 ];
 (_eliteLoadoutData get "rifles") append [
+    ["gm_sg551_swat_blk","", _eliteAccessories, _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 2
     ["gm_sg551_ris_blk", "","", _eliteRifleOptics, ["gm_30Rnd_556x45mm_B_T_DM21_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_DM11_sg550_brn","gm_30Rnd_556x45mm_B_T_DM21_sg550_brn"], [], ""], 5,
-    ["gm_sg542_ris_blk", "","", _eliteRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 5
+    ["gm_sg542_ris_blk", "","", _eliteRifleOptics, ["gm_20Rnd_762x51mm_B_T_DM21A2_sg542_blk","gm_20Rnd_762x51mm_AP_DM151_sg542_blk","gm_20Rnd_762x51mm_B_DM41_sg542_blk","gm_20Rnd_762x51mm_B_DM111_sg542_blk"], [], ""], 2
 ];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 3,
-    ["gm_msg90a1_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 5
+    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
+    ["gm_msg90a1_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];
 (_eliteLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];   
 (_eliteLoadoutData get "designatedGrenadeLaunchers") append [
-    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,
-    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""], 2.5
+    ["gm_hk69a1_blk", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 4,
+    ["gm_pallad_d_brn", "", "", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell", "1Rnd_HE_Grenade_shell"], [], ""], 2
 ];
 (_eliteLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1,
-    ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 2,
+    ["gm_mp5sd6_blk", "", "", "gm_rv_stanagClaw_blk", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
+_militaryRifleSights append ["gm_c79a1_blk", 1, "gm_blits_ris_blk", 0.5, "gm_rv_ris_blk", 2];
 (_militaryLoadoutData get "rifles") append [
-    ["gm_c7a1_oli", "", "", _militaryRifleSights, ["gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry","gm_30Rnd_556x45mm_B_M193_stanag_gry","gm_30Rnd_556x45mm_B_T_M196_stanag_gry"], [], ""], 5,
-    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 3,
-    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 3,
-    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 2.5,
-    ["gm_g3a4a1_ris_oli", "", "", gm_c79a1_oli, ["gm_40Rnd_762x51mm_B_T_DM21_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A1_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], ["gm_1rnd_67mm_heat_dm22a1_g3"], ""], 1.5,
-    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 2.5,
-    ["gm_g3ka4a1_ris_blk", "", "", "gm_c79a1_blk", ["gm_40Rnd_762x51mm_AP_DM151_g3_blk","gm_40Rnd_762x51mm_B_DM41_g3_blk","gm_40Rnd_762x51mm_B_DM111_g3_blk","gm_40Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 1.5
+    ["gm_c7a1_oli", "", "", "gm_c79a1_oli", ["gm_30Rnd_556x45mm_B_M855_stanag_gry", "gm_30Rnd_556x45mm_B_M855_stanag_gry","gm_30Rnd_556x45mm_B_T_M856_stanag_gry"], [], ""], 4,
+    ["gm_g36a1_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 2,
+    ["gm_g36e_blk", "", "", "", ["gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk","gm_30Rnd_556x45mm_B_DM11_g36_blk","gm_30Rnd_556x45mm_B_T_DM21_g36_blk"], [], ""], 6,
+    ["gm_g3a4a1_ris_oli", "", "", _militaryRifleSights, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], ""], 3,
+    ["gm_g3ka4a1_ris_blk", "", "", _militaryRifleSights, ["gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], ""], 2
 ];
+_gmMilitaryMG8Sights = ["gm_rv_stanagHK_blk", 2, "gm_blits_StanagHK_blk", 4, "gm_feroz24_stanagHK_blk", 1, "", 1];
 (_militaryLoadoutData get "machineGuns") append [
     ["gm_mg3_blk", "", "", "", ["gm_120Rnd_762x51mm_B_T_DM21_mg3_grn","gm_120Rnd_762x51mm_B_T_DM21A2_mg3_grn"], [], ""], 4
-    ["gm_mg8a2_blk", "", "", "gm_blits_stanagHK_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
+    ["gm_mg8a2_blk", "", "", _gmMilitaryMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 5
 ];
+_gmMilitaryMarksmanSights = ["gm_feroz24_stanagHK_blk", 3, "gm_blits_stanagHK_blk", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 8
+    ["gm_msg90_blk","","", _gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1,
+    ["gm_msg90a1_blk","","", _gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM111_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 3
 ];
 (_militaryLoadoutData get "sniperRifles") append [
-    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 15
+    ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 //////////////////////////////////////////////////////
+_gmMilitiaMP5Sights = ["gm_rv_StanagClaw_blk", 1, "", 4];
 (_militiaLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4.5,
-    ["gm_mp5a2_blk", "", "", "", ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 5.5
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmMilitiaMP5Sights, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
+    ["gm_mp5a2_blk", "", "", _gmMilitiaMP5Sights, ["gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk","gm_30Rnd_9x19mm_B_DM11_mp5_blk","gm_30Rnd_9x19mm_AP_DM91_mp5_blk"], [], ""], 6
 ];
+_gmMilitiaMG8Sights = ["gm_rv_stanagHK_blk", 3, "gm_blits_StanagHK_blk", 0.5, "gm_feroz24_stanagHK_blk", 1, "", 8];
 (_militiaLoadoutData get "machineGuns") append [
-    ["gm_mg8a1_blk", "", "", "gm_colt4x20_stanagClaw_blk", ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
+    ["gm_mg8a1_blk", "", "", _gmMilitiaMG8Sights, ["gm_100Rnd_762x51mm_B_T_DM21_mg8_oli","gm_100Rnd_762x51mm_B_T_DM21A2_mg8_oli"], [], "gm_g8_bipod_blk"], 8
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["gm_msg90_blk","","","gm_feroz24_stanagHK_blk",["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 1
+    ["gm_msg90_blk","","",gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 2,
+    ["gm_msg90a1_blk","","",gmMilitaryMarksmanSights,["gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk", "gm_20Rnd_762x51mm_B_DM111_g3_blk","gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk"], [], "gm_msg90_bipod_blk"], 6
 ];
 (_militiaLoadoutData get "sniperRifles") append [
     ["gm_psg1_blk","","","gm_zf6x42_psg1_stanag_blk",["gm_20Rnd_762x51mm_B_T_DM21A2_g3_blk","gm_20Rnd_762x51mm_AP_DM151_g3_blk","gm_20Rnd_762x51mm_B_DM41_g3_blk"], [], "gm_msg90_bipod_blk"], 5
 ];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "sidearms") append [
-    ["gm_m49_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM51_p210_blk","gm_8Rnd_9x19mm_B_DM11_p210_blk"], [], ""],
-    ["gm_p1_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p1_blk","gm_8Rnd_9x19mm_B_DM51_p1_blk","gm_8Rnd_9x19mm_BSD_DM81_p1_blk"], [], ""],
-    ["gm_p1sd_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p1_blk","gm_8Rnd_9x19mm_B_DM51_p1_blk","gm_8Rnd_9x19mm_BSD_DM81_p1_blk"], [], ""],
-    ["gm_p210_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p210_blk","gm_8Rnd_9x19mm_B_DM51_p210_blk"], [], ""],
-    ["gm_pim_blk", "", "", "", ["gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk"], [], ""],
-    ["gm_pimb_blk", "", "", "", ["gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk"], [], ""],
-    ["gm_pm63_handgun_blk", "", "", "", ["gm_15Rnd_9x18mm_B_pst_pm63_blk","gm_25Rnd_9x18mm_B_pst_pm63_blk"], [], ""]
+    ["gm_m49_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM51_p210_blk","gm_8Rnd_9x19mm_B_DM11_p210_blk"], [], ""], 0.5,
+    ["gm_p1_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p1_blk","gm_8Rnd_9x19mm_B_DM51_p1_blk","gm_8Rnd_9x19mm_BSD_DM81_p1_blk"], [], ""], 0.5,
+    ["gm_p1sd_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p1_blk","gm_8Rnd_9x19mm_B_DM51_p1_blk","gm_8Rnd_9x19mm_BSD_DM81_p1_blk"], [], ""], 0.1,
+    ["gm_p210_blk", "", "", "", ["gm_8Rnd_9x19mm_B_DM11_p210_blk","gm_8Rnd_9x19mm_B_DM51_p210_blk"], [], ""], 2,
+    ["gm_pim_blk", "", "", "", ["gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk"], [], ""], 0.75,
+    ["gm_pimb_blk", "", "", "", ["gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk","gm_8Rnd_9x18mm_B_pst_pm_blk"], [], ""], 0.2,
+    ["gm_pm63_handgun_blk", "", "", "", ["gm_15Rnd_9x18mm_B_pst_pm63_blk","gm_25Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 0.25
 ];
+_gmPoliceShotgunAccessories = ["gm_surefire_l60_wht_hoseclamp_blk", 1, "", 1.5];
+_gmPoliceSMGSights = ["gm_rv_stanagClaw_blk", 1, "", 3];
 (_policeLoadoutData get "SMGs") append [
-    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", "", ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 4,
-    ["gm_hk512_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", "", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 1,
-    ["gm_hk512_ris_wud", "", "gm_surefire_l60_wht_hoseclamp_blk", _policeSMGSights, ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 3,
-    ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM51_mp2_blk","gm_32Rnd_9x19mm_B_DM11_mp2_blk","gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""], 1.5,
-    ["gm_pm63_blk", "", "", "", ["gm_25Rnd_9x18mm_B_pst_pm63_blk","gm_15Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 1.5
+    ["gm_mp5n_surefire_blk", "", "gm_surefire_l60_wht_surefire_blk", _gmPoliceSMGSights, ["gm_60Rnd_9x19mm_B_DM11_mp5a3_blk","gm_60Rnd_9x19mm_AP_DM91_mp5a3_blk","gm_30Rnd_9x19mm_B_DM51_mp5_blk"], [], ""], 3,
+    ["gm_hk512_wud", "", _gmPoliceShotgunAccessories, "", ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 1.5,
+    ["gm_hk512_ris_wud", "", _gmPoliceShotgunAccessories, _policeSMGSights, ["gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug","gm_7rnd_12ga_hk512_pellet","gm_7rnd_12ga_hk512_slug"], [], ""], 3,
+    ["gm_mp2a1_blk", "", "", "", ["gm_32Rnd_9x19mm_B_DM51_mp2_blk","gm_32Rnd_9x19mm_B_DM11_mp2_blk","gm_32Rnd_9x19mm_AP_DM91_mp2_blk"], [], ""], 3,
+    ["gm_pm63_blk", "", "", "", ["gm_25Rnd_9x18mm_B_pst_pm63_blk","gm_15Rnd_9x18mm_B_pst_pm63_blk"], [], ""], 0.5
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -1,13 +1,14 @@
+_sfMarksmanOptics append ["optic_AMS", 3];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_03_F", "muzzle_snds_B", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_06_olive_F", "muzzle_snds_B", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
+    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
+    ["srifle_DMR_03_multicam_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
+    ["srifle_DMR_03_woodland_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
+    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 4,
+    ["srifle_DMR_06_olive_F", "muzzle_snds_B", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 0.5,
+    ["srifle_DMR_06_camo_F", "muzzle_snds_B", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1
 ];
 (_sfLoadoutData get "machineGuns") append [
-    ["MMG_02_black_F", "muzzle_snds_338_green", "acc_pointer_IR", "optic_Holosight_blk_F", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "muzzle_snds_338_green", "acc_pointer_IR", "optic_MRCO", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "muzzle_snds_338_green", "acc_pointer_IR", "optic_Hamr", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "muzzle_snds_338_green", "acc_pointer_IR", "optic_NVS", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"]
+    ["MMG_02_black_F", "muzzle_snds_338_green", _sfAccessories, _sfMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 2
 ];
 
 (_eliteLoadoutData get "marksmanRifles") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -24,18 +24,18 @@ _eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
     ["MMG_02_black_F", "", _eliteAccessories, _eliteMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 8
 ];
 //////////////////////////////////////////////////////
-_militaryMarksmanSights append ["optic_AMS", 1];
+_militaryMarksmanOptics append ["optic_AMS", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanSights, [], [], ""], 2,
-    ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanSights, [], [], ""], 5
+    ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanOptics, [], [], ""], 2,
+    ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanOptics, [], [], ""], 5
 ];
-_militarySniperSights append ["optic_AMS", 4, "optic_KHS_blk", 2];
+_militarySniperOptics append ["optic_AMS", 4, "optic_KHS_blk", 2];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 15
+    ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanOptics, [], [], ""], 15
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 8
+    ["srifle_DMR_06_olive_F", "", "", _militiaSniperOptics, [], [], ""], 8
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -1,10 +1,10 @@
 _sfMarksmanOptics append ["optic_AMS", 2];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 7,
-    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 7,
-    ["srifle_DMR_03_multicam_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 3,
-    ["srifle_DMR_03_woodland_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 3
+    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10,
+    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10,
     // 2:1 ratio of SIGs to MK14s now.
+    ["srifle_DMR_06_olive_F", "", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5
+    // The standard M14 shouldn't be appearing that frequently now.
 ];
 _sfSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 4];
 (_sfLoadoutData get "machineGuns") append [
@@ -16,6 +16,8 @@ _eliteMarksmanOptics append ["optic_AMS", 3];
     ["srifle_DMR_03_khaki_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5, 
     ["srifle_DMR_03_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5 
     // SIGs now start appearing in even numbers to Mk14s.
+    ["srifle_DMR_06_olive_F", "", "", _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5
+    // The standard M14 shouldn't be appearing that frequently now.
 ];
 _eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
 (_eliteLoadoutData get "machineGuns") append [
@@ -24,19 +26,16 @@ _eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
 
 _militaryMarksmanSights append ["optic_AMS", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "", _militaryAttachment, _militaryMarksmanSights,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1.75
-    ["srifle_DMR_03_F", "", _militaryAttachment, _militaryMarksmanSights,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1.75 
-    // Should be a 4:1 ratio of Mk14s to SIG 556s.
+    ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanSights, [], [], ""],3.5,
+    ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanSights, [], [], ""], 3.5
 ];
 _militarySniperSights append ["optic_AMS", 6, "optic_KHS_blk", 5];
 
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_camo_F", "", "", _militiaMarksmanSights, [], [], ""], 7.5,
-    ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 7.5
+    ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 15
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["srifle_DMR_06_camo_F", "", "", _militiaSniperSights, [], [], ""], 7.5,
-    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 7.5
+    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 15
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -1,36 +1,43 @@
-_sfMarksmanOptics append ["optic_AMS", 3];
+_sfMarksmanOptics append ["optic_AMS", 2];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
-    ["srifle_DMR_03_multicam_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
-    ["srifle_DMR_03_woodland_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1,
-    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 4,
-    ["srifle_DMR_06_olive_F", "muzzle_snds_B", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 0.5,
-    ["srifle_DMR_06_camo_F", "muzzle_snds_B", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1
+    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 7,
+    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 7,
+    ["srifle_DMR_03_multicam_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 3,
+    ["srifle_DMR_03_woodland_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 3
+    // 2:1 ratio of SIGs to MK14s now.
 ];
+_sfSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 4];
 (_sfLoadoutData get "machineGuns") append [
-    ["MMG_02_black_F", "muzzle_snds_338_green", _sfAccessories, _sfMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 2
+    ["MMG_02_black_F", "muzzle_snds_338_green", _sfAccessories, _sfMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 10
 ];
 
+_eliteMarksmanOptics append ["optic_AMS", 3];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "", "acc_pointer_IR", "optic_AMS_khk",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_03_F", "", "acc_pointer_IR", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"],
-    ["srifle_DMR_06_olive_F", "", "", "optic_AMS",["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"]
+    ["srifle_DMR_03_khaki_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5, 
+    ["srifle_DMR_03_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5 
+    // SIGs now start appearing in even numbers to Mk14s.
 ];
+_eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
 (_eliteLoadoutData get "machineGuns") append [
-    ["MMG_02_black_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "", "acc_pointer_IR", "optic_MRCO", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "", "acc_pointer_IR", "optic_Hamr", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"],
-    ["MMG_02_black_F", "", "acc_pointer_IR", "optic_NVS", ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"]
+    ["MMG_02_black_F", "", _eliteAccessories, _eliteMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 10
 ];
 
+_militaryMarksmanSights append ["optic_AMS", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_camo_F", "", "", "optic_SOS", [], [], ""],
-    ["srifle_DMR_06_olive_F", "", "", "optic_Hamr", [], [], ""]
+    ["srifle_DMR_03_khaki_F", "", _militaryAttachment, _militaryMarksmanSights,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1.75
+    ["srifle_DMR_03_F", "", _militaryAttachment, _militaryMarksmanSights,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1.75 
+    // Should be a 4:1 ratio of Mk14s to SIG 556s.
 ];
+_militarySniperSights append ["optic_AMS", 6, "optic_KHS_blk", 5];
 
-(_militiaLoadoutData get "marksmanRifles") append [["srifle_DMR_06_olive_F", "", "", "optic_MRCO", [], [], ""]];
-(_militiaLoadoutData get "sniperRifles") append [["srifle_DMR_06_olive_F", "", "", "optic_SOS", [], [], ""]];
-
+(_militiaLoadoutData get "marksmanRifles") append [
+    ["srifle_DMR_06_camo_F", "", "", _militiaMarksmanSights, [], [], ""], 7.5,
+    ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 7.5
+];
+(_militiaLoadoutData get "sniperRifles") append [
+    ["srifle_DMR_06_camo_F", "", "", _militiaSniperSights, [], [], ""], 7.5,
+    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 7.5
+];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -10,7 +10,7 @@ _sfSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 4];
 (_sfLoadoutData get "machineGuns") append [
     ["MMG_02_black_F", "muzzle_snds_338_green", _sfAccessories, _sfMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 10
 ];
-
+//////////////////////////////////////////////////////
 _eliteMarksmanOptics append ["optic_AMS", 3];
 (_eliteLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_03_khaki_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5, 
@@ -23,14 +23,14 @@ _eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
 (_eliteLoadoutData get "machineGuns") append [
     ["MMG_02_black_F", "", _eliteAccessories, _eliteMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 10
 ];
-
+//////////////////////////////////////////////////////
 _militaryMarksmanSights append ["optic_AMS", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanSights, [], [], ""],3.5,
     ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanSights, [], [], ""], 3.5
 ];
 _militarySniperSights append ["optic_AMS", 6, "optic_KHS_blk", 5];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 15
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/Marksman/Vanilla_AAF.sqf
@@ -1,7 +1,7 @@
-_sfMarksmanOptics append ["optic_AMS", 2];
+_sfMarksmanOptics append ["optic_AMS", 5];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10,
-    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10,
+    ["srifle_DMR_03_khaki_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 8,
+    ["srifle_DMR_03_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 12,
     // 2:1 ratio of SIGs to MK14s now.
     ["srifle_DMR_06_olive_F", "", "", _sfMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5
     // The standard M14 shouldn't be appearing that frequently now.
@@ -13,29 +13,29 @@ _sfSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 4];
 //////////////////////////////////////////////////////
 _eliteMarksmanOptics append ["optic_AMS", 3];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_03_khaki_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5, 
-    ["srifle_DMR_03_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5 
+    ["srifle_DMR_03_khaki_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 4, 
+    ["srifle_DMR_03_F", "", _eliteAccessories, _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 6, 
     // SIGs now start appearing in even numbers to Mk14s.
     ["srifle_DMR_06_olive_F", "", "", _eliteMarksmanOptics,["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 5
     // The standard M14 shouldn't be appearing that frequently now.
 ];
 _eliteSniperOptics append ["optic_AMS", 2, "optic_KHS_blk", 3];
 (_eliteLoadoutData get "machineGuns") append [
-    ["MMG_02_black_F", "", _eliteAccessories, _eliteMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 10
+    ["MMG_02_black_F", "", _eliteAccessories, _eliteMGOptics, ["130Rnd_338_Mag", "130Rnd_338_Mag", "130Rnd_338_Mag"], [], "bipod_03_F_blk"], 8
 ];
 //////////////////////////////////////////////////////
 _militaryMarksmanSights append ["optic_AMS", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanSights, [], [], ""],3.5,
-    ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanSights, [], [], ""], 3.5
+    ["srifle_DMR_06_camo_F", "", "", _militaryMarksmanSights, [], [], ""], 2,
+    ["srifle_DMR_06_olive_F", "", "", _militaryMarksmanSights, [], [], ""], 5
 ];
-_militarySniperSights append ["optic_AMS", 6, "optic_KHS_blk", 5];
+_militarySniperSights append ["optic_AMS", 4, "optic_KHS_blk", 2];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "marksmanRifles") append [
     ["srifle_DMR_06_olive_F", "", "", _militiaMarksmanSights, [], [], ""], 15
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 15
+    ["srifle_DMR_06_olive_F", "", "", _militiaSniperSights, [], [], ""], 8
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -36,21 +36,33 @@ _militaryRifleSights append ["optic_VRCO_RF", 1];
     ["srifle_h6_oli_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10
 ];
 
+_rfSFDeagleSights = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better than making variants of each Deagle with different optics and separately balancing their weights.
 (_sfLoadoutData get "sidearms") append [
     ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5
     ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 7.5,
-    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
-    ["hgun_DEagle_classic_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5,
-    ["hgun_DEagle_copper_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5
+    ["hgun_DEagle_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, 
+    ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5,
+    ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5
+    // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
 ];
+_rfEliteDeagleSights = ["optic_VRCO_pistol_RF", 6, "optic_rds_RF", 4];
 (_eliteLoadoutData get "sidearms") append [
     ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 5,
     ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 5,
-    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5
+    ["hgun_DEagle_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 3,
+    ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1
+    // Elites carry around the Deagle uncommonly, but enough where you should be able to consistently collect them.
 ];
+
+_rfMilitaryDeagleSights = ["optic_rds_RF", 4, "", 6];
 (_militaryLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 10,
-    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5 // Make it super rare, since it's an unusual gun for a normal soldier to have.
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 9,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 1, // Full auto Glocks aren't something the usual soldier is gonna carry around often.
+    ["hgun_DEagle_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.3,
+    ["hgun_DEagle_classic_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    ["hgun_DEagle_copper_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    // Make the Deagle super rare, since it's an unusual gun for a normal soldier to have.
 ];
 (_militiaLoadoutData get "sidearms") append [
     ["hgun_Glock19_Tan_RF", "", "", "", ["17Rnd_9x19_Mag_RF","17Rnd_9x19_Mag_RF"], [], ""], 10

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -7,7 +7,7 @@ _sfRifleOptics append ["optic_VRCO_RF", 1.25];
 //////////////////////////////////////////////////////
 _eliteSMGOptics append ["optic_VRCO_RF", 5];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptic,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
 _eliteSlOptics append ["optic_VRCO_RF", 0.5];
 _eliteRifleOptics append ["optic_VRCO_RF", 3.5];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -37,7 +37,7 @@ _militaryRifleSights append ["optic_VRCO_RF", 2.5];
 //////////////////////////////////////////////////////
 _rfSFDeagleSights = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better than making variants of each Deagle with different optics and separately balancing their weights.
 (_sfLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5,
     ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 7.5,
     ["hgun_DEagle_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, 
     ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -4,26 +4,25 @@ _sfSMGoptics append ["optic_VRCO_RF", 4];
 ];
 _sfTlOptics append ["optic_VRCO_RF", 0.5];
 _sfRifleOptics append ["optic_VRCO_RF", 1.25];
-
+//////////////////////////////////////////////////////
 _eliteSMGOptics append ["optic_VRCO_RF", 5];
 (_eliteLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptic,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5,
 ];
 _eliteSlOptics append ["optic_VRCO_RF", 0.5];
 _eliteRifleOptics append ["optic_VRCO_RF", 3.5];
-
-
+//////////////////////////////////////////////////////
 _militarySMGSights append ["optic_VRCO_RF", 3];
 (_militaryLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _militarySMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
 _militarySlRifleSights append ["optic_VRCO_RF", 1];
 _militaryRifleSights append ["optic_VRCO_RF", 1];
-
+//////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _policeSMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1.5 
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _militiaSMGsights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
 ];
@@ -35,7 +34,7 @@ _militaryRifleSights append ["optic_VRCO_RF", 1];
     ["srifle_h6_digi_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10,
     ["srifle_h6_oli_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10
 ];
-
+//////////////////////////////////////////////////////
 _rfSFDeagleSights = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better than making variants of each Deagle with different optics and separately balancing their weights.
 (_sfLoadoutData get "sidearms") append [
     ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -1,59 +1,64 @@
+_sfSMGoptics append ["optic_VRCO_RF", 4];
 (_sfLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","muzzle_snds_acp", _sfAccessories,["optic_VRCO_RF", "optic_Holosight_smg"],["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 4
+    ["SMG_01_black_RF","muzzle_snds_acp", "acc_flashlight_smg_01", _sfSMGoptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
 ];
 _sfTlOptics append ["optic_VRCO_RF", 0.5];
 _sfRifleOptics append ["optic_VRCO_RF", 1.25];
 
+_eliteSMGOptics append ["optic_VRCO_RF", 5];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_pointer_IR","optic_VRCO_RF",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptic,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5,
 ];
+_eliteSlOptics append ["optic_VRCO_RF", 0.5];
+_eliteRifleOptics append ["optic_VRCO_RF", 3.5];
 
+
+_militarySMGSights append ["optic_VRCO_RF", 3];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01","optic_VRCO_RF",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militarySMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
+_militarySlRifleSights append ["optic_VRCO_RF", 1];
+_militaryRifleSights append ["optic_VRCO_RF", 1];
 
 (_policeLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight","optic_Aco_smg",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _policeSMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1.5 
 ];
 
 (_militiaLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01","",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militiaSMGsights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_h6_digi_rf", "", "", "optic_MRCO",["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""]
+    ["srifle_h6_digi_rf", "", "", _militiaMarksmanSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5,
+    ["srifle_h6_oli_rf", "", "", _militiaMarksmanSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["srifle_h6_digi_rf", "", "", "optic_MRCO",["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""]
+    ["srifle_h6_digi_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10,
+    ["srifle_h6_oli_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10
 ];
 
 (_sfLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_classic_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_copper_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""]
+    ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5
+    ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 7.5,
+    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
+    ["hgun_DEagle_classic_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5,
+    ["hgun_DEagle_copper_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5
 ];
 (_eliteLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_classic_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_copper_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""]
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 5,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 5,
+    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5
 ];
 (_militaryLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""],
-    ["hgun_DEagle_RF", "", "", "optic_rds_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_classic_RF", "", "", "optic_rds_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_copper_RF", "", "", "optic_rds_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_RF", "", "", "", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_classic_RF", "", "", "", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""],
-    ["hgun_DEagle_copper_RF", "", "", "", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""]
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 10,
+    ["hgun_DEagle_RF", "", "", "optic_VRCO_pistol_RF", ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5 // Make it super rare, since it's an unusual gun for a normal soldier to have.
 ];
 (_militiaLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "", "", ["17Rnd_9x19_Mag_RF","17Rnd_9x19_Mag_RF"], [], ""]
+    ["hgun_Glock19_Tan_RF", "", "", "", ["17Rnd_9x19_Mag_RF","17Rnd_9x19_Mag_RF"], [], ""], 10
 ];
-(_policeLoadoutData get "sidearms") append ["hgun_Glock19_RF"];
+
+(_policeLoadoutData get "sidearms") append [
+    ["hgun_Glock19_RF", "", "", "", ["17Rnd_9x19_Mag_RF","17Rnd_9x19_Mag_RF"], [], ""], 10
+];
 
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -1,6 +1,8 @@
 (_sfLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","muzzle_snds_acp","acc_pointer_IR","optic_VRCO_RF",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]
+    ["SMG_01_black_RF","muzzle_snds_acp", _sfAccessories,["optic_VRCO_RF", "optic_Holosight_smg"],["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 4
 ];
+_sfTlOptics append ["optic_VRCO_RF", 0.5];
+_sfRifleOptics append ["optic_VRCO_RF", 1.25];
 
 (_eliteLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_pointer_IR","optic_VRCO_RF",["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""]

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -7,7 +7,7 @@ _sfRifleOptics append ["optic_VRCO_RF", 1.25];
 //////////////////////////////////////////////////////
 _eliteSMGOptics append ["optic_VRCO_RF", 5];
 (_eliteLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptic,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5,
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _eliteSMGOptic,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
 _eliteSlOptics append ["optic_VRCO_RF", 0.5];
 _eliteRifleOptics append ["optic_VRCO_RF", 3.5];
@@ -17,7 +17,7 @@ _militarySMGSights append ["optic_VRCO_RF", 3];
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _militarySMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
 _militarySlRifleSights append ["optic_VRCO_RF", 1];
-_militaryRifleSights append ["optic_VRCO_RF", 1];
+_militaryRifleSights append ["optic_VRCO_RF", 2.5];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","","acc_flashlight_smg_01", _policeSMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1.5 
@@ -40,27 +40,33 @@ _rfSFDeagleSights = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better th
     ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5
     ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 7.5,
     ["hgun_DEagle_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, 
-    ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5,
-    ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2.5
+    ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2,
+    ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5,
+    ["hgun_DEagle_bronze_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_gold_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25
     // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
 ];
 _rfEliteDeagleSights = ["optic_VRCO_pistol_RF", 6, "optic_rds_RF", 4];
+_rfEliteGlockSights = ["optic_MRD_tan_RF", 3, "", 1];
 (_eliteLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 5,
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 5,
-    ["hgun_DEagle_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 3,
-    ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
-    ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 7,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 3,
+    ["hgun_DEagle_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_bronze_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    ["hgun_DEagle_gold_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.025,
+    ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25,
+    ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
     // Elites carry around the Deagle uncommonly, but enough where you should be able to consistently collect them.
 ];
 
-_rfMilitaryDeagleSights = ["optic_rds_RF", 4, "", 6];
+_rfMilitaryDeagleSights = ["optic_rds_RF", 1, "", 2];
+_rfMilitaryGlockSights = ["optic_MRD_tan_RF", 1, "", 3];
 (_militaryLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 9,
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 1, // Full auto Glocks aren't something the usual soldier is gonna carry around often.
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 9,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 1, // Full auto Glocks aren't something the usual soldier is gonna carry around often.
     ["hgun_DEagle_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.3,
     ["hgun_DEagle_classic_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
-    ["hgun_DEagle_copper_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    ["hgun_DEagle_copper_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
     // Make the Deagle super rare, since it's an unusual gun for a normal soldier to have.
 ];
 (_militiaLoadoutData get "sidearms") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -1,6 +1,6 @@
-_sfSMGoptics append ["optic_VRCO_RF", 4];
+_sfSMGOptics append ["optic_VRCO_RF", 4];
 (_sfLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","muzzle_snds_acp", "acc_flashlight_smg_01", _sfSMGoptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
+    ["SMG_01_black_RF","muzzle_snds_acp", "acc_flashlight_smg_01", _sfSMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
 ];
 _sfTlOptics append ["optic_VRCO_RF", 0.5];
 _sfRifleOptics append ["optic_VRCO_RF", 1.25];
@@ -12,61 +12,61 @@ _eliteSMGOptics append ["optic_VRCO_RF", 5];
 _eliteSlOptics append ["optic_VRCO_RF", 0.5];
 _eliteRifleOptics append ["optic_VRCO_RF", 3.5];
 //////////////////////////////////////////////////////
-_militarySMGSights append ["optic_VRCO_RF", 3];
+_militarySMGOptics append ["optic_VRCO_RF", 3];
 (_militaryLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militarySMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militarySMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 2.5
 ];
-_militarySlRifleSights append ["optic_VRCO_RF", 1];
-_militaryRifleSights append ["optic_VRCO_RF", 2.5];
+_militarySlRifleOptics append ["optic_VRCO_RF", 1];
+_militaryRifleOptics append ["optic_VRCO_RF", 2.5];
 //////////////////////////////////////////////////////
 (_policeLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01", _policeSMGSights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1.5 
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _policeSMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1.5 
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "SMGs") append [
-    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militiaSMGsights,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
+    ["SMG_01_black_RF","","acc_flashlight_smg_01", _militiaSMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["srifle_h6_digi_rf", "", "", _militiaMarksmanSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5,
-    ["srifle_h6_oli_rf", "", "", _militiaMarksmanSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5
+    ["srifle_h6_digi_rf", "", "", _militiaMarksmanOptics,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5,
+    ["srifle_h6_oli_rf", "", "", _militiaMarksmanOptics,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 7.5
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["srifle_h6_digi_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10,
-    ["srifle_h6_oli_rf", "", "", _militiaSniperSights,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10
+    ["srifle_h6_digi_rf", "", "", _militiaSniperOptics,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10,
+    ["srifle_h6_oli_rf", "", "", _militiaSniperOptics,["10Rnd_556x45_AP_Stanag_RF","10Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF","20Rnd_556x45_AP_Stanag_RF"], [], ""], 10
 ];
 //////////////////////////////////////////////////////
-_rfSFDeagleSights = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better than making variants of each Deagle with different optics and separately balancing their weights.
+_rfSFDeagleOptics = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better than making variants of each Deagle with different Optics and separately balancing their weights.
 (_sfLoadoutData get "sidearms") append [
     ["hgun_Glock19_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 2.5,
     ["hgun_Glock19_auto_Tan_RF", "muzzle_snds_L", "acc_flashlight_IR_pistol_RF", "optic_MRD_tan_RF", ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 7.5,
-    ["hgun_DEagle_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, 
-    ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2,
-    ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5,
-    ["hgun_DEagle_bronze_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
-    ["hgun_DEagle_gold_RF", "", "", _rfSFDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25
+    ["hgun_DEagle_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 5, 
+    ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2,
+    ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5,
+    ["hgun_DEagle_bronze_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_gold_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25
     // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
 ];
-_rfEliteDeagleSights = ["optic_VRCO_pistol_RF", 6, "optic_rds_RF", 4];
-_rfEliteGlockSights = ["optic_MRD_tan_RF", 3, "", 1];
+_rfEliteDeagleOptics = ["optic_VRCO_pistol_RF", 6, "optic_rds_RF", 4];
+_rfEliteGlockOptics = ["optic_MRD_tan_RF", 3, "", 1];
 (_eliteLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 7,
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 3,
-    ["hgun_DEagle_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
-    ["hgun_DEagle_bronze_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
-    ["hgun_DEagle_gold_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.025,
-    ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25,
-    ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockOptics, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 7,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_IR_pistol_RF", _rfEliteGlockOptics, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF","65Rnd_9x19_Mag_RF"], [], ""], 3,
+    ["hgun_DEagle_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_bronze_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    ["hgun_DEagle_gold_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.025,
+    ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25,
+    ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
     // Elites carry around the Deagle uncommonly, but enough where you should be able to consistently collect them.
 ];
 
-_rfMilitaryDeagleSights = ["optic_rds_RF", 1, "", 2];
-_rfMilitaryGlockSights = ["optic_MRD_tan_RF", 1, "", 3];
+_rfMilitaryDeagleOptics = ["optic_rds_RF", 1, "", 2];
+_rfMilitaryGlockOptics = ["optic_MRD_tan_RF", 1, "", 3];
 (_militaryLoadoutData get "sidearms") append [
-    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 9,
-    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockSights, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 1, // Full auto Glocks aren't something the usual soldier is gonna carry around often.
-    ["hgun_DEagle_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.3,
-    ["hgun_DEagle_classic_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
-    ["hgun_DEagle_copper_RF", "", "", _rfMilitaryDeagleSights, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
+    ["hgun_Glock19_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockOptics, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 9,
+    ["hgun_Glock19_auto_Tan_RF", "", "acc_flashlight_pistol", _rfMilitaryGlockOptics, ["17Rnd_9x19_Mag_RF","33Rnd_9x19_Mag_RF"], [], ""], 1, // Full auto Glocks aren't something the usual soldier is gonna carry around often.
+    ["hgun_DEagle_RF", "", "", _rfMilitaryDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.3,
+    ["hgun_DEagle_classic_RF", "", "", _rfMilitaryDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
+    ["hgun_DEagle_copper_RF", "", "", _rfMilitaryDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
     // Make the Deagle super rare, since it's an unusual gun for a normal soldier to have.
 ];
 (_militiaLoadoutData get "sidearms") append [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/RF/Vanilla_AAF.sqf
@@ -1,3 +1,22 @@
+_psrlAttachments = ["", 2, "acc_pointer_IR", 1];
+
+(_loadoutData get "lightATLaunchers") append [
+    ["launch_PSRL1_digi_RF", "", _psrlAttachments, "", ["PSRL1_AT_RF","PSRL1_AT_RF","PSRL1_FRAG_RF"], [], ""], 4,
+    ["launch_PSRL1_digi_RF", "", _psrlAttachments, "", ["PSRL1_AT_RF","PSRL1_AT_RF","PSRL1_HE_RF"], [], ""], 2,
+
+    ["launch_PSRL1_PWS_digi_RF", "", _psrlAttachments, "", ["PSRL1_AT_RF","PSRL1_AT_RF","PSRL1_FRAG_RF"], [], ""], 2,
+    ["launch_PSRL1_PWS_digi_RF", "", _psrlAttachments, "", ["PSRL1_AT_RF","PSRL1_AT_RF","PSRL1_HE_RF"], [], ""], 1
+];
+
+//dedicated AT troops get the heavier AT rockets as well as more common PWS-equipped launchers
+(_loadoutData get "ATLaunchers") append [
+    ["launch_PSRL1_digi_RF", "",_psrlAttachments, "", ["PSRL1_HEAT_RF","PSRL1_HEAT_RF","PSRL1_AT_RF"], [], ""], 2,
+    ["launch_PSRL1_digi_RF", "",_psrlAttachments, "", ["PSRL1_HEAT_RF","PSRL1_AT_RF","PSRL1_HE_RF"], [], ""], 1,
+
+    ["launch_PSRL1_PWS_digi_RF", "", _psrlAttachments, "", ["PSRL1_HEAT_RF","PSRL1_HEAT_RF","PSRL1_AT_RF"], [], ""], 4,
+    ["launch_PSRL1_PWS_digi_RF", "", _psrlAttachments, "", ["PSRL1_HEAT_RF","PSRL1_AT_RF","PSRL1_HE_RF"], [], ""], 2
+];
+
 _sfSMGOptics append ["optic_VRCO_RF", 4];
 (_sfLoadoutData get "SMGs") append [
     ["SMG_01_black_RF","muzzle_snds_acp", "acc_flashlight_smg_01", _sfSMGOptics,["30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01","30Rnd_45ACP_Mag_SMG_01_Tracer_Green"], [], ""], 1
@@ -43,6 +62,7 @@ _rfSFDeagleOptics = ["optic_VRCO_pistol_RF", 8, "optic_rds_RF", 2]; // Better th
     ["hgun_DEagle_classic_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 2,
     ["hgun_DEagle_copper_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5,
     ["hgun_DEagle_bronze_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 1,
+    ["hgun_DEagle_camo_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.5,
     ["hgun_DEagle_gold_RF", "", "", _rfSFDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25
     // SpecOps use the Deagle enough where it appears as frequently as other sidearms.
 ];
@@ -55,7 +75,9 @@ _rfEliteGlockOptics = ["optic_MRD_tan_RF", 3, "", 1];
     ["hgun_DEagle_bronze_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
     ["hgun_DEagle_gold_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.025,
     ["hgun_DEagle_classic_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.25,
+    ["hgun_DEagle_camo_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1,
     ["hgun_DEagle_copper_RF", "", "", _rfEliteDeagleOptics, ["7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF","7Rnd_50AE_Mag_RF"], [], ""], 0.1
+    
     // Elites carry around the Deagle uncommonly, but enough where you should be able to consistently collect them.
 ];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
@@ -1,139 +1,143 @@
 (_policeLoadoutData get "SMGs") append [
-    ["vn_vz61","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 3,
-    ["vn_type64_f_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 1.5,
-    ["vn_type64_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 1.5,
-    ["vn_mpu","vn_s_mpu","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""], 1,
-    ["vn_mpu","","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""], 2,
-    ["vn_m1897","","","",["vn_m1897_buck_mag","vn_m1897_buck_mag","vn_m1897_fl_mag","vn_m1897_fl_mag"], [], ""], 3,
-    ["vn_izh54_shorty","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""], 1,
-    ["vn_izh54","","","",["vn_izh54_mag","vn_izh54_mag","vn_izh54_mag","vn_izh54_mag"], [], ""], 2
+    ["vn_vz61","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 1,
+    ["vn_type64_f_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 0.05,
+    ["vn_type64_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 0.1,
+    ["vn_mpu",["vn_s_mpu", 1, "", 8],"","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""], 3,
+    ["vn_m1897","","","",["vn_m1897_buck_mag","vn_m1897_buck_mag","vn_m1897_fl_mag","vn_m1897_fl_mag"], [], ""], 4,
+    ["vn_izh54_shorty","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""], 0.2,
+    ["vn_izh54","","","",["vn_izh54_mag","vn_izh54_mag","vn_izh54_mag","vn_izh54_mag"], [], ""], 0.5
 ];
 (_policeLoadoutData get "sidearms") append [
-    ["vn_vz61_p","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 0.5,
-    ["vn_type64","","","",["vn_type64_mag","vn_type64_mag","vn_type64_mag","vn_type64_mag"], [], ""], 1,
-    ["vn_tt33","","","",["vn_tt33_mag","vn_tt33_mag","vn_tt33_mag","vn_tt33_mag"], [], ""], 2,
-    ["vn_ppk","vn_s_ppk","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
-    ["vn_ppk","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
-    ["vn_fkb1_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 0.5,
-    ["vn_pm","vn_s_pm","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
-    ["vn_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
-    ["vn_p38","vn_s_ppk","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""], 1,
-    ["vn_p38","","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""], 1,
-    ["vn_m10","vn_s_mk22","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 0.25,
-    ["vn_m10","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 0.25,
-    ["vn_mk22","vn_s_mk22","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""], 0.5,
-    ["vn_mk22","","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""], 0.5,
-    ["vn_m712","","","",["vn_m712_mag","vn_m712_mag","vn_m712_mag","vn_m712_mag"], [], ""], 0.5,
-    ["vn_mx991_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 0.25,
-    ["vn_mx991_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 0.25,
-    ["vn_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 1,
-    ["vn_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 1,
-    ["vn_m1895","vn_s_m1895","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""], 0.25,
-    ["vn_m1895","","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""], 0.25,
+    ["vn_vz61_p","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 0.2,
+    ["vn_type64","","","",["vn_type64_mag","vn_type64_mag","vn_type64_mag","vn_type64_mag"], [], ""], 0.05,
+    ["vn_tt33","","","",["vn_tt33_mag","vn_tt33_mag","vn_tt33_mag","vn_tt33_mag"], [], ""], 0.5,
+    ["vn_ppk",["vn_s_ppk", 1, "", 9],"","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 2,
+    ["vn_fkb1_pm",["vn_s_pm", 1, "", 9],"","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 0.1,
+    ["vn_pm",["vn_s_pm", 1, "", 9],"","",["vn_pm_mag","vn_pm_mag","vn_pm_mag","vn_pm_mag"], [], ""], 0.5,
+    ["vn_p38",["vn_s_ppk", 1, "", 9],"","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""], 1,
+    ["vn_m10",["vn_s_mk22", 1, "", 9],"","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 1,
+    ["vn_mk22",["vn_s_mk22", 1, "", 8],"","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""], 0.25,
+    ["vn_m712","","","",["vn_m712_mag","vn_m712_mag","vn_m712_mag","vn_m712_mag"], [], ""], 0.2,
+    ["vn_mx991_m1911",["vn_s_m1911", 1, "", 9],"","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 0.5,
+    ["vn_m1911",["vn_s_m1911", 1, "", 9],"","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 4,
+    ["vn_m1895",["vn_s_m1895", 1, "", 4],"","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""], 0.1,
     ["vn_izh54_p","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""], 0.5,
-    ["vn_hp","vn_s_hp","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""], 1,
-    ["vn_hp","","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""], 1,
-    ["vn_hd","","","",["vn_hd_mag","vn_hd_mag","vn_hd_mag","vn_hd_mag"], [], ""], 1,
-    ["vn_p38s","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""] 0.5,
+    ["vn_hp",["vn_s_hp", 1, "", 9],"","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""], 5,
+    ["vn_hd","","","",["vn_hd_mag","vn_hd_mag","vn_hd_mag","vn_hd_mag"], [], ""], 0.2,
+    ["vn_p38s","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 1
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "slRifles") append [
-    ["vn_xm177_xm148_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
-    ["vn_xm177_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
-    ["vn_xm177_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
+    ["vn_xm177_xm148_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
+    ["vn_xm177_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
+    ["vn_xm177_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.75,
     ["vn_xm177_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 3,
-    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
-    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 4,
-    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2.5,
-    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
-    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2
+
+    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
+    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 6,
+    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
+
+    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.75,
+    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5
 ];
+_sogM16Optics = ["vn_o_9x_m16", 0.25, "vn_o_4x_m16", 0.75, "", 9]; //10% of the time
+_sogM16bayos = ["vn_b_m16", 1, "", 3];
+_sogL1A1Optics = ["vn_o_3x_l1a1", 1, "", 5]; //15% of the time, bc L1A1s are rarer than M16s
+_sogL1A1bayos = ["vn_b_l1a1", 1, "", 2];
+
 (_militiaLoadoutData get "rifles") append [
-    ["vn_xm16e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2,
-    ["vn_m63a","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
-    ["vn_m16_camo","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
-    ["vn_m16_camo","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 1.5,
-    ["vn_m16","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
-    ["vn_m16","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 1.5,
-    ["vn_m16_usaf","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 2,
-    ["vn_m16_usaf","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 0.5,
-    ["vn_m14a1_shorty","","","vn_o_m14_front",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],""],
-    ["vn_l2a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
-    ["vn_l1a1_03_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
-    ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
-    ["vn_l1a1_02_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
-    ["vn_l1a1_02","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.34,
-    // ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], // Duplicate entry without any unique attachments.
-    ["vn_l1a1_01_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
-    ["vn_l1a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.34
+    ["vn_m63a","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 2,
+
+    ["vn_xm16e1","",_sogM16bayos,_sogM16Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1,
+    ["vn_m16_camo","",_sogM16bayos,_sogM16Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2,
+    ["vn_m16","",_sogM16bayos,_sogM16Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 6,
+    ["vn_m16_usaf","",_sogM16bayos,_sogM16Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1, 
+
+    ["vn_m14a1_shorty","","","vn_o_m14_front",["vn_m14_mag","vn_m14_mag","vn_m14_t_mag"],[],""], 0.5,
+
+    ["vn_l2a1_01","","",_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.1,
+    ["vn_l1a1_03_camo","","",_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.25,
+    ["vn_l1a1_03","","",_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.5,
+    ["vn_l1a1_02_camo",_sogL1A1bayos,_sogL1A1bayos,_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.1,
+    ["vn_l1a1_02","",_sogL1A1bayos,_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.5,
+    ["vn_l1a1_01_camo","",_sogL1A1bayos,_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 0.5,
+    ["vn_l1a1_01","",_sogL1A1bayos,_sogL1A1Optics,["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 2 
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["vn_xm16e1_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
-    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
-    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
-    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
-    ["vn_m79","","","",["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],["vn_40mm_m576_buck_mag"],""], 2,
-    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
+    ["vn_xm16e1_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.25,
+    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
+    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 4,
+    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
+
+    ["vn_m79","","","",["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],["vn_40mm_m576_buck_mag"],""], 3,
+
+    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.25,
     ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
-    ["vn_l1a1_02_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 0.5,
-    ["vn_l1a1_01_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 0.5
+    ["vn_l1a1_02_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 0.25,
+    ["vn_l1a1_01_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 1,
+
+     ["vn_l34a1_xm148","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],["vn_40mm_m433_hedp_mag","vn_40mm_m406_he_mag"],""], 0.25 //moved to GLs because crewmen should not be given a grenade launcher
 ];
+_sogCAR15Optics = ["vn_o_4x_m16", 1, "", 8];
 (_militiaLoadoutData get "carbines") append [
-    ["vn_xm177_stock_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
-    ["vn_xm177_short","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
-    ["vn_xm177_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
-    ["vn_xm177","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
-    ["vn_xm177e1_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2.5,
-    ["vn_xm177e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2.5,
-    ["vn_gau5a","","","vn_o_4x_m16",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""], 2.5,
-    ["vn_gau5a","","","",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""], 2.5
+    ["vn_xm177_stock_camo","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 0.5,
+    ["vn_xm177_stock","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.5,
+    ["vn_xm177_short","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1,
+    ["vn_xm177_camo","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1,
+    ["vn_xm177","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 4,
+    ["vn_xm177e1_camo","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 0.25,
+    ["vn_xm177e1","","",_sogCAR15Optics,["vn_m16_30_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 0.5,
+    ["vn_gau5a","","",_sogCAR15Optics,["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_30_t_mag"],[],""], 1.5
 ];
+_sogSVDCamo = ["vn_b_camo_svd", 1, "", 3];
+
+_sogM14Suppressor = ["vn_s_m14", 1, "", 5];
+_sogM14Bayo = ["vn_b_m14", 1, "", 4];
+_sogM14Camo = ["vn_b_camo_m14", 1, "", 3];
+_sogM14A1Bipod = ["vn_b_camo_m14a1", 1, "vn_bipod_m14", 2, "", 3];
+
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["vn_svd","","","vn_o_4x_svd",["vn_svd_mag","vn_svd_mag","vn_svd_t_mag"],[],"vn_b_camo_svd"], 10,
-    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"], 1.665,
-    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"], 1.665,
-    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"], 1.665,
-    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"], 1.665,
-    ["vn_m14_camo","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.23,
-    ["vn_m14_camo","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
-    ["vn_m14_camo","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
-    ["vn_m14","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.23,
-    ["vn_m14","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
-    ["vn_m14","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22, // M14 weights add up to 20. These will outnumber the Mk14 EBR by double.
-    ["vn_m1carbine_shorty","","","",["vn_carbine_30_mag","vn_carbine_30_mag","vn_carbine_30_t_mag","vn_carbine_15_t_mag"],[],"vn_b_camo_m14"], 10
+    ["vn_svd","","","vn_o_4x_svd",["vn_svd_mag","vn_svd_mag","vn_svd_t_mag"],[],_sogSVDCamo], 2,
+
+    ["vn_m14a1",_sogM14Suppressor,"","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],_sogM14A1Bipod ], 2,
+    ["vn_m14_camo",_sogM14Suppressor, _sogM14Bayo,"vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[], _sogM14Camo], 4,
+    ["vn_m14",_sogM14Suppressor, _sogM14Bayo,"vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[], _sogM14Camo], 8, 
+
+    ["vn_m1carbine_shorty","","","",["vn_hp_sd_mag"],[],""], 0.25 //extremely rare + not very useful gun
 ];
+
 (_militiaLoadoutData get "machineGuns") append [
-    ["vn_mg42","","","",["vn_mg42_50_mag","vn_mg42_50_mag","vn_mg42_50_t_mag","vn_mg42_50_t_mag"],[],""], 5,
-    ["vn_m63a_lmg","","","",["vn_m63a_100_mag","vn_m63a_100_t_mag","vn_m63a_100_mag","vn_m63a_100_t_mag"],[],"vn_bipod_m63a"], 6,
-    ["vn_m63a_cdo","","","",["vn_m63a_150_mag","vn_m63a_150_t_mag","vn_m63a_150_mag","vn_m63a_150_t_mag"],[],"vn_bipod_m63a"], 6,
-    ["vn_m60_shorty_camo","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4,
-    ["vn_m60_shorty","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4,
-    ["vn_m60","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4
+    ["vn_mg42","","","",["vn_mg42_50_mag","vn_mg42_50_mag","vn_mg42_50_t_mag","vn_mg42_50_t_mag"],[],""], 4,
+    ["vn_m63a_lmg","","","",["vn_m63a_100_mag","vn_m63a_100_t_mag","vn_m63a_100_mag","vn_m63a_100_t_mag"],[],"vn_bipod_m63a"], 3,
+    ["vn_m63a_cdo","","","",["vn_m63a_150_mag","vn_m63a_150_t_mag","vn_m63a_150_mag","vn_m63a_150_t_mag"],[],"vn_bipod_m63a"], 1,
+    ["vn_m60_shorty_camo","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],""], 1.5,
+    ["vn_m60_shorty","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],""], 3,
+    ["vn_m60","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],""], 6
 ];
+
 (_militiaLoadoutData get "SMGs") append [
-    ["vn_l34a1_xm148","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],["vn_40mm_m433_hedp_mag","vn_40mm_m406_he_mag"],""], 1,
-    ["vn_l34a1_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.25,
-    ["vn_l34a1","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.25,
-    ["vn_l2a3_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.75,
-    ["vn_l2a3","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.75
+    ["vn_l34a1_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 0.5,
+    ["vn_l34a1","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 1,
+    ["vn_l2a3_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2,
+    ["vn_l2a3","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 4
 ];
+_sogM40Camo = ["vn_b_camo_m40a1", 1, "", 1];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["vn_m40a1_camo","vn_s_m14","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],"vn_b_camo_m40a1"], 2,
-    ["vn_m40a1_camo","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5,
-    ["vn_m40a1","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5
+    ["vn_m40a1_camo",_sogM14Suppressor,"","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],_sogM40Camo], 2,
+    ["vn_m40a1",_sogM14Suppressor,"","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],_sogM40Camo], 6
 ];
 //////////////////////////////////////////////////////
 (_loadoutData get "lightATLaunchers") append [
-    ["vn_m72", "", "", "", ["vn_m72_mag"], [], ""], 8,
-    ["vn_rpg7", "", "", "", ["vn_rpg7_mag","vn_rpg7_mag","vn_rpg7_mag"], [], ""], 5,
-    ["vn_rpg2", "", "", "", ["vn_rpg2_fuze_mag","vn_rpg2_fuze_mag","vn_rpg2_mag"], [], ""], 6
+    ["vn_m72", "", "", "", ["vn_m72_mag"], [], ""], 12,
+    ["vn_rpg7", "", "", "", ["vn_rpg7_mag","vn_rpg7_mag","vn_rpg7_mag"], [], ""], 6,
+    ["vn_rpg2", "", "", "", ["vn_rpg2_fuze_mag","vn_rpg2_fuze_mag","vn_rpg2_mag"], [], ""], 3
 ];
 (_loadoutData get "ATLaunchers") append [
-    ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_wp_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag"], [], ""], 5
+    ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_wp_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag"], [], ""], 2  
 ];
 (_loadoutData get "AALaunchers") append [
-    ["vn_sa7b", "", "", "", ["vn_sa7b_mag"], [], ""], 3.5,
-    ["vn_sa7", "", "", "", ["vn_sa7_mag"], [], ""], 3.5
+    ["vn_sa7b", "", "", "", ["vn_sa7b_mag"], [], ""], 3,
+    ["vn_sa7", "", "", "", ["vn_sa7_mag"], [], ""], 2
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
@@ -36,7 +36,7 @@
     ["vn_hd","","","",["vn_hd_mag","vn_hd_mag","vn_hd_mag","vn_hd_mag"], [], ""], 1,
     ["vn_p38s","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""] 0.5,
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "slRifles") append [
     ["vn_xm177_xm148_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
     ["vn_xm177_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
@@ -122,7 +122,7 @@
     ["vn_m40a1_camo","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5,
     ["vn_m40a1","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5
 ];
-
+//////////////////////////////////////////////////////
 (_loadoutData get "lightATLaunchers") append [
     ["vn_m72", "", "", "", ["vn_m72_mag"], [], ""], 8,
     ["vn_rpg7", "", "", "", ["vn_rpg7_mag","vn_rpg7_mag","vn_rpg7_mag"], [], ""], 5,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SOG/Vanilla_AAF.sqf
@@ -1,139 +1,139 @@
 (_policeLoadoutData get "SMGs") append [
-    ["vn_vz61","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""],
-    ["vn_type64_f_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""],
-    ["vn_type64_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""],
-    ["vn_mpu","vn_s_mpu","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""],
-    ["vn_mpu","","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""],
-    ["vn_m1897","","","",["vn_m1897_buck_mag","vn_m1897_buck_mag","vn_m1897_fl_mag","vn_m1897_fl_mag"], [], ""],
-    ["vn_izh54_shorty","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""],
-    ["vn_izh54","","","",["vn_izh54_mag","vn_izh54_mag","vn_izh54_mag","vn_izh54_mag"], [], ""]
+    ["vn_vz61","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 3,
+    ["vn_type64_f_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 1.5,
+    ["vn_type64_smg","","","",["vn_type64_smg_mag","vn_type64_smg_mag","vn_type64_smg_t_mag","vn_type64_smg_t_mag"], [], ""], 1.5,
+    ["vn_mpu","vn_s_mpu","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""], 1,
+    ["vn_mpu","","","",["vn_mpu_mag","vn_mpu_mag","vn_mpu_t_mag","vn_mpu_t_mag"], [], ""], 2,
+    ["vn_m1897","","","",["vn_m1897_buck_mag","vn_m1897_buck_mag","vn_m1897_fl_mag","vn_m1897_fl_mag"], [], ""], 3,
+    ["vn_izh54_shorty","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""], 1,
+    ["vn_izh54","","","",["vn_izh54_mag","vn_izh54_mag","vn_izh54_mag","vn_izh54_mag"], [], ""], 2
 ];
 (_policeLoadoutData get "sidearms") append [
-    ["vn_vz61_p","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""],
-    ["vn_type64","","","",["vn_type64_mag","vn_type64_mag","vn_type64_mag","vn_type64_mag"], [], ""],
-    ["vn_tt33","","","",["vn_tt33_mag","vn_tt33_mag","vn_tt33_mag","vn_tt33_mag"], [], ""],
-    ["vn_ppk","vn_s_ppk","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""],
-    ["vn_ppk","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""],
-    ["vn_fkb1_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""],
-    ["vn_pm","vn_s_pm","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""],
-    ["vn_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""],
-    ["vn_p38","vn_s_ppk","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""],
-    ["vn_p38","","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""],
-    ["vn_m10","vn_s_mk22","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""],
-    ["vn_m10","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""],
-    ["vn_mk22","vn_s_mk22","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""],
-    ["vn_mk22","","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""],
-    ["vn_m712","","","",["vn_m712_mag","vn_m712_mag","vn_m712_mag","vn_m712_mag"], [], ""],
-    ["vn_mx991_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""],
-    ["vn_mx991_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""],
-    ["vn_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""],
-    ["vn_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""],
-    ["vn_m1895","vn_s_m1895","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""],
-    ["vn_m1895","","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""],
-    ["vn_izh54_p","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""],
-    ["vn_hp","vn_s_hp","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""],
-    ["vn_hp","","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""],
-    ["vn_hd","","","",["vn_hd_mag","vn_hd_mag","vn_hd_mag","vn_hd_mag"], [], ""],
-    ["vn_p38s","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""]
+    ["vn_vz61_p","","","",["vn_vz61_mag","vn_vz61_mag","vn_vz61_t_mag","vn_vz61_t_mag"], [], ""], 0.5,
+    ["vn_type64","","","",["vn_type64_mag","vn_type64_mag","vn_type64_mag","vn_type64_mag"], [], ""], 1,
+    ["vn_tt33","","","",["vn_tt33_mag","vn_tt33_mag","vn_tt33_mag","vn_tt33_mag"], [], ""], 2,
+    ["vn_ppk","vn_s_ppk","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
+    ["vn_ppk","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
+    ["vn_fkb1_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 0.5,
+    ["vn_pm","vn_s_pm","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
+    ["vn_pm","","","",["vn_ppk_mag","vn_ppk_mag","vn_ppk_mag","vn_ppk_mag"], [], ""], 1,
+    ["vn_p38","vn_s_ppk","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""], 1,
+    ["vn_p38","","","",["vn_p38_mag","vn_p38_mag","vn_p38_mag","vn_p38_mag"], [], ""], 1,
+    ["vn_m10","vn_s_mk22","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 0.25,
+    ["vn_m10","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""], 0.25,
+    ["vn_mk22","vn_s_mk22","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""], 0.5,
+    ["vn_mk22","","","",["vn_mk22_mag","vn_mk22_mag","vn_mk22_mag","vn_mk22_mag"], [], ""], 0.5,
+    ["vn_m712","","","",["vn_m712_mag","vn_m712_mag","vn_m712_mag","vn_m712_mag"], [], ""], 0.5,
+    ["vn_mx991_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 0.25,
+    ["vn_mx991_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 0.25,
+    ["vn_m1911","vn_s_m1911","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 1,
+    ["vn_m1911","","","",["vn_m1911_mag","vn_m1911_mag","vn_m1911_mag","vn_m1911_mag"], [], ""], 1,
+    ["vn_m1895","vn_s_m1895","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""], 0.25,
+    ["vn_m1895","","","",["vn_m1895_mag","vn_m1895_mag","vn_m1895_mag","vn_m1895_mag"], [], ""], 0.25,
+    ["vn_izh54_p","","","",["vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag","vn_izh54_so_mag"], [], ""], 0.5,
+    ["vn_hp","vn_s_hp","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""], 1,
+    ["vn_hp","","","",["vn_hp_mag","vn_hp_mag","vn_hp_mag","vn_hp_mag"], [], ""], 1,
+    ["vn_hd","","","",["vn_hd_mag","vn_hd_mag","vn_hd_mag","vn_hd_mag"], [], ""], 1,
+    ["vn_p38s","","","",["vn_m10_mag","vn_m10_mag","vn_m10_mag","vn_m10_mag"], [], ""] 0.5,
 ];
 
 (_militiaLoadoutData get "slRifles") append [
-    ["vn_xm177_xm148_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_xm177_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_xm177_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_xm177_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""]
+    ["vn_xm177_xm148_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
+    ["vn_xm177_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
+    ["vn_xm177_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1.5,
+    ["vn_xm177_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 3,
+    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
+    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 4,
+    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m583_flare_w_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2.5,
+    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
+    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["vn_xm16e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_m63a","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16_camo","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16_camo","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16_usaf","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
-    ["vn_m16_usaf","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""],
+    ["vn_xm16e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2,
+    ["vn_m63a","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
+    ["vn_m16_camo","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
+    ["vn_m16_camo","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 1.5,
+    ["vn_m16","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 3,
+    ["vn_m16","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 1.5,
+    ["vn_m16_usaf","","","",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 2,
+    ["vn_m16_usaf","","vn_b_m16","vn_o_9x_m16",["vn_m63a_30_mag","vn_m63a_30_mag","vn_m63a_30_t_mag"],[],""], 0.5,
     ["vn_m14a1_shorty","","","vn_o_m14_front",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],""],
-    ["vn_l2a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_03_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_02_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_02","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_01_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""],
-    ["vn_l1a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""]
+    ["vn_l2a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
+    ["vn_l1a1_03_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
+    ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
+    ["vn_l1a1_02_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
+    ["vn_l1a1_02","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.34,
+    // ["vn_l1a1_03","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], // Duplicate entry without any unique attachments.
+    ["vn_l1a1_01_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.33,
+    ["vn_l1a1_01","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],[],""], 1.34
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["vn_xm16e1_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_m79","","","",["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],["vn_40mm_m576_buck_mag"],""],
-    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""],
-    ["vn_l1a1_02_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""],
-    ["vn_l1a1_01_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""]
+    ["vn_xm16e1_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
+    ["vn_m16_xm148","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
+    ["vn_m16_m203","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 2,
+    ["vn_m16_m203_camo","","","",["vn_m16_40_t_mag","vn_m16_40_mag","vn_m16_30_t_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 1,
+    ["vn_m79","","","",["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],["vn_40mm_m576_buck_mag"],""], 2,
+    ["vn_l1a1_xm148_camo","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"], ["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
+    ["vn_l1a1_xm148","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_40mm_m651_cs_mag","vn_40mm_m381_he_mag","vn_40mm_m397_ab_mag","vn_40mm_m406_he_mag","vn_40mm_m433_hedp_mag"],""], 0.5,
+    ["vn_l1a1_02_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 0.5,
+    ["vn_l1a1_01_gl","","","",["vn_l1a1_30_02_t_mag","vn_l1a1_30_02_mag","vn_l1a1_30_t_mag","vn_l1a1_30_mag"],["vn_22mm_m61_frag_mag","vn_22mm_m61_frag_mag","vn_22mm_n94_heat_mag","vn_22mm_n94_heat_mag"],""], 0.5
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["vn_xm177_stock_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_xm177_short","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_xm177_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_xm177","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_xm177e1_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_xm177e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""],
-    ["vn_gau5a","","","vn_o_4x_m16",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""],
-    ["vn_gau5a","","","",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""]
+    ["vn_xm177_stock_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
+    ["vn_xm177_short","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
+    ["vn_xm177_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
+    ["vn_xm177","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 1.25,
+    ["vn_xm177e1_camo","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2.5,
+    ["vn_xm177e1","","","",["vn_m16_20_mag","vn_m16_40_mag","vn_m16_30_mag"],[],""], 2.5,
+    ["vn_gau5a","","","vn_o_4x_m16",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""], 2.5,
+    ["vn_gau5a","","","",["vn_m16_30_t_mag","vn_m16_30_mag","vn_m16_40_t_mag","vn_m16_20_t_mag"],[],""], 2.5
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["vn_svd","","","vn_o_4x_svd",["vn_svd_mag","vn_svd_mag","vn_svd_t_mag"],[],"vn_b_camo_svd"],
-    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"],
-    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"],
-    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"],
-    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"],
-    ["vn_m14_camo","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m14_camo","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m14_camo","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m14","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m14","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m14","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"],
-    ["vn_m1carbine_shorty","","","",["vn_carbine_30_mag","vn_carbine_30_mag","vn_carbine_30_t_mag","vn_carbine_15_t_mag"],[],"vn_b_camo_m14"]
+    ["vn_svd","","","vn_o_4x_svd",["vn_svd_mag","vn_svd_mag","vn_svd_t_mag"],[],"vn_b_camo_svd"], 10,
+    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"], 1.665,
+    ["vn_m14a1","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"], 1.665,
+    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_bipod_m14"], 1.665,
+    ["vn_m14a1","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14a1"], 1.665,
+    ["vn_m14_camo","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.23,
+    ["vn_m14_camo","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
+    ["vn_m14_camo","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
+    ["vn_m14","vn_s_m14","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.23,
+    ["vn_m14","","","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22,
+    ["vn_m14","","vn_b_m14","vn_o_9x_m14",["vn_m14_t_mag","vn_m14_mag","vn_m14_10_t_mag","vn_m14_10_mag"],[],"vn_b_camo_m14"], 2.22, // M14 weights add up to 20. These will outnumber the Mk14 EBR by double.
+    ["vn_m1carbine_shorty","","","",["vn_carbine_30_mag","vn_carbine_30_mag","vn_carbine_30_t_mag","vn_carbine_15_t_mag"],[],"vn_b_camo_m14"], 10
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["vn_mg42","","","",["vn_mg42_50_mag","vn_mg42_50_mag","vn_mg42_50_t_mag","vn_mg42_50_t_mag"],[],""],
-    ["vn_m63a_lmg","","","",["vn_m63a_100_mag","vn_m63a_100_t_mag","vn_m63a_100_mag","vn_m63a_100_t_mag"],[],"vn_bipod_m63a"],
-    ["vn_m63a_cdo","","","",["vn_m63a_150_mag","vn_m63a_150_t_mag","vn_m63a_150_mag","vn_m63a_150_t_mag"],[],"vn_bipod_m63a"],
-    ["vn_m60_shorty_camo","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"],
-    ["vn_m60_shorty","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"],
-    ["vn_m60","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"]
+    ["vn_mg42","","","",["vn_mg42_50_mag","vn_mg42_50_mag","vn_mg42_50_t_mag","vn_mg42_50_t_mag"],[],""], 5,
+    ["vn_m63a_lmg","","","",["vn_m63a_100_mag","vn_m63a_100_t_mag","vn_m63a_100_mag","vn_m63a_100_t_mag"],[],"vn_bipod_m63a"], 6,
+    ["vn_m63a_cdo","","","",["vn_m63a_150_mag","vn_m63a_150_t_mag","vn_m63a_150_mag","vn_m63a_150_t_mag"],[],"vn_bipod_m63a"], 6,
+    ["vn_m60_shorty_camo","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4,
+    ["vn_m60_shorty","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4,
+    ["vn_m60","","","",["vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag","vn_m60_100_mag"],[],"vn_bipod_m63a"], 4
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["vn_l34a1_xm148","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],["vn_40mm_m433_hedp_mag","vn_40mm_m406_he_mag"],""],
-    ["vn_l34a1_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""],
-    ["vn_l34a1","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""],
-    ["vn_l2a3_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""],
-    ["vn_l2a3","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""]
+    ["vn_l34a1_xm148","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],["vn_40mm_m433_hedp_mag","vn_40mm_m406_he_mag"],""], 1,
+    ["vn_l34a1_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.25,
+    ["vn_l34a1","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.25,
+    ["vn_l2a3_f","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.75,
+    ["vn_l2a3","","","",["vn_f1_smg_t_mag","vn_f1_smg_mag","vn_f1_smg_mag"],[],""], 2.75
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["vn_m40a1_camo","vn_s_m14","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],"vn_b_camo_m40a1"],
-    ["vn_m40a1_camo","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""],
-    ["vn_m40a1","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""]
+    ["vn_m40a1_camo","vn_s_m14","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],"vn_b_camo_m40a1"], 2,
+    ["vn_m40a1_camo","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5,
+    ["vn_m40a1","","","vn_o_9x_m40a1",["vn_m40a1_mag","vn_m40a1_mag","vn_m40a1_t_mag","vn_m40a1_t_mag"],[],""], 6.5
 ];
 
 (_loadoutData get "lightATLaunchers") append [
-    ["vn_m72", "", "", "", ["vn_m72_mag"], [], ""],
-    ["vn_rpg7", "", "", "", ["vn_rpg7_mag","vn_rpg7_mag","vn_rpg7_mag"], [], ""],
-    ["vn_rpg2", "", "", "", ["vn_rpg2_fuze_mag","vn_rpg2_fuze_mag","vn_rpg2_mag"], [], ""]
+    ["vn_m72", "", "", "", ["vn_m72_mag"], [], ""], 8,
+    ["vn_rpg7", "", "", "", ["vn_rpg7_mag","vn_rpg7_mag","vn_rpg7_mag"], [], ""], 5,
+    ["vn_rpg2", "", "", "", ["vn_rpg2_fuze_mag","vn_rpg2_fuze_mag","vn_rpg2_mag"], [], ""], 6
 ];
 (_loadoutData get "ATLaunchers") append [
-    ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_wp_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag"], [], ""]
+    ["vn_m20a1b1_01", "", "", "", ["vn_m20a1b1_wp_mag", "vn_m20a1b1_heat_mag", "vn_m20a1b1_heat_mag"], [], ""], 5
 ];
 (_loadoutData get "AALaunchers") append [
-    ["vn_sa7b", "", "", "", ["vn_sa7b_mag"], [], ""],
-    ["vn_sa7", "", "", "", ["vn_sa7_mag"], [], ""]
+    ["vn_sa7b", "", "", "", ["vn_sa7b_mag"], [], ""], 3.5,
+    ["vn_sa7", "", "", "", ["vn_sa7_mag"], [], ""], 3.5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
@@ -30,7 +30,7 @@
     ["SPE_M1903A3_Springfield", ["SPE_ACC_M1_Bayo", 1, "SPE_ACC_M1905_Bayo", 1, "", 3],"","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 0.5,
     ["SPE_M1_Garand",["SPE_ACC_M1_Bayo", 1, "SPE_ACC_M1905_Bayo", 1, "", 3],"","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 1,
     ["SPE_K98_Late",["SPE_ACC_K98_Bayo", 1, "", 3],"","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 0.25,
-    ["SPE_K98"["SPE_ACC_K98_Bayo", 1, "", 3],"","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 0.2,
+    ["SPE_K98", ["SPE_ACC_K98_Bayo", 1, "", 3],"","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 0.2,
     ["SPE_G43","","","",["SPE_10Rnd_792x57","SPE_10Rnd_792x57_T2","SPE_10Rnd_792x57_SMK","SPE_10Rnd_792x57_sS","SPE_10Rnd_792x57_T"],[],""], 0.5
 ];
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
@@ -15,7 +15,7 @@
     ["SPE_M1911","","","",["SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911"], [], ""], 5,
     ["SPE_P08","","","",["SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08"], [], ""], 2.5
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "rifles") append [
     ["SPE_STG44","","","",["SPE_30Rnd_792x33","SPE_30Rnd_792x33","SPE_30rnd_792x33_t"],[],""], 5,
     ["SPE_M1918A2_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
@@ -51,7 +51,7 @@
     ["SPE_M1903A4_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP"],[],""], 7,
     ["SPE_K98ZF39","","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 7
 ];
-
+//////////////////////////////////////////////////////
 (_loadoutData get "lightATLaunchers") append [
     ["SPE_M1A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2.5,
     ["SPE_M9A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3"], [], ""], 2.5,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
@@ -1,51 +1,46 @@
+
+
 (_policeLoadoutData get "SMGs") append [
-    ["SPE_M1_Carbine","SPE_ACC_GL_M8","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 1.5, // Grenade launcher adapter on this particular variant.
-    ["SPE_M1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 1.5,
-    ["SPE_Fusil_Mle_208_12_Sawedoff","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.75,
-    ["SPE_Fusil_Mle_208_12","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.75,
+    ["SPE_M1A1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 1,
+    ["SPE_M1_Carbine",["SPE_ACC_GL_M8", 1, "", 5],"","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 4,
 
-    ["SPE_Model_37_Trenchgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 1.5,
-    ["SPE_Model_37_Trenchgun","SPE_ACC_M1917_Bayo","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 0.5,
-    ["SPE_Model_37_Riotgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 1,
+    ["SPE_Fusil_Mle_208_12_Sawedoff","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.1,
+    ["SPE_Fusil_Mle_208_12","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.25,
 
-    ["SPE_M1A1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 0.5
+    ["SPE_Model_37_Trenchgun",["SPE_ACC_M1917_Bayo", 1, "", 5],"","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 1,
+    ["SPE_Model_37_Riotgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 4
 
 ];
+
 (_policeLoadoutData get "sidearms") append [
-    ["SPE_M1911","","","",["SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911"], [], ""], 5,
-    ["SPE_P08","","","",["SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08"], [], ""], 2.5
+    ["SPE_M1911","","","",["SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911"], [], ""], 8,
+    ["SPE_P08","","","",["SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08"], [], ""], 2
 ];
 //////////////////////////////////////////////////////
+
 (_militiaLoadoutData get "rifles") append [
-    ["SPE_STG44","","","",["SPE_30Rnd_792x33","SPE_30Rnd_792x33","SPE_30rnd_792x33_t"],[],""], 5,
-    ["SPE_M1918A2_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
-    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"],1,
-    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
-    ["SPE_M1918A2_erla_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"], 1,
-    ["SPE_M1918A0_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
-    ["SPE_FG42_E","","","",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""], 2.5,
-    ["SPE_FG42_E","","","SPE_Optic_ZFG42",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""], 2.5
+    ["SPE_STG44","","","",["SPE_30Rnd_792x33","SPE_30Rnd_792x33","SPE_30rnd_792x33_t"],[],""], 4,
+    ["SPE_M1918A2_BAR","",["SPE_M1918A2_BAR_Handle", 1, "", 1],"",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_M1918A2_erla_BAR","",["SPE_M1918A2_BAR_Handle", 1, "", 1],"",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[], ["SPE_M1918A2_BAR_Bipod", 1, "", 3]], 0.5,
+    ["SPE_M1918A0_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 0.25,
+    ["SPE_FG42_E","","",["SPE_Optic_ZFG42", 1, "", 1],["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""], 0.1 //FG42s are unobtanium
 ];
-(_militiaLoadoutData get "marksmanRifles") append [
-    ["SPE_M1903A3_Springfield","SPE_ACC_M1_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1903A3_Springfield","SPE_ACC_GL_M1","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1903A3_Springfield","SPE_ACC_M1905_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1903A3_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1_Garand","SPE_ACC_M1_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1_Garand","SPE_ACC_M1905_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1_Garand","SPE_ACC_GL_M7","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_M1_Garand","","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
-    ["SPE_K98_Late","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 4,
-    ["SPE_K98","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 4,
-    ["SPE_G43","SPE_ACC_K98_Bayo","","",["SPE_10Rnd_792x57","SPE_10Rnd_792x57_T2","SPE_10Rnd_792x57_SMK","SPE_10Rnd_792x57_sS","SPE_10Rnd_792x57_T"],[],""], 8,
+
+(_militiaLoadoutData get "marksmanRifles") append [ //most of these are terrible DMRs and thus will be uncommon
+    ["SPE_M1903A3_Springfield", ["SPE_ACC_M1_Bayo", 1, "SPE_ACC_M1905_Bayo", 1, "", 3],"","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 0.5,
+    ["SPE_M1_Garand",["SPE_ACC_M1_Bayo", 1, "SPE_ACC_M1905_Bayo", 1, "", 3],"","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_K98_Late",["SPE_ACC_K98_Bayo", 1, "", 3],"","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 0.25,
+    ["SPE_K98"["SPE_ACC_K98_Bayo", 1, "", 3],"","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 0.2,
+    ["SPE_G43","","","",["SPE_10Rnd_792x57","SPE_10Rnd_792x57_T2","SPE_10Rnd_792x57_SMK","SPE_10Rnd_792x57_sS","SPE_10Rnd_792x57_T"],[],""], 0.5
 ];
+
 (_militiaLoadoutData get "machineGuns") append [
-    ["SPE_MG42","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 4,
-    ["SPE_MG34","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 3,
-    ["SPE_M1919A6","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 2.5,
-    ["SPE_M1919A4","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 4.5,
-    ["SPE_FM_24_M29","","","",["SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP"],[],""], 5,
-    ["SPE_LMG_303_Mk2","","","",["SPE_30Rnd_770x56","SPE_30Rnd_770x56_AP_MKI","SPE_30Rnd_770x56_MKVIII"],[],""], 5
+    ["SPE_MG42","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 6,
+    ["SPE_MG34","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 2,
+    ["SPE_M1919A6","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_M1919A4","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 0.5,
+    ["SPE_FM_24_M29","","","",["SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP"],[],""], 1,
+    ["SPE_LMG_303_Mk2","","","",["SPE_30Rnd_770x56","SPE_30Rnd_770x56_AP_MKI","SPE_30Rnd_770x56_MKVIII"],[],""], 4
 ];
 (_militiaLoadoutData get "sniperRifles") append [
     ["SPE_M1903A4_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP"],[],""], 7,
@@ -53,7 +48,7 @@
 ];
 //////////////////////////////////////////////////////
 (_loadoutData get "lightATLaunchers") append [
-    ["SPE_M1A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2.5,
-    ["SPE_M9A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3"], [], ""], 2.5,
-    ["SPE_M9_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2.5
+    ["SPE_M1A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 0.5,
+    ["SPE_M9A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3"], [], ""], 4,
+    ["SPE_M9_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/SPE/Vanilla_AAF.sqf
@@ -1,59 +1,59 @@
 (_policeLoadoutData get "SMGs") append [
-    ["SPE_M1_Carbine","SPE_ACC_GL_M8","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""],
-    ["SPE_M1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""],
-    ["SPE_Fusil_Mle_208_12_Sawedoff","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""],
-    ["SPE_Fusil_Mle_208_12","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""],
+    ["SPE_M1_Carbine","SPE_ACC_GL_M8","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 1.5, // Grenade launcher adapter on this particular variant.
+    ["SPE_M1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 1.5,
+    ["SPE_Fusil_Mle_208_12_Sawedoff","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.75,
+    ["SPE_Fusil_Mle_208_12","","","",["SPE_2Rnd_12x65_No4_Buck","SPE_2Rnd_12x65_Pellets","SPE_2Rnd_12x65_Slug","SPE_2Rnd_12x65_No4_Buck"], [], ""], 0.75,
 
-    ["SPE_Model_37_Trenchgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""],
-    ["SPE_Model_37_Trenchgun","SPE_ACC_M1917_Bayo","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""],
-    ["SPE_Model_37_Riotgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""],
+    ["SPE_Model_37_Trenchgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 1.5,
+    ["SPE_Model_37_Trenchgun","SPE_ACC_M1917_Bayo","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 0.5,
+    ["SPE_Model_37_Riotgun","","","",["SPE_5Rnd_12x70_No4_Buck","SPE_5Rnd_12x70_Pellets","SPE_5Rnd_12x70_Slug","SPE_5Rnd_12x70_Slug"], [], ""], 1,
 
-    ["SPE_M1A1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""]
+    ["SPE_M1A1_Carbine","","","",["SPE_15Rnd_762x33","SPE_15Rnd_762x33","SPE_15Rnd_762x33_t","SPE_15Rnd_762x33_t"], [], ""], 0.5
 
 ];
 (_policeLoadoutData get "sidearms") append [
-    ["SPE_M1911","","","",["SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911"], [], ""],
-    ["SPE_P08","","","",["SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08"], [], ""]
+    ["SPE_M1911","","","",["SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911","SPE_7Rnd_45ACP_1911"], [], ""], 5,
+    ["SPE_P08","","","",["SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08","SPE_8Rnd_9x19_P08"], [], ""], 2.5
 ];
 
 (_militiaLoadoutData get "rifles") append [
-    ["SPE_STG44","","","",["SPE_30Rnd_792x33","SPE_30Rnd_792x33","SPE_30rnd_792x33_t"],[],""],
-    ["SPE_M1918A2_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"],
-    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1918A2_erla_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"],
-    ["SPE_M1918A0_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""],
-    ["SPE_FG42_E","","","",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""],
-    ["SPE_FG42_E","","","SPE_Optic_ZFG42",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""]
+    ["SPE_STG44","","","",["SPE_30Rnd_792x33","SPE_30Rnd_792x33","SPE_30rnd_792x33_t"],[],""], 5,
+    ["SPE_M1918A2_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"],1,
+    ["SPE_M1918A2_erla_BAR","","SPE_M1918A2_BAR_Handle","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_M1918A2_erla_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],"SPE_M1918A2_BAR_Bipod"], 1,
+    ["SPE_M1918A0_BAR","","","",["SPE_20Rnd_762x63","SPE_20Rnd_762x63_M1","SPE_20Rnd_762x63_M2_AP"],[],""], 1,
+    ["SPE_FG42_E","","","",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""], 2.5,
+    ["SPE_FG42_E","","","SPE_Optic_ZFG42",["SPE_20Rnd_792x57","SPE_20Rnd_792x57_t2","SPE_20Rnd_792x57_SMK","SPE_20Rnd_792x57_sS","SPE_20Rnd_792x57_t"],[],""], 2.5
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["SPE_M1903A3_Springfield","SPE_ACC_M1_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1903A3_Springfield","SPE_ACC_GL_M1","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1903A3_Springfield","SPE_ACC_M1905_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1903A3_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1_Garand","SPE_ACC_M1_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1_Garand","SPE_ACC_M1905_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1_Garand","SPE_ACC_GL_M7","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1_Garand","","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""],
-    ["SPE_K98_Late","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""],
-    ["SPE_K98","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""],
-    ["SPE_G43","SPE_ACC_K98_Bayo","","",["SPE_10Rnd_792x57","SPE_10Rnd_792x57_T2","SPE_10Rnd_792x57_SMK","SPE_10Rnd_792x57_sS","SPE_10Rnd_792x57_T"],[],""]
+    ["SPE_M1903A3_Springfield","SPE_ACC_M1_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1903A3_Springfield","SPE_ACC_GL_M1","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1903A3_Springfield","SPE_ACC_M1905_Bayo","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1903A3_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP","SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1_Garand","SPE_ACC_M1_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1_Garand","SPE_ACC_M1905_Bayo","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1_Garand","SPE_ACC_GL_M7","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_M1_Garand","","","",["SPE_8Rnd_762x63","SPE_8Rnd_762x63_M1","SPE_8Rnd_762x63_t","SPE_8Rnd_762x63_M2_AP"],[],""], 2,
+    ["SPE_K98_Late","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 4,
+    ["SPE_K98","SPE_ACC_K98_Bayo","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 4,
+    ["SPE_G43","SPE_ACC_K98_Bayo","","",["SPE_10Rnd_792x57","SPE_10Rnd_792x57_T2","SPE_10Rnd_792x57_SMK","SPE_10Rnd_792x57_sS","SPE_10Rnd_792x57_T"],[],""], 8,
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["SPE_MG42","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""],
-    ["SPE_MG34","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""],
-    ["SPE_M1919A6","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""],
-    ["SPE_M1919A4","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""],
-    ["SPE_FM_24_M29","","","",["SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP"],[],""],
-    ["SPE_LMG_303_Mk2","","","",["SPE_30Rnd_770x56","SPE_30Rnd_770x56_AP_MKI","SPE_30Rnd_770x56_MKVIII"],[],""]
+    ["SPE_MG42","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 4,
+    ["SPE_MG34","","","",["SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_SMK","SPE_50Rnd_792x57_sS","SPE_50Rnd_792x57"],[],""], 3,
+    ["SPE_M1919A6","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 2.5,
+    ["SPE_M1919A4","","","",["SPE_100Rnd_762x63","SPE_100Rnd_762x63_M1","SPE_100Rnd_762x63_M2_AP","SPE_50Rnd_762x63_M2_AP"],[],""], 4.5,
+    ["SPE_FM_24_M29","","","",["SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54","SPE_25Rnd_75x54","SPE_25Rnd_75x54_35P_AP","SPE_25Rnd_75x54_35P_AP"],[],""], 5,
+    ["SPE_LMG_303_Mk2","","","",["SPE_30Rnd_770x56","SPE_30Rnd_770x56_AP_MKI","SPE_30Rnd_770x56_MKVIII"],[],""], 5
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["SPE_M1903A4_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP"],[],""],
-    ["SPE_K98ZF39","","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""]
+    ["SPE_M1903A4_Springfield","","","",["SPE_5Rnd_762x63","SPE_5Rnd_762x63_M1","SPE_5Rnd_762x63_t","SPE_5Rnd_762x63_M2_AP"],[],""], 7,
+    ["SPE_K98ZF39","","","",["SPE_5Rnd_792x57","SPE_5Rnd_792x57_t","SPE_5Rnd_792x57_SMK","SPE_5Rnd_792x57_sS"],[],""], 7
 ];
 
 (_loadoutData get "lightATLaunchers") append [
-    ["SPE_M1A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""],
-    ["SPE_M9A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3"], [], ""],
-    ["SPE_M9_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""]
+    ["SPE_M1A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2.5,
+    ["SPE_M9A1_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3","SPE_1Rnd_60mm_M6A3"], [], ""], 2.5,
+    ["SPE_M9_Bazooka", "", "", "", ["SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6","SPE_1Rnd_60mm_M6"], [], ""], 2.5
 ];

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -78,54 +78,54 @@ _eliteRifleOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1]
 //////////////////////////////////////////////////////
 _militaryAttachments append ["saber_light_lxWS", 4];
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 9,
-    ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
+    ["LMG_S77_AAF_lxWS", "", _militaryAttachments, _militaryMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 9,
+    ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
 ];
 
-_militarySlRifleSights append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
-_militaryRifleSights append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
+_militarySlRifleOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
+_militaryRifleOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
 (_militaryLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","",_militaryAttachments,_militarySlRifleSights,["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 0.5,
-    ["arifle_Galat_lxWS","",_militaryAttachments,_militarySlRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 4,
-    ["arifle_SLR_V_lxWS","","",_militarySlRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
-    ["arifle_Velko_lxWS","",_militaryAttachments,_militarySlRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["sgun_aa40_lxWS","",_militaryAttachments,_militarySlRifleOptics,["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 0.5,
+    ["arifle_Galat_lxWS","",_militaryAttachments,_militarySlRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 4,
+    ["arifle_SLR_V_lxWS","","",_militarySlRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
+    ["arifle_Velko_lxWS","",_militaryAttachments,_militarySlRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","",_militaryAttachments,_militaryRifleSights,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.25,
-    ["arifle_Galat_lxWS","",_militaryAttachments,_militaryRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 3,
-    ["arifle_SLR_V_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
-    ["arifle_Velko_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 6
+    ["sgun_aa40_lxWS","",_militaryAttachments,_militaryRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.25,
+    ["arifle_Galat_lxWS","",_militaryAttachments,_militaryRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 3,
+    ["arifle_SLR_V_lxWS","","",_militaryRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
+    ["arifle_Velko_lxWS","",_militaryAttachments,_militaryRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 6
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 3,
-    ["arifle_VelkoR5_GL_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 6
+    ["arifle_SLR_V_GL_lxWS","","",_militaryRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 3,
+    ["arifle_VelkoR5_GL_lxWS","",_militaryAttachments,_militaryRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 6
 ];
 
 (_militaryLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
-    ["arifle_SLR_Para_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4,
-    ["arifle_SLR_Para_snake_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1
+    ["arifle_VelkoR5_lxWS","",_militaryAttachments,_militaryRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
+    ["arifle_SLR_Para_lxWS", "", _militaryAttachments, _militaryRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4,
+    ["arifle_SLR_Para_snake_lxWS", "", _militaryAttachments, _militaryRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1
 ];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanSights, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 2
+    ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 2
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "slRifles") append [
-    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 6,
-    ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
-    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 6,
+    ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 8,
-    ["arifle_SLR_V_lxWS","","",_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
-    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 8,
+    ["arifle_SLR_V_lxWS","","",_militiaRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","", _militiaAttachments, _militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 4,
+    ["arifle_SLR_V_GL_lxWS","", _militiaAttachments, _militiaRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 4,
     ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 8
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","", _militiaAttachments, _militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
+    ["arifle_VelkoR5_lxWS","", _militiaAttachments, _militiaRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -1,42 +1,36 @@
 
-sfAccessories append ["saber_light_ir_lxWS", 0.5];
+_sfAccessories append ["saber_light_ir_lxWS", 2.5];
+_sfSMGoptics append ["optic_r1_low_lxWS", 4];
 
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
-    ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 0.75,
-    ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 1
+    ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,
+    ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 10
 ]];
 
-_sfMGOptics append ["optic_r1_high_lxWS", 1.5];
+_sfMGOptics append ["optic_r1_high_lxWS", 2];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 0.75,
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 1
+    ["arifle_XMS_M_khk_lxWS", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS"], [], "bipod_03_F_blk"], 10,
+    ["arifle_XMS_M_Sand_lxWS", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS"], [], "bipod_03_F_blk"], 5,
 ];
 
-_sfRifleOptics append ["optic_r1_high_lxWS", 1];
+_sfRifleOptics append ["optic_r1_high_lxWS", 2];
 (_sfLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,"optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.5,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
-    ["arifle_SLR_Para_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 1.5
+    ["arifle_XMS_Base_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2.75,
+    ["arifle_XMS_Base_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 1.25,
+    ["arifle_XMS_GL_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4,
+    ["arifle_XMS_GL_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
 ];
 (_sfLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,"optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.5,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
-    ["arifle_SLR_Para_lxWS","suppressor_h_lxWS",_sfAccessories,_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 1.5
+    ["arifle_XMS_Base_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 13.5,
+    ["arifle_XMS_Base_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.5,
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 0.5,
-    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 1
+    ["arifle_XMS_GL_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 13.5,
+    ["arifle_XMS_GL_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 6.5
 ];
-(_sfLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 1,
-    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 0.5,
-    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 0.25
-];
+
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 1,
-    ["srifle_EBR_snake_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 0.25
+    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5,
 ];
 
 _eliteLoadoutData set ["designatedGrenadeLaunchers", [

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -1,4 +1,4 @@
-_sfAccessories append ["saber_light_ir_lxWS", 2.5, "saber_light_lxWS", 1]
+_sfAccessories append ["saber_light_ir_lxWS", 2.5, "saber_light_lxWS", 1];
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
     ["glaunch_GLX_lxWS", "", _sfAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,  
     ["glaunch_GLX_camo_lxWS", "", _sfAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 10
@@ -6,37 +6,37 @@ _sfLoadoutData set ["designatedGrenadeLaunchers", [
 
 (_sfLoadoutData get "machineGuns") append [
     ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3,
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5,
+    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5
 ];
 
-_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
-_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
+_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2];
+_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2];
 (_sfLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 7,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
-    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 4,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
+    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 4,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_sfLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 6,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
-    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 1,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
+    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 1, // Why Special Forces are using rifle grenades, I do not know. Thus, very rare.
-    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
+    ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 1, //uncommon bc rifle grenades are odd for SF
+    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 4
 ];
 (_sfLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 7,
-    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4,
-    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4
+    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5,
+    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 2.5,
+    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1
 ];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
+    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 10
 ];
 //////////////////////////////////////////////////////
-_eliteAccessories append ["saber_light_lxWS", 1, "saber_light_ir_lxW", 2.5]
+_eliteAccessories append ["saber_light_lxWS", 1, "saber_light_ir_lxW", 2.5];
 _eliteLoadoutData set ["designatedGrenadeLaunchers", [
     ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 3.5,
     ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 6.5
@@ -44,85 +44,85 @@ _eliteLoadoutData set ["designatedGrenadeLaunchers", [
 
 (_eliteLoadoutData get "machineGuns") append [
     ["LMG_S77_AAF_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 6,
-    ["LMG_S77_Compact_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 4,
+    ["LMG_S77_Compact_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 4
 ];
 
-_eliteSlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
-_eliteRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
+_eliteSlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
+_eliteRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
 (_eliteLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteSlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 7,
-    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteSlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
-    ["arifle_SLR_V_lxWS","","",_eliteSlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
+    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteSlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 2,
+    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteSlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1.5,
+    ["arifle_SLR_V_lxWS","","",_eliteSlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2,
     // Elites using antiquated weapons like the Galil or FN FAL should be relatively rare.
-    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteSlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteSlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 6,
-    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
-    ["arifle_SLR_V_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
+    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 1,
+    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1.5,
+    ["arifle_SLR_V_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2,
     // Elites using antiquated weapons like the Galil or FN FAL should be relatively rare.
-    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_eliteLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 2.5, // Why are elites using rifle grenades?
-    ["arifle_VelkoR5_GL_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
+    ["arifle_SLR_V_GL_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 1.5, 
+    ["arifle_VelkoR5_GL_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 4
 ];
 (_eliteLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
-    ["arifle_SLR_Para_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 7,
-    ["arifle_SLR_Para_snake_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 3
+    ["arifle_VelkoR5_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5,
+    ["arifle_SLR_Para_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 2,
+    ["arifle_SLR_Para_snake_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1
 ];
 (_eliteLoadoutData get "marksmanRifles") append [
     ["srifle_EBR_blk_lxWS", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
 //////////////////////////////////////////////////////
-_militaryAttachments append ["saber_light_lxWS", 4]
+_militaryAttachments append ["saber_light_lxWS", 4];
 (_militaryLoadoutData get "machineGuns") append [
     ["LMG_S77_AAF_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 9,
     ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
 ];
 
-_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2]
-_militaryRifleSights append ["optic_r1_high_black_sand_lxWS", 3]
+_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2 "optic_r1_high_black_sand_lxWS", 1];
+_militaryRifleSights append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
 (_militaryLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","",_militaryAttachments,"optic_r1_high_lxWS",["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 5,
-    ["arifle_Galat_lxWS","",_militaryAttachments,"optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
-    ["arifle_SLR_V_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
-    ["arifle_Velko_lxWS","",_militaryAttachments,"optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
+    ["sgun_aa40_lxWS","",_militaryAttachments,_militarySlRifleSights,["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 0.5,
+    ["arifle_Galat_lxWS","",_militaryAttachments,_militarySlRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 4,
+    ["arifle_SLR_V_lxWS","","",_militarySlRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
+    ["arifle_Velko_lxWS","",_militaryAttachments,_militarySlRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","",_militaryAttachments,_militaryRifleSights,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 5,
-    ["arifle_Galat_lxWS","",_militaryAttachments,_militaryRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 5,
-    ["arifle_SLR_V_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 5,
-    ["arifle_Velko_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 10
+    ["sgun_aa40_lxWS","",_militaryAttachments,_militaryRifleSights,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.25,
+    ["arifle_Galat_lxWS","",_militaryAttachments,_militaryRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 3,
+    ["arifle_SLR_V_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
+    ["arifle_Velko_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 6
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 5,
-    ["arifle_VelkoR5_GL_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10
+    ["arifle_SLR_V_GL_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 3,
+    ["arifle_VelkoR5_GL_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 6
 ];
 
 (_militaryLoadoutData get "carbines") append [
     ["arifle_VelkoR5_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
-    ["arifle_SLR_Para_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 9,
-    ["arifle_SLR_Para_snake_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1,
+    ["arifle_SLR_Para_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4,
+    ["arifle_SLR_Para_snake_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1
 ];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanSights, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
+    ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanSights, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 2
 ];
 //////////////////////////////////////////////////////
 (_militiaLoadoutData get "slRifles") append [
-    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 10,
-    ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 10,
-    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 7.5
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 6,
+    ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 10,
-    ["arifle_SLR_V_lxWS","","",_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 10,
-    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 7.5
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 8,
+    ["arifle_SLR_V_lxWS","","",_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 3,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 3
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","", _militiaAttachments, _militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 10,
-    ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 7.5
+    ["arifle_SLR_V_GL_lxWS","", _militiaAttachments, _militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 4,
+    ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 8
 ];
 (_militiaLoadoutData get "carbines") append [
     ["arifle_VelkoR5_lxWS","", _militiaAttachments, _militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -35,7 +35,7 @@ _sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_
 (_sfLoadoutData get "marksmanRifles") append [
     ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
-
+//////////////////////////////////////////////////////
 _eliteAccessories append ["saber_light_lxWS", 1, "saber_light_ir_lxW", 2.5]
 _eliteLoadoutData set ["designatedGrenadeLaunchers", [
     ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 3.5,
@@ -75,7 +75,7 @@ _eliteRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sa
 (_eliteLoadoutData get "marksmanRifles") append [
     ["srifle_EBR_blk_lxWS", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
-
+//////////////////////////////////////////////////////
 _militaryAttachments append ["saber_light_lxWS", 4]
 (_militaryLoadoutData get "machineGuns") append [
     ["LMG_S77_AAF_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 9,
@@ -109,7 +109,7 @@ _militaryRifleSights append ["optic_r1_high_black_sand_lxWS", 3]
 (_militaryLoadoutData get "marksmanRifles") append [
     ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanSights, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "slRifles") append [
     ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 10,
     ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 10,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -9,8 +9,8 @@ _sfLoadoutData set ["designatedGrenadeLaunchers", [
     ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5
 ];
 
-_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2];
-_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2];
+_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
+_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
 (_sfLoadoutData get "slRifles") append [
     ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 4,
     ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
@@ -82,7 +82,7 @@ _militaryAttachments append ["saber_light_lxWS", 4];
     ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
 ];
 
-_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2 "optic_r1_high_black_sand_lxWS", 1];
+_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
 _militaryRifleSights append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
 (_militaryLoadoutData get "slRifles") append [
     ["sgun_aa40_lxWS","",_militaryAttachments,_militarySlRifleSights,["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 0.5,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -9,8 +9,8 @@ _sfLoadoutData set ["designatedGrenadeLaunchers", [
     ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5
 ];
 
-_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
-_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
+_sfTlOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 2];
+_sfRifleOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 2];
 (_sfLoadoutData get "slRifles") append [
     ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 4,
     ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
@@ -47,8 +47,8 @@ _eliteLoadoutData set ["designatedGrenadeLaunchers", [
     ["LMG_S77_Compact_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 4
 ];
 
-_eliteSlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
-_eliteRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
+_eliteSlOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
+_eliteRifleOptics append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
 (_eliteLoadoutData get "slRifles") append [
     ["sgun_aa40_lxWS","",_eliteAccessories,_eliteSlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 2,
     ["arifle_Galat_lxWS","",_eliteAccessories,_eliteSlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1.5,
@@ -82,8 +82,8 @@ _militaryAttachments append ["saber_light_lxWS", 4];
     ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
 ];
 
-_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
-_militaryRifleSights append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 1];
+_militarySlRifleSights append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
+_militaryRifleSights append ["optic_r1_high_lxWS", 2, "optic_r1_high_sand_lxWS", 1];
 (_militaryLoadoutData get "slRifles") append [
     ["sgun_aa40_lxWS","",_militaryAttachments,_militarySlRifleSights,["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 0.5,
     ["arifle_Galat_lxWS","",_militaryAttachments,_militarySlRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 4,

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -1,129 +1,131 @@
-
-_sfAccessories append ["saber_light_ir_lxWS", 2.5];
-_sfSMGoptics append ["optic_r1_low_lxWS", 4];
-
+_sfAccessories append ["saber_light_ir_lxWS", 2.5, "saber_light_lxWS", 1]
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
-    ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,
-    ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 10
+    ["glaunch_GLX_lxWS", "", _sfAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 5,  
+    ["glaunch_GLX_camo_lxWS", "", _sfAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 10
 ]];
 
-_sfMGOptics append ["optic_r1_high_lxWS", 2];
 (_sfLoadoutData get "machineGuns") append [
-    ["arifle_XMS_M_khk_lxWS", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS"], [], "bipod_03_F_blk"], 10,
-    ["arifle_XMS_M_Sand_lxWS", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS", "75Rnd_556x45_Stanag_red_lxWS"], [], "bipod_03_F_blk"], 5,
+    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3,
+    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5,
 ];
 
-_sfRifleOptics append ["optic_r1_high_lxWS", 2];
+_sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
+_sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
 (_sfLoadoutData get "slRifles") append [
-    ["arifle_XMS_Base_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 2.75,
-    ["arifle_XMS_Base_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Pellets","6Rnd_12Gauge_Slug","6Rnd_12Gauge_Slug"], ""], 1.25,
-    ["arifle_XMS_GL_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4,
-    ["arifle_XMS_GL_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 7,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
+    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_sfLoadoutData get "rifles") append [
-    ["arifle_XMS_Base_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 13.5,
-    ["arifle_XMS_Base_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.5,
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 6,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
+    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["arifle_XMS_GL_khk_lxWS", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 13.5,
-    ["arifle_XMS_GL_Sand_lxWS", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 6.5
+    ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 1, // Why Special Forces are using rifle grenades, I do not know. Thus, very rare.
+    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
 ];
-
+(_sfLoadoutData get "carbines") append [
+    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 7,
+    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4,
+    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 4
+];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5,
+    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
 
+_eliteAccessories append ["saber_light_lxWS", 1, "saber_light_ir_lxW", 2.5]
 _eliteLoadoutData set ["designatedGrenadeLaunchers", [
-    ["glaunch_GLX_lxWS", "", "acc_pointer_IR", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""],
-    ["glaunch_GLX_camo_lxWS", "", "acc_pointer_IR", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""]
+    ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 3.5,
+    ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 6.5
 ]];
 
 (_eliteLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "", "acc_pointer_IR", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "", "acc_pointer_IR", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "", "acc_pointer_IR", "optic_NVS", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_pointer_IR", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_pointer_IR", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_pointer_IR", "optic_NVS", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""]
+    ["LMG_S77_AAF_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 6,
+    ["LMG_S77_Compact_lxWS", "", _eliteAccessories, _eliteMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 4,
 ];
 
+_eliteSlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
+_eliteRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS" 2]
 (_eliteLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","","saber_light_ir_lxWS","optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","","acc_pointer_IR","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteSlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 7,
+    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteSlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
+    ["arifle_SLR_V_lxWS","","",_eliteSlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
+    // Elites using antiquated weapons like the Galil or FN FAL should be relatively rare.
+    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteSlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_eliteLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","","saber_light_ir_lxWS","optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","","acc_pointer_IR","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","",_eliteAccessories,_eliteRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 6,
+    ["arifle_Galat_lxWS","",_eliteAccessories,_eliteRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
+    ["arifle_SLR_V_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
+    // Elites using antiquated weapons like the Galil or FN FAL should be relatively rare.
+    ["arifle_Velko_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_eliteLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""],
-    ["arifle_VelkoR5_GL_lxWS","","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""]
+    ["arifle_SLR_V_GL_lxWS","","",_eliteRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 2.5, // Why are elites using rifle grenades?
+    ["arifle_VelkoR5_GL_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
 ];
 (_eliteLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""],
-    ["arifle_SLR_Para_lxWS", "", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""],
-    ["arifle_SLR_Para_snake_lxWS", "", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""]
+    ["arifle_VelkoR5_lxWS","",_eliteAccessories,_eliteRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
+    ["arifle_SLR_Para_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 7,
+    ["arifle_SLR_Para_snake_lxWS", "", _eliteAccessories, _eliteRifleOptics, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 3
 ];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "", "acc_pointer_IR", "optic_DMS", ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""]
+    ["srifle_EBR_blk_lxWS", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
 
+_militaryAttachments append ["saber_light_lxWS", 4]
 (_militaryLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "", "acc_flashlight", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "", "acc_flashlight", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "", "acc_flashlight", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_flashlight", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_flashlight", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "", "acc_flashlight", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""]
+    ["LMG_S77_AAF_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 9,
+    ["LMG_S77_Compact_lxWS", "", _militaryAttachments, _militaryMGSights, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3
 ];
 
+_militarySlRifleSights append ["optic_r1_high_black_lxWS", 2]
+_militaryRifleSights append ["optic_r1_high_black_sand_lxWS", 3]
 (_militaryLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","","acc_flashlight","optic_r1_high_lxWS",["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","","acc_flashlight","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_flashlight","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","",_militaryAttachments,"optic_r1_high_lxWS",["8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Pellets_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Slug_lxWS"], [], ""], 5,
+    ["arifle_Galat_lxWS","",_militaryAttachments,"optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2.5,
+    ["arifle_SLR_V_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 2.5,
+    ["arifle_Velko_lxWS","",_militaryAttachments,"optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 5
 ];
 (_militaryLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","","acc_flashlight","optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","","acc_flashlight","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_flashlight","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","",_militaryAttachments,_militaryRifleSights,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 5,
+    ["arifle_Galat_lxWS","",_militaryAttachments,_militaryRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 5,
+    ["arifle_SLR_V_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 5,
+    ["arifle_Velko_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 10
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""],
-    ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""]
+    ["arifle_SLR_V_GL_lxWS","","",_militaryRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 5,
+    ["arifle_VelkoR5_GL_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10
 ];
+
 (_militaryLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","","acc_flashlight","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""],
-    ["arifle_SLR_Para_lxWS", "", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""],
-    ["arifle_SLR_Para_snake_lxWS", "", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""]
+    ["arifle_VelkoR5_lxWS","",_militaryAttachments,_militaryRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 10,
+    ["arifle_SLR_Para_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 9,
+    ["arifle_SLR_Para_snake_lxWS", "", _militaryAttachments, _militaryRifleSights, ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 1,
 ];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "", "acc_flashlight", "optic_DMS", ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""]
+    ["srifle_EBR_blk_lxWS", "", _militaryAttachments, _militaryMarksmanSights, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 5
 ];
 
 (_militiaLoadoutData get "slRifles") append [
-    ["arifle_Galat_worn_lxWS","","acc_flashlight","",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_lxWS","","acc_flashlight","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 10,
+    ["arifle_SLR_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 10,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 7.5
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["arifle_Galat_worn_lxWS","","acc_flashlight","",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["arifle_Galat_worn_lxWS","",_militiaAttachments,_militiaRifleSights,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 10,
+    ["arifle_SLR_V_lxWS","","",_militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 10,
+    ["arifle_Velko_lxWS","",_militiaAttachments,_militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 7.5
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","","",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""],
-    ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""]
+    ["arifle_SLR_V_GL_lxWS","", _militiaAttachments, _militiaRifleSights,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 10,
+    ["arifle_VelkoR5_GL_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 7.5
 ];
 (_militiaLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","","acc_flashlight","",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""]
+    ["arifle_VelkoR5_lxWS","", _militiaAttachments, _militiaRifleSights,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 5
 ];
 
 

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -5,23 +5,23 @@ _sfLoadoutData set ["designatedGrenadeLaunchers", [
 ]];
 
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3,
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5
+    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 3,
+    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 5
 ];
 
 _sfTlOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
 _sfRifleOptics append ["optic_r1_high_black_lxWS", 2, "optic_r1_high_black_sand_lxWS", 2];
 (_sfLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 4,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,_sfTlOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 4,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
     ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 4,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_sfLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",sfAccessories,_sfRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 1,
-    ["arifle_Galat_lxWS","suppressor_h_lxWS",sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,_sfRifleOptics,["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 1,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 2,
     ["arifle_SLR_V_lxWS","suppressor_h_lxWS","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
-    ["arifle_Velko_lxWS","suppressor_l_lxWS",sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 4
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
     ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 1, //uncommon bc rifle grenades are odd for SF

--- a/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/DLC_content/weapons/WS/Vanilla_AAF.sqf
@@ -1,42 +1,42 @@
+
+sfAccessories append ["saber_light_ir_lxWS", 0.5];
+
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
-    ["glaunch_GLX_lxWS", "", "acc_pointer_IR", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""],
-    ["glaunch_GLX_camo_lxWS", "", "acc_pointer_IR", "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""]
+    ["glaunch_GLX_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], ["1Rnd_Smoke_Grenade_shell"], ""], 0.75,
+    ["glaunch_GLX_camo_lxWS", "", _eliteAccessories, "", ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell", "3Rnd_HE_Grenade_shell"], [], ""], 1
 ]];
 
+_sfMGOptics append ["optic_r1_high_lxWS", 1.5];
 (_sfLoadoutData get "machineGuns") append [
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_NVS", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_Holosight_blk_F", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_MRCO", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_Hamr", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""],
-    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", "acc_pointer_IR", "optic_NVS", ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""]
+    ["LMG_S77_AAF_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 0.75,
+    ["LMG_S77_Compact_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfMGOptics, ["100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_lxWS", "100Rnd_762x51_S77_Red_Tracer_lxWS"], [], ""], 1
 ];
 
+_sfRifleOptics append ["optic_r1_high_lxWS", 1];
 (_sfLoadoutData get "slRifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS","saber_light_ir_lxWS","optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","suppressor_h_lxWS","acc_pointer_IR","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","suppressor_l_lxWS","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,"optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.5,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
+    ["arifle_SLR_Para_lxWS","suppressor_h_lxWS",_sfAccessories,_sfTlOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1.5,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfTlOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 1.5
 ];
 (_sfLoadoutData get "rifles") append [
-    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS","saber_light_ir_lxWS","optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""],
-    ["arifle_Galat_lxWS","suppressor_h_lxWS","acc_pointer_IR","optic_Hamr",["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""],
-    ["arifle_SLR_V_lxWS","suppressor_h_lxWS","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""],
-    ["arifle_Velko_lxWS","suppressor_l_lxWS","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""]
+    ["sgun_aa40_lxWS","muzzle_snds_12Gauge_lxWS",_sfAccessories,"optic_r1_high_lxWS",["20Rnd_12Gauge_AA40_Pellets_lxWS","20Rnd_12Gauge_AA40_Slug_lxWS","8Rnd_12Gauge_AA40_Smoke_lxWS","8Rnd_12Gauge_AA40_HE_lxWS"], [], ""], 0.5,
+    ["arifle_Galat_lxWS","suppressor_h_lxWS",_sfAccessories,_sfRifleOptics,["30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F","30Rnd_762x39_Mag_F"], [], ""], 1,
+    ["arifle_SLR_Para_lxWS","suppressor_h_lxWS",_sfAccessories,_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], [], ""], 1,
+    ["arifle_Velko_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], [], ""], 1.5
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["arifle_SLR_V_GL_lxWS","","","optic_Hamr",["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""],
-    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""]
+    ["arifle_SLR_V_GL_lxWS","","",_sfRifleOptics,["30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_reload_tracer_green_lxWS","30Rnd_762x51_slr_tracer_green_lxWS"], ["1Rnd_40mm_HE_lxWS","1Rnd_58mm_AT_lxWS","1Rnd_50mm_Smoke_lxWS"], ""], 0.5,
+    ["arifle_VelkoR5_GL_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 1
 ];
 (_sfLoadoutData get "carbines") append [
-    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS","acc_pointer_IR","optic_Hamr",["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""],
-    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""],
-    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", "saber_light_lxWS", "optic_r1_high_black_sand_lxWS",  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""]
+    ["arifle_VelkoR5_lxWS","suppressor_l_lxWS",_sfAccessories,_sfRifleOptics,["35Rnd_556x45_Velko_reload_tracer_red_lxWS","35Rnd_556x45_Velko_reload_tracer_red_lxWS","50Rnd_556x45_Velko_reload_tracer_red_lxWS"], ["1Rnd_HE_Grenade_shell","1Rnd_HE_Grenade_shell","1Rnd_Pellet_Grenade_shell_lxWS"], ""], 1,
+    ["arifle_SLR_Para_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 0.5,
+    ["arifle_SLR_Para_snake_lxWS", "suppressor_h_lxWS", _sfAccessories, _sfRifleOptics,  ["20Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS", "30Rnd_762x51_slr_lxWS"], [], ""], 0.25
 ];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", "acc_pointer_IR", "optic_DMS", ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""]
+    ["srifle_EBR_blk_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 1,
+    ["srifle_EBR_snake_lxWS", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS","20Rnd_762x51_Mag_blk_lxWS"], [], ""], 0.25
 ];
 
 _eliteLoadoutData set ["designatedGrenadeLaunchers", [

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
@@ -35,7 +35,7 @@
     ];
 (_sfLoadoutData get "vests") append [];
 (_sfLoadoutData get "Hvests") append [];
-
+//////////////////////////////////////////////////////
 (_eliteLoadoutData get "helmets") append [
     "CUP_H_RUS_Altyn_black", 0.1,
     "CUP_H_RUS_Altyn_Goggles_black", 0.05,
@@ -90,7 +90,7 @@
     "CUP_V_CZ_NPP2006_vz95_black", 2,
     "CUP_V_CZ_NPP2006_nk_black" 4
     ];
-
+//////////////////////////////////////////////////////
 (_militaryLoadoutData get "helmets") append [
     "CUP_H_PMC_Beanie_Headphones_Khaki", 1,
     "CUP_H_OpsCore_Covered_AAF_NoHS", 3,
@@ -141,7 +141,7 @@
     "CUP_V_B_Ciras_Olive2", 2,
     "CUP_V_B_Ciras_Olive", 4
     ];
-
+//////////////////////////////////////////////////////
 (_militiaLoadoutData get "helmets") append [
     "CUP_H_PMC_Beanie_Headphones_Khaki", 0.5,
     "CUP_H_RUS_ZSH_1_Goggles", 0.75,

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
@@ -16,7 +16,7 @@
     "CUP_H_OpsCore_Covered_AAF_NoHS", 4,
     "CUP_H_OpsCore_Covered_AAF", 4,
     "CUP_H_RUS_K6_3_Shield_Up_khaki", 0.25,
-    "CUP_H_RUS_K6_3_Shield_Down_khaki", 0.25
+    "CUP_H_RUS_K6_3_Shield_Down_khaki", 0.25,
     "CUP_H_RUS_K6_3_Goggles_khaki", 0.25,
     "CUP_H_RUS_K6_3_khaki", 0.5,
     "CUP_H_RUS_K6_3_Shield_Up", 0.25,
@@ -88,14 +88,14 @@
     "CUP_V_CZ_NPP2006_co_black", 2,
     "CUP_V_CZ_NPP2006_ok_black", 2,
     "CUP_V_CZ_NPP2006_vz95_black", 2,
-    "CUP_V_CZ_NPP2006_nk_black" 4
+    "CUP_V_CZ_NPP2006_nk_black", 4
     ];
 //////////////////////////////////////////////////////
 (_militaryLoadoutData get "helmets") append [
     "CUP_H_PMC_Beanie_Headphones_Khaki", 1,
     "CUP_H_OpsCore_Covered_AAF_NoHS", 3,
     "CUP_H_OpsCore_Covered_AAF", 3,
-    "CUP_H_PMC_EP_Headset" 1
+    "CUP_H_PMC_EP_Headset", 1
     ];
 (_militaryLoadoutData get "backpacks") append [
     "CUP_B_Kombat_Olive", 2,
@@ -109,7 +109,7 @@
     "CUP_V_PMC_CIRAS_OD_Patrol", 0.5,
     "CUP_V_CPC_communications_rngr", 0.5,
     "CUP_V_CPC_Fast_rngr", 0.5,
-    "CUP_V_CPC_light_rngr", , 0.5,
+    "CUP_V_CPC_light_rngr", 0.5,
     "CUP_V_CPC_medical_rngr",  0.5,
     "CUP_V_CPC_tl_rngr", 0.5,
     "CUP_V_CPC_weapons_rngr", 0.5,

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Gear_AAF.sqf
@@ -1,19 +1,175 @@
-(_sfLoadoutData get "helmets") append ["CUP_H_RUS_Altyn_black","CUP_H_RUS_Altyn_Goggles_black","CUP_H_RUS_Altyn_Shield_Down_black","CUP_H_RUS_Altyn_Shield_Up_black","CUP_H_RUS_Altyn","CUP_H_RUS_Altyn_Goggles","CUP_H_RUS_Altyn_Shield_Down","CUP_H_RUS_Altyn_Shield_Up","CUP_H_RUS_Altyn_khaki","CUP_H_RUS_Altyn_Goggles_khaki","CUP_H_RUS_Altyn_Shield_Down_khaki","CUP_H_RUS_Altyn_Shield_Up_khaki","CUP_H_PMC_Beanie_Headphones_Khaki","CUP_H_PMC_EP_Headset","CUP_H_OpsCore_Covered_AAF_NoHS","CUP_H_OpsCore_Covered_AAF","CUP_H_RUS_K6_3_Shield_Up_khaki","CUP_H_RUS_K6_3_Shield_Down_khaki","CUP_H_RUS_K6_3_Goggles_khaki","CUP_H_RUS_K6_3_khaki","CUP_H_RUS_K6_3_Shield_Up","CUP_H_RUS_K6_3_Shield_Down","CUP_H_RUS_K6_3_Goggles","CUP_H_RUS_K6_3","CUP_H_RUS_K6_3_Shield_Up_black","CUP_H_RUS_K6_3_Shield_Down_black","CUP_H_RUS_K6_3_Goggles_black","CUP_H_RUS_K6_3_black","CUP_H_FR_Headset"];
-(_sfLoadoutData get "backpacks") append ["CUP_B_Kombat_Olive","CUP_B_AlicePack_OD"];
+(_sfLoadoutData get "helmets") append [
+    "CUP_H_RUS_Altyn_black", 0.5,
+    "CUP_H_RUS_Altyn_Goggles_black", 0.25,
+    "CUP_H_RUS_Altyn_Shield_Down_black", 0.25,
+    "CUP_H_RUS_Altyn_Shield_Up_black", 0.25,
+    "CUP_H_RUS_Altyn", 1,
+    "CUP_H_RUS_Altyn_Goggles", 0.5,
+    "CUP_H_RUS_Altyn_Shield_Down", 0.5,
+    "CUP_H_RUS_Altyn_Shield_Up", 0.5,
+    "CUP_H_RUS_Altyn_khaki", 0.75,
+    "CUP_H_RUS_Altyn_Goggles_khaki", 0.3,
+    "CUP_H_RUS_Altyn_Shield_Down_khaki", 0.3,
+    "CUP_H_RUS_Altyn_Shield_Up_khaki", 0.3, 
+    "CUP_H_PMC_Beanie_Headphones_Khaki", 0.3,
+    "CUP_H_PMC_EP_Headset", 1,
+    "CUP_H_OpsCore_Covered_AAF_NoHS", 4,
+    "CUP_H_OpsCore_Covered_AAF", 4,
+    "CUP_H_RUS_K6_3_Shield_Up_khaki", 0.25,
+    "CUP_H_RUS_K6_3_Shield_Down_khaki", 0.25
+    "CUP_H_RUS_K6_3_Goggles_khaki", 0.25,
+    "CUP_H_RUS_K6_3_khaki", 0.5,
+    "CUP_H_RUS_K6_3_Shield_Up", 0.25,
+    "CUP_H_RUS_K6_3_Shield_Down", 0.25,
+    "CUP_H_RUS_K6_3_Goggles", 0.25,
+    "CUP_H_RUS_K6_3", 0.5,
+    "CUP_H_RUS_K6_3_Shield_Up_black", 0.1,
+    "CUP_H_RUS_K6_3_Shield_Down_black", 0.1,
+    "CUP_H_RUS_K6_3_Goggles_black", 0.1,
+    "CUP_H_RUS_K6_3_black", 0.25,
+    "CUP_H_FR_Headset", 1
+    ];
+(_sfLoadoutData get "backpacks") append [
+    "CUP_B_Kombat_Olive", 1,
+    "CUP_B_AlicePack_OD", 0.1
+    ];
 (_sfLoadoutData get "vests") append [];
 (_sfLoadoutData get "Hvests") append [];
 
-(_eliteLoadoutData get "helmets") append ["CUP_H_RUS_Altyn_black","CUP_H_RUS_Altyn_Goggles_black","CUP_H_RUS_Altyn_Shield_Down_black","CUP_H_RUS_Altyn_Shield_Up_black","CUP_H_RUS_Altyn","CUP_H_RUS_Altyn_Goggles","CUP_H_RUS_Altyn_Shield_Down","CUP_H_RUS_Altyn_Shield_Up","CUP_H_RUS_Altyn_khaki","CUP_H_RUS_Altyn_Goggles_khaki","CUP_H_RUS_Altyn_Shield_Down_khaki","CUP_H_RUS_Altyn_Shield_Up_khaki","CUP_H_PMC_Beanie_Headphones_Khaki","CUP_H_PMC_EP_Headset","CUP_H_OpsCore_Covered_AAF_NoHS","CUP_H_OpsCore_Covered_AAF","CUP_H_RUS_K6_3_Shield_Up_khaki","CUP_H_RUS_K6_3_Shield_Down_khaki","CUP_H_RUS_K6_3_Goggles_khaki","CUP_H_RUS_K6_3_khaki","CUP_H_RUS_K6_3_Shield_Up","CUP_H_RUS_K6_3_Shield_Down","CUP_H_RUS_K6_3_Goggles","CUP_H_RUS_K6_3","CUP_H_RUS_K6_3_Shield_Up_black","CUP_H_RUS_K6_3_Shield_Down_black","CUP_H_RUS_K6_3_Goggles_black","CUP_H_RUS_K6_3_black","CUP_H_FR_Headset"];
-(_eliteLoadoutData get "backpacks") append ["CUP_B_Kombat_Olive","CUP_B_AlicePack_OD"];
-(_eliteLoadoutData get "vests") append ["CUP_V_B_Ciras_Olive4","CUP_V_B_Ciras_Olive3","CUP_V_B_Ciras_Olive2","CUP_V_B_Ciras_Olive","CUP_V_B_Armatus_OD","CUP_V_B_Armatus_BB_OD","CUP_V_PMC_IOTV_Black_Patrol","CUP_V_PMC_IOTV_Black_TL","CUP_V_PMC_IOTV_Black_Empty","CUP_V_PMC_IOTV_Black_AR"];
-(_eliteLoadoutData get "Hvests") append ["CUP_V_PMC_IOTV_Black_Gren","CUP_V_CZ_NPP2006_co_black","CUP_V_CZ_NPP2006_ok_black","CUP_V_CZ_NPP2006_vz95_black","CUP_V_CZ_NPP2006_nk_black"];
+(_eliteLoadoutData get "helmets") append [
+    "CUP_H_RUS_Altyn_black", 0.1,
+    "CUP_H_RUS_Altyn_Goggles_black", 0.05,
+    "CUP_H_RUS_Altyn_Shield_Down_black", 0.05,
+    "CUP_H_RUS_Altyn_Shield_Up_black", 0.05,
+    "CUP_H_RUS_Altyn", 0.25,
+    "CUP_H_RUS_Altyn_Goggles", 0.1,
+    "CUP_H_RUS_Altyn_Shield_Down", 0.1,
+    "CUP_H_RUS_Altyn_Shield_Up", 0.1,
+    "CUP_H_RUS_Altyn_khaki", 0.25,
+    "CUP_H_RUS_Altyn_Goggles_khaki", 0.1,
+    "CUP_H_RUS_Altyn_Shield_Down_khaki", 0.1, 
+    "CUP_H_RUS_Altyn_Shield_Up_khaki", 0.1,
+    "CUP_H_PMC_Beanie_Headphones_Khaki", 0.1,
+    "CUP_H_PMC_EP_Headset", 0.5,
+    "CUP_H_OpsCore_Covered_AAF_NoHS", 5,
+    "CUP_H_OpsCore_Covered_AAF", 5,
+    "CUP_H_RUS_K6_3_Shield_Up_khaki", 0.1,
+    "CUP_H_RUS_K6_3_Shield_Down_khaki", 0.1,
+    "CUP_H_RUS_K6_3_Goggles_khaki", 0.1,
+    "CUP_H_RUS_K6_3_khaki", 0.25,
+    "CUP_H_RUS_K6_3_Shield_Up", 0.1,
+    "CUP_H_RUS_K6_3_Shield_Down", 0.1,
+    "CUP_H_RUS_K6_3_Goggles", 0.1,
+    "CUP_H_RUS_K6_3", 0.25,
+    "CUP_H_RUS_K6_3_Shield_Up_black", 0.05,
+    "CUP_H_RUS_K6_3_Shield_Down_black", 0.05,
+    "CUP_H_RUS_K6_3_Goggles_black", 0.05,
+    "CUP_H_RUS_K6_3_black", 0.1,
+    "CUP_H_FR_Headset", 0.5
+    ];
+(_eliteLoadoutData get "backpacks") append [
+    "CUP_B_Kombat_Olive", 1,
+    "CUP_B_AlicePack_OD", 0.25
+    ];
+(_eliteLoadoutData get "vests") append [
+    "CUP_V_B_Ciras_Olive4", 2,
+    "CUP_V_B_Ciras_Olive3", 2,
+    "CUP_V_B_Ciras_Olive2", 2,
+    "CUP_V_B_Ciras_Olive", 3,
+    "CUP_V_B_Armatus_OD", 0.5,
+    "CUP_V_B_Armatus_BB_OD", 0.5,
+    "CUP_V_PMC_IOTV_Black_Patrol", 1,
+    "CUP_V_PMC_IOTV_Black_TL", 1,
+    "CUP_V_PMC_IOTV_Black_Empty", 0.1,
+    "CUP_V_PMC_IOTV_Black_AR", 1
+    ];
+(_eliteLoadoutData get "Hvests") append [
+    "CUP_V_PMC_IOTV_Black_Gren", 2,
+    "CUP_V_CZ_NPP2006_co_black", 2,
+    "CUP_V_CZ_NPP2006_ok_black", 2,
+    "CUP_V_CZ_NPP2006_vz95_black", 2,
+    "CUP_V_CZ_NPP2006_nk_black" 4
+    ];
 
-(_militaryLoadoutData get "helmets") append ["CUP_H_PMC_Beanie_Headphones_Khaki","CUP_H_OpsCore_Covered_AAF_NoHS","CUP_H_OpsCore_Covered_AAF","CUP_H_PMC_EP_Headset"];
-(_militaryLoadoutData get "backpacks") append ["CUP_B_Kombat_Olive","CUP_B_AlicePack_OD"];
-(_militaryLoadoutData get "vests") append ["CUP_V_PMC_CIRAS_OD_Veh","CUP_V_PMC_CIRAS_OD_Empty","CUP_V_PMC_CIRAS_OD_Grenadier","CUP_V_PMC_CIRAS_OD_TL","CUP_V_PMC_CIRAS_OD_Patrol","CUP_V_CPC_communications_rngr","CUP_V_CPC_Fast_rngr","CUP_V_CPC_light_rngr","CUP_V_CPC_medical_rngr","CUP_V_CPC_tl_rngr","CUP_V_CPC_weapons_rngr","CUP_V_CPC_communicationsbelt_rngr","CUP_V_CPC_Fastbelt_rngr","CUP_V_CPC_lightbelt_rngr","CUP_V_CPC_medicalbelt_rngr","CUP_V_CPC_tlbelt_rngr","CUP_V_CPC_weaponsbelt_rngr","CUP_V_B_Interceptor_Base_Olive","CUP_V_B_Interceptor_Grenadier_Olive","CUP_V_B_Interceptor_Rifleman_Olive","CUP_V_JPC_weaponsbelt_rngr","CUP_V_JPC_tlbelt_rngr","CUP_V_JPC_medicalbelt_rngr","CUP_V_JPC_lightbelt_rngr","CUP_V_JPC_Fastbelt_rngr","CUP_V_JPC_communicationsbelt_rngr","CUP_V_JPC_weapons_rngr","CUP_V_JPC_tl_rngr","CUP_V_JPC_medical_rngr","CUP_V_B_JPC_OD_Light","CUP_V_JPC_Fast_rngr","CUP_V_JPC_communications_rngr"];
-(_militaryLoadoutData get "Hvests") append ["CUP_V_B_Ciras_Olive4","CUP_V_B_Ciras_Olive3","CUP_V_B_Ciras_Olive2","CUP_V_B_Ciras_Olive"];
+(_militaryLoadoutData get "helmets") append [
+    "CUP_H_PMC_Beanie_Headphones_Khaki", 1,
+    "CUP_H_OpsCore_Covered_AAF_NoHS", 3,
+    "CUP_H_OpsCore_Covered_AAF", 3,
+    "CUP_H_PMC_EP_Headset" 1
+    ];
+(_militaryLoadoutData get "backpacks") append [
+    "CUP_B_Kombat_Olive", 2,
+    "CUP_B_AlicePack_OD", 1
+    ];
+(_militaryLoadoutData get "vests") append [
+    "CUP_V_PMC_CIRAS_OD_Veh", 0.5,
+    "CUP_V_PMC_CIRAS_OD_Empty", 0.1,
+    "CUP_V_PMC_CIRAS_OD_Grenadier", 0.5,
+    "CUP_V_PMC_CIRAS_OD_TL", 0.5,
+    "CUP_V_PMC_CIRAS_OD_Patrol", 0.5,
+    "CUP_V_CPC_communications_rngr", 0.5,
+    "CUP_V_CPC_Fast_rngr", 0.5,
+    "CUP_V_CPC_light_rngr", , 0.5,
+    "CUP_V_CPC_medical_rngr",  0.5,
+    "CUP_V_CPC_tl_rngr", 0.5,
+    "CUP_V_CPC_weapons_rngr", 0.5,
+    "CUP_V_CPC_communicationsbelt_rngr", 2,
+    "CUP_V_CPC_Fastbelt_rngr", 2,
+    "CUP_V_CPC_lightbelt_rngr", 2,
+    "CUP_V_CPC_medicalbelt_rngr", 2,
+    "CUP_V_CPC_tlbelt_rngr", 2,
+    "CUP_V_CPC_weaponsbelt_rngr", 2,
+    "CUP_V_B_Interceptor_Base_Olive", 0.1,
+    "CUP_V_B_Interceptor_Grenadier_Olive", 0.5,
+    "CUP_V_B_Interceptor_Rifleman_Olive", 0.5,
+    "CUP_V_JPC_weaponsbelt_rngr", 1,
+    "CUP_V_JPC_tlbelt_rngr", 1,
+    "CUP_V_JPC_medicalbelt_rngr", 1,
+    "CUP_V_JPC_lightbelt_rngr", 1,
+    "CUP_V_JPC_Fastbelt_rngr", 1,
+    "CUP_V_JPC_communicationsbelt_rngr", 1,
+    "CUP_V_JPC_weapons_rngr", 0.25,
+    "CUP_V_JPC_tl_rngr", 0.25,
+    "CUP_V_JPC_medical_rngr", 0.25,
+    "CUP_V_B_JPC_OD_Light", 0.25,
+    "CUP_V_JPC_Fast_rngr", 0.25,
+    "CUP_V_JPC_communications_rngr", 0.25
+    ];
+(_militaryLoadoutData get "Hvests") append [
+    "CUP_V_B_Ciras_Olive4", 2,
+    "CUP_V_B_Ciras_Olive3", 2,
+    "CUP_V_B_Ciras_Olive2", 2,
+    "CUP_V_B_Ciras_Olive", 4
+    ];
 
-(_militiaLoadoutData get "helmets") append ["CUP_H_PMC_Beanie_Headphones_Khaki","CUP_H_RUS_ZSH_1_Goggles","CUP_H_RUS_ZSH_1","CUP_H_PASGTv2_OD","CUP_H_PASGTv2_NVG_OD","CUP_H_USArmy_Helmet_ECH1_Green","CUP_H_USArmy_Helmet_ECH2_GREEN","CUP_H_USArmy_Helmet_ECH1_Black","CUP_H_USArmy_Helmet_ECH2_Black","CUP_H_PMC_EP_Headset"];
-(_militiaLoadoutData get "vests") append ["CUP_V_B_RRV_TL","CUP_V_B_RRV_Scout3_GRN","CUP_V_B_RRV_Scout2","CUP_V_B_RRV_Scout","CUP_V_B_RRV_Officer","CUP_V_B_RRV_Medic","CUP_V_B_RRV_MG_GRN","CUP_V_I_RACS_Carrier_Rig_wdl_3","CUP_V_I_RACS_Carrier_Rig_wdl_2"];
-(_militiaLoadoutData get "backpacks") append ["CUP_B_Kombat_Olive","CUP_B_AlicePack_OD"];
-(_militiaLoadoutData get "Hvests") append ["CUP_V_B_PASGT_no_bags_OD","CUP_V_B_PASGT_OD"];
+(_militiaLoadoutData get "helmets") append [
+    "CUP_H_PMC_Beanie_Headphones_Khaki", 0.5,
+    "CUP_H_RUS_ZSH_1_Goggles", 0.75,
+    "CUP_H_RUS_ZSH_1", 0.75,
+    "CUP_H_PASGTv2_OD", 1,
+    "CUP_H_PASGTv2_NVG_OD", 0.5,
+    "CUP_H_USArmy_Helmet_ECH1_Green", 0.25,
+    "CUP_H_USArmy_Helmet_ECH2_GREEN", 0.25,
+    "CUP_H_USArmy_Helmet_ECH1_Black", 0.1,
+    "CUP_H_USArmy_Helmet_ECH2_Black", 0.1,
+    "CUP_H_PMC_EP_Headset", 0.2
+    ];
+(_militiaLoadoutData get "vests") append [
+    "CUP_V_B_RRV_TL", 0.5,
+    "CUP_V_B_RRV_Scout3_GRN", 1,
+    "CUP_V_B_RRV_Scout2", 1,
+    "CUP_V_B_RRV_Scout", 2,
+    "CUP_V_B_RRV_Officer", 0.5,
+    "CUP_V_B_RRV_Medic", 0.75,
+    "CUP_V_B_RRV_MG_GRN", 0.5,
+    "CUP_V_I_RACS_Carrier_Rig_wdl_3", 1,
+    "CUP_V_I_RACS_Carrier_Rig_wdl_2", 1
+    ];
+(_militiaLoadoutData get "backpacks") append [
+    "CUP_B_Kombat_Olive", 1.5,
+    "CUP_B_AlicePack_OD", 3
+    ];
+(_militiaLoadoutData get "Hvests") append [
+    "CUP_V_B_PASGT_no_bags_OD", 0.5,
+    "CUP_V_B_PASGT_OD", 2
+    ];

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -151,271 +151,302 @@ _cupSFSniperOptics = ["CUP_optic_LeupoldMk4_20x40_LRT", 5, "CUP_optic_LeupoldMk4
 _cupEliteGreenAttachments = ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 3, "CUP_acc_ANPEQ_15_OD", 2];
 _cupEliteAttachments = ["CUP_acc_ANPEQ_2_grey", 2, "CUP_acc_ANPEQ_15_black", 1.5, "CUP_acc_ANPEQ_15_Flashlight_Black_L", 3];
 
-_cupEliteGreenSlOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 1, "CUP_optic_Elcan_SpecterDR_RMR_od", 1.5, "CUP_optic_Elcan_SpecterDR_od", 2, "CUP_optic_Elcan_SpecterDR_KF_od", 0.5];
-_cupEliteSlOptics = ["CUP_optic_HensoldtZO_RDS", 3, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
-_cupEliteXM8Optics = ["CUP_optic_AMO_PCAP", 3, "CUP_optic_ISM_PCAP", 2];
+_cupEliteGreenSlOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 1, "CUP_optic_Elcan_SpecterDR_RMR_od", 1.5, "CUP_optic_Elcan_SpecterDR_od", 3, "CUP_optic_Elcan_SpecterDR_KF_od", 0.5];
+_cupEliteSlOptics = ["CUP_optic_HensoldtZO_RDS", 2.5, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 2, "CUP_optic_Elcan_SpecterDR_black", 4, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
+_cupEliteXM8SlOptics = ["CUP_optic_AMO_PCAP", 5, "CUP_optic_ISM_PCAP", 2];
+
 (_eliteLoadoutData get "slRifles") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 3,
+	["CUP_arifle_XM8_Carbine_GL_Rail", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_XM8_Carbine_GL_Green", "",_cupEliteGreenAttachments,_cupEliteXM8SlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_XM8_Carbine_GL", "",_cupEliteAttachments,_cupEliteXM8SlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
 
-	["CUP_arifle_xm29_olive", "",_cupEliteGreenAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	["CUP_arifle_xm29_blk", "",_cupEliteAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	["CUP_arifle_xm29_olive", "",_cupEliteGreenAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 0.75,
+	["CUP_arifle_xm29_blk", "",_cupEliteAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 0.25,
 
-	["CUP_arifle_Mk17_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk17_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.25,
+	["CUP_arifle_Mk17_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.1,
 
-	["CUP_arifle_Mk17_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk17_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
+	["CUP_arifle_Mk17_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.25,
 	
-	["CUP_arifle_Mk16_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk16_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
+	["CUP_arifle_Mk16_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5,
 	
-	["CUP_arifle_Mk16_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk16_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_Mk16_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
 	
-	["CUP_arifle_HK_M27_AG36", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_HK_M27_AG36", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 	
-	["CUP_CZ_BREN2_556_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_556_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
+	["CUP_CZ_BREN2_556_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5,
 
-	["CUP_CZ_BREN2_556_11_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_556_11_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_11_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
+	["CUP_CZ_BREN2_556_11_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.25,
 
-	["CUP_CZ_BREN2_762_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_762_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5,
+	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.25,
 
-	["CUP_arifle_CZ805_GL_blk", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_CZ805_GL_blk", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
-	["CUP_arifle_ACRC_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_ACRC_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_ACRC_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 2,
+	["CUP_arifle_ACRC_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
 
-	["CUP_arifle_ACR_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
+	["CUP_arifle_ACR_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5
 ];
 
-_cupEliteRifleOptics = [];
-_cupEliteGreenRifleOptics = [];
+_cupEliteRifleOptics = ["CUP_optic_HensoldtZO_RDS", 0.75, "CUP_optic_HensoldtZO_", 1.25, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5, "CUP_optic_ACOG_TA01B_RMR_Black", 1, "CUP_optic_ACOG_TA01B_Black", 2, "CUP_optic_AIMM_M68_BLK", 1, "CUP_optic_CompM2_low", 3.5, "CUP_optic_G33_HWS_BLK", 0.75, "CUP_optic_Eotech553_Black", 3];
+_cupEliteGreenRifleOptics = ["CUP_optic_HensoldtZO_RDS_OD", 0.75, "CUP_optic_HensoldtZO_OD", 1.25,"CUP_optic_Elcan_SpecterDR_KF_RMR_od", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_od", 1.25, "CUP_optic_Elcan_SpecterDR_od", 2.5, "CUP_optic_Elcan_SpecterDR_KF_od", 0.5, "CUP_optic_ACOG_TA01B_RMR_OD", 1, "CUP_optic_ACOG_TA01B_OD", 2, "CUP_optic_AIMM_M68_OD", 1, "CUP_optic_CompM2_low_OD", 3];
+_cupEliteXM8Optics = ["CUP_optic_AMO_PCAP", 3, "CUP_optic_ISM_PCAP", 2, "CUP_optic_RCO_PCAP", 0.5];
+
+_eliteRifleOptics append ["CUP_optic_HensoldtZO_RDS", 0.5, "CUP_optic_HensoldtZO_", 1, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2.5, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5, "CUP_optic_ACOG_TA01B_RMR_Black", 0.75, "CUP_optic_ACOG_TA01B_Black", 2, "CUP_optic_AIMM_M68_BLK", 1, "CUP_optic_CompM2_low", 3.5, "CUP_optic_G33_HWS_BLK", 0.75, "CUP_optic_Eotech553_Black", 2.5];
+
+_cupEliteRifleBipods = ["CUP_bipod_VLTOR_Modpod_black", 1, "", 2];
+_cupEliteGreenRifleBipods = ["CUP_bipod_VLTOR_Modpod_od", 1, "", 2];
+
 (_eliteLoadoutData get "rifles") append [
-    ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+    ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 1,
+	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 3,
+	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 0.75,
+	["CUP_arifle_XM8_Sharpshooter_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 1.5,
+	["CUP_arifle_XM8_Sharpshooter_FG_Green", "",_cupEliteGreenAttachments ,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 0.25,
+	["CUP_arifle_XM8_Sharpshooter_Green", "",_cupEliteGreenAttachments ,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 0.75,
+	["CUP_arifle_XM8_Sharpshooter", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 1.5,
+	["CUP_arifle_XM8_Sharpshooter_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 0.5,
 
-	["CUP_arifle_Mk20_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk20_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk20_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.2,
+	["CUP_arifle_Mk20_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
 
-	["CUP_arifle_Mk17_STD_SFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
-	["CUP_arifle_Mk17_STD_SFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
+	["CUP_arifle_Mk17_STD_SFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
+	["CUP_arifle_Mk17_STD_SFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
-	["CUP_arifle_Mk17_STD_FG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_STD_FG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk17_STD_FG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.2,
+	["CUP_arifle_Mk17_STD_FG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.1,
 
-	["CUP_arifle_Mk17_STD_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_STD_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_STD_AFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_STD_AFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk17_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.25,
+	["CUP_arifle_Mk17_STD_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.75,
+	["CUP_arifle_Mk17_STD_AFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.2,
+	["CUP_arifle_Mk17_STD_AFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.1,
 
-	["CUP_arifle_Mk16_SV_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_SV_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk16_SV_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 0.5,
+	["CUP_arifle_Mk16_SV_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_arifle_Mk16_STD_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_STD_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_STD_FG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_STD_FG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk16_STD_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 1.75,
+	["CUP_arifle_Mk16_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.75,
+	["CUP_arifle_Mk16_STD_FG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 0.5,
+	["CUP_arifle_Mk16_STD_FG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_arifle_Mk16_STD_SFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], ""],
-	["CUP_arifle_Mk16_STD_SFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], ""],
+	["CUP_arifle_Mk16_STD_SFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_Mk16_STD_SFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.25,
 
-	["CUP_arifle_Mk16_STD_AFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], ""],
-	["CUP_arifle_Mk16_STD_AFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], [], ""],
+	["CUP_arifle_Mk16_STD_AFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_Mk16_STD_AFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.25,
 	
-	["CUP_arifle_HK_M27_VFG", "","CUP_acc_ANPEQ_2_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_RMR_black",["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_arifle_HK_M27", "","CUP_acc_ANPEQ_2_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_RMR_black",["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_arifle_HK_M27_VFG", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
+	["CUP_arifle_HK_M27", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], [], _cupEliteRifleBipods], 1,
 
-	["CUP_CZ_BREN2_556_14_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AIMM_M68_BLK",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_CZ_BREN2_556_14", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AIMM_M68_BLK",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_CZ_BREN2_556_14_Grn", "",_cupEliteGreenAttachments ,_cupEliteRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 1,
+	["CUP_CZ_BREN2_556_14", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.5,
 
-	["CUP_CZ_BREN2_556_11_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AIMM_M68_BLK",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_CZ_BREN2_556_11", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AIMM_M68_BLK",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_CZ_BREN2_556_11_Grn", "",_cupEliteGreenAttachments ,_cupEliteRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 0.75,
+	["CUP_CZ_BREN2_556_11", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_CZ_BREN2_762_14_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_black",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_CZ_BREN2_762_14", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_black",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_CZ_BREN2_762_14_Grn", "",_cupEliteGreenAttachments ,_cupEliteRifleOptics ,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], _cupEliteGreenRifleBipods], 0.5,
+	["CUP_CZ_BREN2_762_14", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_arifle_CZ805_A2_blk", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_black",["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_arifle_CZ805_A2_blk", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], [], _cupEliteRifleBipods], 0.75,
 
-	["CUP_arifle_CZ805_A1_blk", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_black",["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_arifle_CZ805_A1_blk", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], [], _cupEliteRifleBipods], 0.75,
 
-	["CUP_arifle_ACR_DMR_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_arifle_ACR_DMR_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_arifle_ACR_DMR_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], _cupEliteRifleBipods], 1.5,
+	["CUP_arifle_ACR_DMR_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], _cupEliteRifleBipods], 0.5,
 
-	["CUP_arifle_ACR_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_ACR_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], ""],
+	["CUP_arifle_ACR_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], ""], 3,
+	["CUP_arifle_ACR_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], ""], 1,
 
-	["CUP_sgun_AA12", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","",["CUP_20Rnd_B_AA12_Buck_4","CUP_20Rnd_B_AA12_Buck_00","CUP_20Rnd_B_AA12_Slug","CUP_20Rnd_B_AA12_HE"], [], ""]
+	["CUP_sgun_AA12", "",cupEliteAttachments,"",["CUP_20Rnd_B_AA12_Buck_4","CUP_20Rnd_B_AA12_Buck_00","CUP_20Rnd_B_AA12_Slug","CUP_20Rnd_B_AA12_HE"], [], ""], 0.5
 ];
+
+_cupEliteMGOptics = ["CUP_optic_ElcanM145", 5, "CUP_optic_G33_HWS_BLK", 2, "CUP_optic_Eotech553_Black", 0.5, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2.5, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
+_cupEliteMGOptics762 = ["CUP_optic_ACOG_TA648_308_Black", 4, "CUP_optic_ACOG_TA648_308_RDS_Black", 1.5, "CUP_optic_G33_HWS_BLK", 2, "CUP_optic_Eotech553_Black", 0.75];
+_eliteMGOptics append ["CUP_optic_G33_HWS_BLK", 1.5, "CUP_optic_Eotech553_Black", 0.5, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 3, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
+
 (_eliteLoadoutData get "machineGuns") append [
-    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.5,
+	["CUP_arifle_XM8_SAW_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
+	["CUP_arifle_XM8_SAW_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_SAW_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
+	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_SAW_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.25,
+	["CUP_arifle_XM8_SAW", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
 
-	["CUP_lmg_Mk48_wdl", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_Mk48_nohg_wdl", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_Mk48_nohg_od", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_Mk48_nohg", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_Mk48_wdl", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 3,
+	["CUP_lmg_Mk48_nohg_wdl", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.75,
+	["CUP_lmg_Mk48_nohg_od", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.75,
+	["CUP_lmg_Mk48_nohg", "",_cupEliteAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
 
-	["CUP_lmg_Mk48_od", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_Mk48", "","CUP_acc_ANPEQ_2_Flashlight_OD_L","CUP_optic_ACOG_TA31_KF",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_Mk48_od", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1.5,
+	["CUP_lmg_Mk48", "",_cupEliteAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1.5,
 
-	["CUP_M60A4_EP1", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG_TA01B_RMR_Black",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_M60E4", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG_TA01B_RMR_Black",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	//["CUP_M60A4_EP1", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG_TA01B_RMR_Black",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], //no idea why this is here
+	["CUP_lmg_M60E4", "",_cupEliteAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.1,
 
-	["CUP_lmg_m249_para_gl", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_lmg_m249_para_gl", "",_cupEliteAttachments,"",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.1,
 
-	["CUP_lmg_m249_pip4", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG_TA31_KF",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
+	["CUP_lmg_m249_pip4", "",_cupEliteAttachments,_cupEliteMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 
-	["CUP_lmg_M240_B", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG2",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_M240_B", "",_cupEliteAttachments,_cupEliteMGOptics,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1,
 
-	["CUP_lmg_L110A1", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG2",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""]
+	["CUP_lmg_L110A1", "",_cupEliteAttachments,_cupEliteMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 0.5
 ];
+_cupEliteCarbineBipods = ["CUP_bipod_VLTOR_Modpod_black", 1, "", 6];
+_cupEliteGreenCarbineBipods = ["CUP_bipod_VLTOR_Modpod_od", 1, "", 6];
+
+_cupEliteCarbineOptics = ["CUP_optic_Eotech553_Black", 0.5, "CUP_optic_VortexRazor_UH1_black", 1, "CUP_optic_AC11704_black", 1, "CUP_optic_CompM4", 1];
+_cupEliteXM8CarbineOptics = ["CUP_optic_RCO_PCAP", 1, "CUP_optic_ISM_PCAP", 4];
+
 (_eliteLoadoutData get "carbines") append [
-	["CUP_arifle_XM8_Carbine_FG_Rail_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Carbine_FG_Rail","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Carbine_Rail_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Railed","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Rail_Green","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.5,
+	["CUP_arifle_XM8_Carbine_FG_Rail","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.25,
+	["CUP_arifle_XM8_Carbine_Rail_Green","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenCarbineBipods], 3,
+	["CUP_arifle_XM8_Railed","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [],  _cupEliteCarbineBipods], 1.5,
 
-	["CUP_arifle_XM8_Carbine_FG_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_FG","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Green","",_cupEliteGreenAttachments,_cupEliteXM8CarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenCarbineBipods], 0.5,
+	["CUP_arifle_XM8_Carbine_FG","",_cupEliteAttachments,_cupEliteXM8CarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteCarbineBipods], 0.25,
+	["CUP_arifle_XM8_Carbine_Green","",_cupEliteGreenAttachments,_cupEliteXM8CarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenCarbineBipods], 2,
+	["CUP_arifle_XM8_Carbine","",_cupEliteAttachments,_cupEliteXM8CarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteCarbineBipods], 1,
 
-	["CUP_arifle_xm29_ke_rail_olive","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_rail_blk","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_olive","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_blk","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
+	["CUP_arifle_xm29_ke_rail_olive","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.5,
+	["CUP_arifle_xm29_ke_rail_blk","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.25,
+	["CUP_arifle_xm29_ke_olive","",_cupEliteGreenAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.2,
+	["CUP_arifle_xm29_ke_blk","",_cupEliteAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.1,
 
-	["CUP_arifle_Mk17_CQC_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_CQC_FG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_CQC_FG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk17_CQC_Black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk17_CQC_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 1,
+	["CUP_arifle_Mk17_CQC_FG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.25,
+	["CUP_arifle_Mk17_CQC_FG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.1,
+	["CUP_arifle_Mk17_CQC_Black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.5,
 
-	["CUP_arifle_Mk17_CQC_SFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
-	["CUP_arifle_Mk17_CQC_SFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
+	["CUP_arifle_Mk17_CQC_SFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
+	["CUP_arifle_Mk17_CQC_SFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
-	["CUP_arifle_Mk17_CQC_AFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
-	["CUP_arifle_Mk17_CQC_AFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
+	["CUP_arifle_Mk17_CQC_AFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
+	["CUP_arifle_Mk17_CQC_AFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
-	["CUP_arifle_Mk16_CQC_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_CQC_FG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_CQC_FG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_CQC_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_CQC_AFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_Mk16_CQC_AFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk16_CQC_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 2,
+	["CUP_arifle_Mk16_CQC_FG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.5,
+	["CUP_arifle_Mk16_CQC_FG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.25,
+	["CUP_arifle_Mk16_CQC_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 1,
+	["CUP_arifle_Mk16_CQC_AFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.2,
+	["CUP_arifle_Mk16_CQC_AFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.1,
 
-	["CUP_arifle_Mk16_CQC_SFG_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
-	["CUP_arifle_Mk16_CQC_SFG_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], [], ""],
+	["CUP_arifle_Mk16_CQC_SFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
+	["CUP_arifle_Mk16_CQC_SFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
-	["CUP_arifle_SBR_od", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL_Tracer_Green"], [], ""],
+	["CUP_arifle_SBR_od", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_SBR_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL_Tracer_Green"], [], ""], 0.25,
 
-	["CUP_CZ_BREN2_556_8_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_CZ_BREN2_556_8", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_CZ_BREN2_556_8_Grn", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland"], [], _cupEliteCarbineBipods], 1,
+	["CUP_CZ_BREN2_556_8", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland"], [], _cupEliteCarbineBipods], 0.5,
 
-	["CUP_CZ_BREN2_762_8", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_CZ_BREN2_762_8_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_CZ_BREN2_762_8", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], _cupEliteCarbineBipods], 0.25,
+	["CUP_CZ_BREN2_762_8_Grn", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], [], _cupEliteCarbineBipods], 0.75,
 
-	["CUP_arifle_ACRC_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_ACRC_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], ""]
+	["CUP_arifle_ACRC_blk_68", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], ""], 3,
+	["CUP_arifle_ACRC_blk_556", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], ""], 1
 ];
 (_eliteLoadoutData get "grenadeLaunchers") append [
-   	["CUP_arifle_XM8_Carbine_GL_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+   	["CUP_arifle_XM8_Carbine_GL_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 4,
+	["CUP_arifle_XM8_Carbine_GL_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_XM8_Carbine_GL_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_XM8_Carbine_GL", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 
-	["CUP_arifle_xm29_olive", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	["CUP_arifle_xm29_blk", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	["CUP_arifle_xm29_olive", "",_cupEliteGreenAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 0.75,
+	["CUP_arifle_xm29_blk", "",_cupEliteAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 0.25,
 
-	["CUP_arifle_Mk17_STD_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_Mk17_STD_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_Mk17_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
+	["CUP_arifle_Mk17_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.25,
 
-	["CUP_arifle_Mk17_CQC_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_Mk17_CQC_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_Mk17_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
+	["CUP_arifle_Mk17_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.25,
 	
-	["CUP_arifle_Mk16_STD_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_Mk16_STD_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_Mk16_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_Mk16_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 	
-	["CUP_arifle_Mk16_CQC_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_Mk16_CQC_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_Mk16_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_Mk16_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 	
-	["CUP_arifle_HK_M27_AG36", "","CUP_acc_ANPEQ_2_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_RMR_black",["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_HK_M27_AG36", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 	
-	["CUP_CZ_BREN2_556_14_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_CZ_BREN2_556_14_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_CZ_BREN2_556_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
+	["CUP_CZ_BREN2_556_14_GL", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.25,
 
-	["CUP_CZ_BREN2_556_11_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_CZ_BREN2_556_11_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_CZ_BREN2_556_11_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
+	["CUP_CZ_BREN2_556_11_GL", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.25,
 
-	["CUP_CZ_BREN2_762_14_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_CZ_BREN2_762_14_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_CZ_BREN2_762_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.2,
+	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.1,
 
-	["CUP_arifle_CZ805_GL_blk", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_CZ805_GL_blk", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 
-	["CUP_arifle_ACRC_EGLM_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_ACRC_EGLM_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_ACRC_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_ACRC_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
-	["CUP_arifle_ACR_EGLM_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_ACR_EGLM_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""]
+	["CUP_arifle_ACR_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""] 0.75
 	
 ];
+_eliteMarksmanOptics append ["CUP_optic_SB_11_4x20_PM", 5, "CUP_optic_AN_PVS_10_black", 0.5];
 (_eliteLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_RSASS_Jungle","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_srifle_RSASS_Black","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_Mk20_woodland", "",_cupEliteGreenAttachments ,_eliteMarksmanOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_od"], 4,
+	["CUP_arifle_Mk20_black", "",_cupEliteAttachments,_eliteMarksmanOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_black"], 2,
 
-	["CUP_srifle_Mk12SPR","","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_arifle_Mk16_SV_woodland", "",_cupEliteGreenAttachments , _eliteMarksmanOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_Mk16_SV_black", "",_cupEliteAttachments, _eliteMarksmanOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
 
-	["CUP_srifle_M110_black","","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_m110_kac_black","","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"]
+    ["CUP_srifle_RSASS_Jungle","",_cupEliteGreenAttachments,_eliteMarksmanOptics,["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_srifle_RSASS_Black","",_cupEliteAttachments,_eliteMarksmanOptics,["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+
+	["CUP_srifle_Mk12SPR","",_cupEliteAttachments,_eliteMarksmanOptics,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
+
+	["CUP_srifle_M110_black","",_cupEliteAttachments,_eliteMarksmanOptics,["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"], 2,
+	["CUP_srifle_m110_kac_black","",_cupEliteAttachments,_eliteMarksmanOptics,["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.75
 ];
+_eliteSniperOptics append ["CUP_optic_LeupoldMk4", 5, "CUP_optic_LeupoldMk4_20x40_LRT", 3, "CUP_optic_LeupoldM3LR", 2, "CUP_optic_AN_PVS_10_black", 0.75, "CUP_optic_CWS", 0.5];
 (_eliteLoadoutData get "sniperRifles") append [
-    ["CUP_srifle_M2010_blk","","acc_pointer_IR","CUP_optic_LeupoldMk4",["CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_TE1_Red_Tracer_762x67_M2010_M"], [], "CUP_bipod_VLTOR_Modpod_black"],
+    ["CUP_srifle_M2010_blk","","acc_pointer_IR",_eliteSniperOptics,["CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_TE1_Red_Tracer_762x67_M2010_M"], [], "CUP_bipod_VLTOR_Modpod_black"], 3,
 
-	["CUP_srifle_M107_Pristine","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_M107_Base","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_srifle_M107_Pristine","","",_eliteSniperOptics,["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], ""], 4,
+	["CUP_srifle_M107_Base","","",_eliteSniperOptics,["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], ""], 2,
+	["CUP_srifle_M107_Woodland","","",_eliteSniperOptics,["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], ""], 0.5,
 
-	["CUP_srifle_AWM_blk","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_AWM_wdl","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_srifle_AWM_blk","","",_eliteSniperOptics,["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
+	["CUP_srifle_AWM_wdl","","",_eliteSniperOptics,["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
 
-	["CUP_srifle_G22_blk","","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_G22_wdl","","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_srifle_G22_blk","","",_eliteSniperOptics,["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
+	["CUP_srifle_G22_wdl","","",_eliteSniperOptics,["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.2,
 
-	["CUP_srifle_AS50","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M", "CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M"], [], ""]
+	["CUP_srifle_AS50","","",_eliteSniperOptics,["CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M", "CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M"], [], ""], 1.5
 ];   
 (_eliteLoadoutData get "designatedGrenadeLaunchers") append [
-    ["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""]
+    ["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""], 5
 ];
+
+_cupEliteSMGXM8Optics = ["CUP_optic_ISM_PCAP", 10];
 (_eliteLoadoutData get "SMGs") append [
-    ["CUP_arifle_XM8_Compact_FG_Rail_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Rail","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_Rail_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_Rail","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+    ["CUP_arifle_XM8_Compact_FG_Rail_Green","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.5,
+	["CUP_arifle_XM8_Compact_FG_Rail","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.25,
+	["CUP_arifle_XM8_Compact_Rail_Green","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 3,
+	["CUP_arifle_XM8_Compact_Rail","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1.5,
 
-	["CUP_arifle_XM8_Compact_FG_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Green","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_FG","","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG_Green","",_cupEliteGreenAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.2,
+	["CUP_arifle_XM8_Compact_FG","",_cupEliteAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.1,
+	["CUP_arifle_XM8_Compact_FG_Green","",_cupEliteGreenAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Compact_FG","",_cupEliteAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 
-	["CUP_smg_PS90_olive","","CUP_acc_ANPEQ_15_Top_Flashlight_OD_L","CUP_optic_Eotech553_OD",["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""],
-	["CUP_smg_EVO","","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""]
+	["CUP_smg_PS90_olive","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""], 1,
+	["CUP_smg_EVO","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 0.5
 ];
 //////////////////////////////////////////////////////
 _militarySlRifleSights append ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
@@ -446,6 +477,7 @@ _cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""] 0.75
 ];
 _militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
+_cupMilitaryG36RISOptics = ["CUP_optic_HoloBlack", 4, "CUP_optic_Eotech553_Black", 2, "CUP_optic_HensoldtZO_low", 1];
 
 (_militaryLoadoutData get "rifles") append [
    	["CUP_arifle_DSA_SA58_OSW_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.75,
@@ -468,35 +500,35 @@ _militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 
 	["CUP_arifle_L85A2_NG", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
 	["CUP_arifle_L85A2", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
 
-	["CUP_arifle_G36KA3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
-	["CUP_arifle_G36KA3_afg", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
-	["CUP_arifle_G36KA3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3_afg", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
-	["CUP_arifle_G36K_KSK_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
-	["CUP_arifle_G36K_KSK_AFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
-	["CUP_arifle_G36K_KSK", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36K_KSK_VFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36K_KSK_AFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36K_KSK", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 
-	["CUP_arifle_G36K_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2.5,
-	["CUP_arifle_G36A_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36K_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2.5,
+	["CUP_arifle_G36A_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
 	["CUP_arifle_G36K", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.75,
 	["CUP_arifle_G36E", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
 	["CUP_arifle_G36A", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
 
-	["CUP_arifle_G36A3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
-	["CUP_arifle_G36A3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2
+	["CUP_arifle_G36A3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36A3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2
 
 ];
 (_militaryLoadoutData get "carbines") append [
 	["CUP_arifle_Colt727", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 3,
 
-	["CUP_arifle_G36CA3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
-	["CUP_arifle_G36CA3_afg", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
-	["CUP_arifle_G36CA3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
+	["CUP_arifle_G36CA3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36CA3_afg", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36CA3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
 
-	["CUP_arifle_G36C_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1,
-	["CUP_arifle_G36C_VFG_Carry", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
-	["CUP_arifle_G36C", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 4
+	["CUP_arifle_G36C_VFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1,
+	["CUP_arifle_G36C_VFG_Carry", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
+	["CUP_arifle_G36C", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 4
 ];
 _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 (_militaryLoadoutData get "machineGuns") append [
@@ -506,7 +538,7 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 
 	["CUP_lmg_L110A1", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1,
 
-	["CUP_arifle_MG36", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag"], [], ""], 1.5,
+	["CUP_arifle_MG36", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag"], [], ""], 1.5,
 
 	["CUP_lmg_MG3_rail", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
 
@@ -522,12 +554,12 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 	
 	["CUP_arifle_L85A2_GL", "",_cupMilitaryAttachments,_cupMilitaryL85Optics,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 
-	["CUP_arifle_G36K_RIS_AG36", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
+	["CUP_arifle_G36K_RIS_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
 	["CUP_arifle_G36K_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 
-	["CUP_arifle_G36A3_AG36", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
+	["CUP_arifle_G36A3_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 	
-	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
+	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1
 ];

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -563,7 +563,7 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 
 	["CUP_arifle_G36A3_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 	
-	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
+	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1
 ];
@@ -680,10 +680,10 @@ _militiaMGSights = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 
 
 _militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "CUP_optic_LeupoldMk4_CQ_T", 7.5]; // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
+    ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
 
 	["CUP_srifle_M21", "","","CUP_optic_artel_m14",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 4,
-	["CUP_srifle_M21_ris", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
+	["CUP_srifle_M21_ris", "","",_militiaMarksmanSights,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
 
 ];
 _militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5];

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -1,4 +1,4 @@
-_CUPRPGOptics = ["CUP_optic_PGO7V", 3, "CUP_optic_PGO7V2", 2, "CUP_optic_PGO7V3", 1];
+_cupRPGOptics = ["CUP_optic_PGO7V", 3, "CUP_optic_PGO7V2", 2, "CUP_optic_PGO7V3", 1];
 
 (_loadoutData get "lightATLaunchers") append [
     ["CUP_launch_BF3", "", "", "", [], [], ""], 0.5,
@@ -6,21 +6,21 @@ _CUPRPGOptics = ["CUP_optic_PGO7V", 3, "CUP_optic_PGO7V2", 2, "CUP_optic_PGO7V3"
     ["CUP_launch_M72A6", "", "", "", [""], [], ""], 5,
 	["CUP_launch_HCPF3", "", "", "", [], [], ""], 0.5,
 	["CUP_launch_PzF3", "", "", "", [], [], ""], 1,
-	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""], 1.75,
-	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""], 0.5,
-	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""], 0.25
+	["CUP_launch_RPG7V", "", "", _cupRPGOptics, ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""], 1.75,
+	["CUP_launch_RPG7V", "", "", _cupRPGOptics, ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""], 0.5,
+	["CUP_launch_RPG7V", "", "", _cupRPGOptics, ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""], 0.25
 ];
 
-_CUPMAAAWSOptics = ["CUP_optic_MAAWS_Scope", 2, "", 1];
-_CUPSMAWOptics = ["CUP_optic_ACOG_TA01NSN_RMR_OD", 2, "", 1];
+_cupMAAAWSOptics = ["CUP_optic_MAAWS_Scope", 2, "", 1];
+_cupSMAWOptics = ["CUP_optic_ACOG_TA01NSN_RMR_OD", 2, "", 1];
 
 (_loadoutData get "ATLaunchers") append [
     ["CUP_launch_Javelin", "", "", "", ["CUP_Javelin_M", "CUP_Javelin_M"], [], ""], 0.5,
     ["CUP_launch_M47", "", "", "", ["CUP_Dragon_EP1_M", "CUP_Dragon_EP1_M"], [], ""], 2,
 	["CUP_launch_APILAS", "", "", "", ["CUP_APILAS_M", "CUP_APILAS_M"], [], ""], 1,
-	["CUP_launch_MAAWS", "", "", _CUPMAAAWSOptics, ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 2.5,
-	["CUP_launch_Mk153Mod0", "", "", _CUPSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 1.75,
-	["CUP_launch_Mk153Mod0_blk", "", "", _CUPSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 0.75
+	["CUP_launch_MAAWS", "", "", _cupMAAAWSOptics, ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 2.5,
+	["CUP_launch_Mk153Mod0", "", "", _cupSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 1.75,
+	["CUP_launch_Mk153Mod0_blk", "", "", _cupSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 0.75
 ];
 
 (_loadoutData get "AALaunchers") append [
@@ -148,47 +148,55 @@ _cupSFSniperOptics = ["CUP_optic_LeupoldMk4_20x40_LRT", 5, "CUP_optic_LeupoldMk4
 	["CUP_smg_EVO","CUP_muzzle_snds_MP5","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 3
 ];
 ////////////////////////////////////////////////
+_cupEliteGreenAttachments = ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 3, "CUP_acc_ANPEQ_15_OD", 2];
+_cupEliteAttachments = ["CUP_acc_ANPEQ_2_grey", 2, "CUP_acc_ANPEQ_15_black", 1.5, "CUP_acc_ANPEQ_15_Flashlight_Black_L", 3];
 
+_cupEliteGreenSlOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 1, "CUP_optic_Elcan_SpecterDR_RMR_od", 1.5, "CUP_optic_Elcan_SpecterDR_od", 2, "CUP_optic_Elcan_SpecterDR_KF_od", 0.5];
+_cupEliteSlOptics = ["CUP_optic_HensoldtZO_RDS", 3, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
+_cupEliteXM8Optics = ["CUP_optic_AMO_PCAP", 3, "CUP_optic_ISM_PCAP", 2];
 (_eliteLoadoutData get "slRifles") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Rail", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_xm29_olive", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	["CUP_arifle_xm29_blk", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	["CUP_arifle_xm29_olive", "",_cupEliteGreenAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	["CUP_arifle_xm29_blk", "",_cupEliteAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
 
-	["CUP_arifle_Mk17_STD_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk17_STD_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_Mk17_CQC_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk17_CQC_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk17_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_50Rnd_762x51_B_SCAR","CUP_50Rnd_TE1_Green_Tracer_762x51_SCAR","CUP_20Rnd_TE1_White_Tracer_762x51_SCAR_wdl","CUP_20Rnd_762x51_B_SCAR_wdl"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 	
-	["CUP_arifle_Mk16_STD_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk16_STD_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_STD_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_STD_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 	
-	["CUP_arifle_Mk16_CQC_EGLM_woodland", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_Mk16_CQC_EGLM_black", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ACOG_TA01B_OD",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_CQC_EGLM_woodland", "",_cupEliteGreenAttachments,_cupEliteGreenSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_Mk16_CQC_EGLM_black", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_60Rnd_556x45_SureFire"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 	
-	["CUP_arifle_HK_M27_AG36", "","CUP_acc_ANPEQ_2_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_RMR_black",["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_HK_M27_AG36", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag","CUP_30Rnd_556x45_Emag_Tracer_Green","CUP_30Rnd_556x45_Emag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 	
-	["CUP_CZ_BREN2_556_14_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_556_14_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_CZ_BREN2_556_11_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_556_11_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_11_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_556_11_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_CZ_BREN2_762_14_GL_Grn", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_CZ_BREN2_762_14_GL", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_762_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_CZ805_GL_blk", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_RDS",["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_CZ805_GL_blk", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_ACRC_EGLM_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_ACRC_EGLM_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_ACRC_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_ACRC_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_ACR_EGLM_blk_68", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_ACR_EGLM_blk_556", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_Elcan_SpecterDR_KF_RMR_black",["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
+	["CUP_arifle_ACR_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteSlOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
 ];
+
+_cupEliteRifleOptics = [];
+_cupEliteGreenRifleOptics = [];
 (_eliteLoadoutData get "rifles") append [
     ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
@@ -410,262 +418,277 @@ _cupSFSniperOptics = ["CUP_optic_LeupoldMk4_20x40_LRT", 5, "CUP_optic_LeupoldMk4
 	["CUP_smg_EVO","","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""]
 ];
 //////////////////////////////////////////////////////
+_militarySlRifleSights append ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
+_cupMilitarySlG36Optics = ["CUP_optic_Eotech553_Black", 1, "CUP_optic_HensoldtZO_low", 2];
+
+_cupMilitaryG36Optics = ["CUP_optic_G36DualOptics_3D", 4, "CUP_optic_G36Optics_3D", 2, "CUP_optic_G36Optics_Holo_3D", 1];
+_cupMilitaryL85Optics = ["CUP_optic_SUSAT", 2, "CUP_optic_HoloBlack", 1];
+
+_cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "CUP_acc_ANPEQ_15_Flashlight_Black_L", 1];
 
 (_militaryLoadoutData get "slRifles") append [
-    ["CUP_arifle_DSA_SA58_OSW_M203", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+    ["CUP_arifle_DSA_SA58_OSW_M203", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
-	["CUP_arifle_M4A1_GL_carryhandle", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_M4A1_BUIS_GL", "","","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 3,
+	["CUP_arifle_M4A1_BUIS_GL", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
-	["CUP_arifle_M16A4_GL", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_M16A4_GL", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 2,
 	
-	["CUP_arifle_L85A2_GL", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_L85A2_GL", "",_cupMilitaryAttachments, _cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
 
-	["CUP_arifle_G36K_RIS_AG36", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_G36K_RIS_AG36", "","CUP_acc_Flashlight","CUP_optic_G36DualOptics_3D",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_G36K_RIS_AG36", "",_cupMilitaryAttachments,_cupMilitarySlG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_G36K_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
-	["CUP_arifle_G36A3_AG36", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_G36A3_AG36", "",_cupMilitaryAttachments,_cupMilitarySlG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75,
 	
-	["CUP_arifle_G36A_AG36_RIS", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments,_cupMilitarySlG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5,
 
-	["CUP_arifle_AG36", "","CUP_acc_Flashlight","CUP_optic_G36DualOptics_3D",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
+	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""] 0.75
 ];
+_militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
+
 (_militaryLoadoutData get "rifles") append [
-   	["CUP_arifle_DSA_SA58_OSW_VFG", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
-   	["CUP_arifle_DSA_SA58_OSW", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
-   	["CUP_arifle_DSA_SA58_DMR", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
-   	["CUP_arifle_DSA_SA58", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
+   	["CUP_arifle_DSA_SA58_OSW_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.75,
+   	["CUP_arifle_DSA_SA58_OSW", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 1.5,
+   	["CUP_arifle_DSA_SA58_DMR", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
+   	["CUP_arifle_DSA_SA58", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 1,
 
-	["CUP_arifle_M4A3_black", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_M4A1", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_M4A1_standard_black", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_M4A1_black", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
+	["CUP_arifle_M4A3_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1,
+	["CUP_arifle_M4A1", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4,
+	["CUP_arifle_M4A1_standard_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.25,
+	["CUP_arifle_M4A1_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.75,
 
-	["CUP_arifle_M16A4_Grip", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_M16A4_Base", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
+	["CUP_arifle_M16A4_Grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.5,
+	["CUP_arifle_M16A4_Base", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4,
 
-	["CUP_arifle_M16A2", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
-	["CUP_arifle_M16A1E1", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
+	["CUP_arifle_M16A2", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2,
+	["CUP_arifle_M16A1E1", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 0.5,
 
-	["CUP_arifle_L85A2_G", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""],
-	["CUP_arifle_L85A2_NG", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""],
-	["CUP_arifle_L85A2", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""],
+	["CUP_arifle_L85A2_G", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
+	["CUP_arifle_L85A2_NG", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
+	["CUP_arifle_L85A2", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
 
-	["CUP_arifle_G36KA3_grip", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36KA3_afg", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36KA3", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36KA3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3_afg", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
-	["CUP_arifle_G36K_KSK_VFG", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36K_KSK_AFG", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36K_KSK", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36K_KSK_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36K_KSK_AFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36K_KSK", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 
-	["CUP_arifle_G36K_RIS", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36K_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2.5,
+	["CUP_arifle_G36A_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
-	["CUP_arifle_G36K_RIS", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36E", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36K", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.75,
+	["CUP_arifle_G36E", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
+	["CUP_arifle_G36A", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
 
-	["CUP_arifle_G36A3_grip", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36A3", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36A3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36A3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2
 
-	["CUP_arifle_G36A_RIS", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36A", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""]
 ];
 (_militaryLoadoutData get "carbines") append [
-	["CUP_arifle_Colt727", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""],
+	["CUP_arifle_Colt727", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 3,
 
-	["CUP_arifle_G36CA3_grip", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36CA3_afg", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36CA3", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
+	["CUP_arifle_G36CA3_grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36CA3_afg", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36CA3", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
 
-	["CUP_arifle_G36C_VFG", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36C_VFG_Carry", "","CUP_acc_Flashlight","CUP_optic_G36DualOptics_3D",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""],
-	["CUP_arifle_G36C", "","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""]
+	["CUP_arifle_G36C_VFG", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1,
+	["CUP_arifle_G36C_VFG_Carry", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
+	["CUP_arifle_G36C", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 4
 ];
+_cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 (_militaryLoadoutData get "machineGuns") append [
-    ["CUP_lmg_m249_pip4", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG_TA31_KF",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
+    ["CUP_lmg_m249_pip4", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 3,
 
-	["CUP_lmg_M240_B", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG2",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_M240_B", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
 
-	["CUP_lmg_L110A1", "","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_ACOG2",["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
+	["CUP_lmg_L110A1", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1,
 
-	["CUP_arifle_MG36", "","CUP_acc_Flashlight","CUP_optic_ACOG2",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag"], [], ""],
+	["CUP_arifle_MG36", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_TE1_Green_Tracer_556x45_BetaCMag"], [], ""], 1.5,
 
-	["CUP_lmg_MG3_rail", "","CUP_acc_Flashlight","CUP_optic_ACOG2",["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_MG3_rail", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
 
-	["CUP_M60A4_EP1", "","CUP_acc_Flashlight","CUP_optic_ACOG2",["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""]
+	["CUP_M60A4_EP1", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1
 ];
 (_militaryLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_DSA_SA58_OSW_M203", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+    ["CUP_arifle_DSA_SA58_OSW_M203", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 
-	["CUP_arifle_M4A1_GL_carryhandle", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_M4A1_BUIS_GL", "","","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 4,
+	["CUP_arifle_M4A1_BUIS_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
 
-	["CUP_arifle_M16A4_GL", "","CUP_acc_Flashlight","CUP_optic_Eotech553_Black",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_M16A4_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2.5,
 	
-	["CUP_arifle_L85A2_GL", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_L85A2_GL", "",_cupMilitaryAttachments,_cupMilitaryL85Optics,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 
-	["CUP_arifle_G36K_RIS_AG36", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_G36K_RIS_AG36", "","CUP_acc_Flashlight","CUP_optic_G36DualOptics_3D",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_G36K_RIS_AG36", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
+	["CUP_arifle_G36K_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 
-	["CUP_arifle_G36A3_AG36", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_G36A3_AG36", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 	
-	["CUP_arifle_G36A_AG36_RIS", "","CUP_acc_Flashlight","CUP_optic_SUSAT",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
-	["CUP_arifle_AG36", "","CUP_acc_Flashlight","CUP_optic_G36DualOptics_3D",["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""]
+	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1
 ];
+_militaryMarksmanSights append ["CUP_optic_LeupoldMk4", 3, "CUP_optic_LeupoldM3LR", 1];
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_M14_DMR", "","CUP_acc_Flashlight","CUP_optic_LeupoldMk4",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"]
+    ["CUP_srifle_M14_DMR", "",_cupMilitaryAttachments,_cupMilitaryMarksmanOptics ,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
+_cupMilitarySniperCamo = ["CUP_Mxx_camo", 1, "CUP_Mxx_camo_half", 1.5, "", 1];
+_militarySniperSights append ["CUP_optic_LeupoldMk4_20x40_LRT", 3];
 (_militaryLoadoutData get "sniperRifles") append [
-    ["CUP_srifle_M40A3","","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"],
-	["CUP_srifle_M40A3","","CUP_Mxx_camo_half","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"]
+	["CUP_srifle_M40A3","",_cupMilitarySniperCamo, _militarySniperSights,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
+_militarySMGSights append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
 (_militaryLoadoutData get "SMGs") append [
-    ["CUP_smg_MP7","","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_40Rnd_46x30_MP7_Green_Tracer"], [], ""],
+    ["CUP_smg_MP7","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_40Rnd_46x30_MP7_Green_Tracer"], [], ""], 2,
 
-	["CUP_smg_MP5SD6","","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""],
+	["CUP_smg_MP5SD6","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Subsonic_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 0.5,
 
-	["CUP_smg_MP5A5_Rail_VFG","","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""],
-	["CUP_smg_MP5A5_Rail_AFG","","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""],
-	["CUP_smg_MP5A5_Rail","","CUP_acc_Flashlight","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""]
+	["CUP_smg_MP5A5_Rail_VFG","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 1,
+	["CUP_smg_MP5A5_Rail_AFG","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 1,
+	["CUP_smg_MP5A5_Rail","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 5
 ];
 /////////////
 
 (_militiaLoadoutData get "slRifles") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["CUP_arifle_G3A3_modern_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
-	["CUP_arifle_G3A3_modern_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
+    ["CUP_arifle_G3A3_modern_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
+	["CUP_arifle_G3A3_modern_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 2,
 	
-	["CUP_arifle_G3A3_ris_vfg_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
-	["CUP_arifle_G3A3_ris_vfg", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
+	["CUP_arifle_G3A3_ris_vfg_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
+	["CUP_arifle_G3A3_ris_vfg", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
 
-	["CUP_arifle_G3A3_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
-	["CUP_arifle_G3A3_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""],
+	["CUP_arifle_G3A3_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.5,
+	["CUP_arifle_G3A3_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1,
 
-	["CUP_arifle_Steyr_Stg58_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
-	["CUP_arifle_Steyr_Stg58", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
+	["CUP_arifle_Steyr_Stg58_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
+	["CUP_arifle_Steyr_Stg58", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
 
-	["CUP_arifle_IMI_Romat", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
+	["CUP_arifle_IMI_Romat", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
 
-	["CUP_arifle_Gewehr1_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_Gewehr1", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
+	["CUP_arifle_Gewehr1_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_Gewehr1", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
 
-	["CUP_arifle_Fort222", "","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""],
+	["CUP_arifle_Fort222", "","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
 
-	["CUP_Famas_F1_Rail", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""],
-	["CUP_Famas_F1", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""],
+	["CUP_Famas_F1_Rail", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
+	["CUP_Famas_F1", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.1,
 
-	["CUP_arifle_FNFAL_OSW_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL_OSW", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5061_wooden_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5061_wooden", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
+	["CUP_arifle_FNFAL_OSW_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
+	["CUP_arifle_FNFAL_OSW", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5061_wooden_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL5061_wooden", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
 
-	["CUP_arifle_FNFAL_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5062_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5062", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5061_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5061", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5060_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
-	["CUP_arifle_FNFAL5060", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"],
+	["CUP_arifle_FNFAL_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
+	["CUP_arifle_FNFAL", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5062_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5062", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL5061_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.75,
+	["CUP_arifle_FNFAL5061", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.15,
+	["CUP_arifle_FNFAL5060_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 2,
+	["CUP_arifle_FNFAL5060", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
 
-	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""],
+	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""], 0.25,
 
-	["CUP_arifle_M16A1", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""],
+	["CUP_arifle_M16A1", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 6,
 
-	["CUP_srifle_M14", "","","",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""]
+	["CUP_srifle_M14", "","","",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
 ];
 (_militiaLoadoutData get "carbines") append [
-	["CUP_arifle_Fort224_Grippod","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""],
-	["CUP_arifle_Fort224","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""],
-	["CUP_arifle_Fort221","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""],
+	["CUP_arifle_Fort224_Grippod","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.1,
+	["CUP_arifle_Fort224","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
+	["CUP_arifle_Fort221","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
 
-	["CUP_arifle_X95_Grippod","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""],
-	["CUP_arifle_X95","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""],
+	["CUP_arifle_X95_Grippod","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_X95","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1.5,
 
-	["CUP_arifle_M4A1","","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""]
+	["CUP_arifle_M4A1","","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""]
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""]
+    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6
 ];
 (_militiaLoadoutData get "designatedGrenadeLaunchers") append [
-    ["CUP_glaunch_M79", "", "", "", ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203"], [], ""]
+    ["CUP_glaunch_M79", "", "", "", ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203"], [], ""], 5
 ];
 (_militiaLoadoutData get "machineGuns") append [
-    ["CUP_lmg_Mk48_nohg_wdl", "", "", "", ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+    ["CUP_lmg_Mk48_nohg_wdl", "", "", "", ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
 
-	["CUP_lmg_minimipara", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
-	["CUP_lmg_minimi_railed", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
-	["CUP_lmg_minimi", "", "", "", ["CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green"], [], ""],
+	["CUP_lmg_minimipara", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
+	["CUP_lmg_minimi_railed", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
+	["CUP_lmg_minimi", "", "", "", ["CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green"], [], ""], 6,
 
-	["CUP_lmg_MG3", "", "", "", ["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_MG3", "", "", "", ["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
 
-	["CUP_lmg_FNMAG", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_FNMAG", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 1.5,
 
-	["CUP_lmg_M60", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""],
+	["CUP_lmg_M60", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 3,
 
-	["CUP_lmg_M249_E2", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
-	["CUP_lmg_M249_E1", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""],
+	["CUP_lmg_M249_E2", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1,
+	["CUP_lmg_M249_E1", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 
-	["CUP_lmg_M240", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""],
-	["CUP_lmg_M240_norail", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""]
+	["CUP_lmg_M240", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 0.75,
+	["CUP_lmg_M240_norail", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 1
 ];
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["CUP_arifle_IMI_Romat_railed", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""],
+    ["CUP_arifle_IMI_Romat_railed", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
 
-	["CUP_srifle_M21", "","","CUP_optic_artel_m14",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""],
-	["CUP_srifle_M21_ris", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""]
+	["CUP_srifle_M21", "","","CUP_optic_artel_m14",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 4,
+	["CUP_srifle_M21_ris", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
 
 ];
 (_militiaLoadoutData get "sniperRifles") append [
-    ["CUP_srifle_Remington700","","","CUP_optic_Remington",["CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700"], [], ""],
-	["CUP_srifle_LeeEnfield_rail","","","CUP_optic_SB_11_4x20_PM",["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"],
-	["CUP_srifle_M24_blk","","","CUP_optic_SB_11_4x20_PM",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"]
+    ["CUP_srifle_Remington700","","","CUP_optic_Remington",["CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700"], [], ""], 1,
+	["CUP_srifle_LeeEnfield_rail","","","CUP_optic_SB_11_4x20_PM",["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
+	["CUP_srifle_M24_blk","","","CUP_optic_SB_11_4x20_PM",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 2
 ];
 ///////////
 
 (_policeLoadoutData get "sidearms") append [
-    ["CUP_hgun_Browning_HP", "", "", "", ["CUP_13Rnd_9x19_Browning_HP","CUP_13Rnd_9x19_Browning_HP"], [], ""],
-	["CUP_hgun_CZ75", "", "", "", ["CUP_hgun_CZ75","CUP_hgun_CZ75"], [], ""],
-	["CUP_hgun_Compact", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_10Rnd_9x19_Compact"], [], ""],
-	["CUP_hgun_Duty", "", "", "", ["16Rnd_9x21_Mag","16Rnd_9x21_green_Mag"], [], ""],
-	["CUP_hgun_Phantom", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_18Rnd_9x19_Phantom"], [], ""],
-	["CUP_hgun_Colt1911", "", "", "", ["CUP_7Rnd_45ACP_1911","CUP_7Rnd_45ACP_1911"], [], ""],
+    ["CUP_hgun_Browning_HP", "", "", "", ["CUP_13Rnd_9x19_Browning_HP","CUP_13Rnd_9x19_Browning_HP"], [], ""], 1,
 
-	["CUP_hgun_M9", "", "", "", ["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], ""],
-	["CUP_hgun_M9A1", "", "", "", ["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], ""],
+	["CUP_hgun_CZ75", "", "", "", ["CUP_hgun_CZ75","CUP_hgun_CZ75"], [], ""], 1.5,
+	["CUP_hgun_Compact", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_10Rnd_9x19_Compact"], [], ""], 2,
+	["CUP_hgun_Duty", "", "", "", ["16Rnd_9x21_Mag","16Rnd_9x21_green_Mag"], [], ""], 3,
+	["CUP_hgun_Phantom", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_18Rnd_9x19_Phantom"], [], ""], 2,
+	["CUP_hgun_Colt1911", "", "", "", ["CUP_7Rnd_45ACP_1911","CUP_7Rnd_45ACP_1911"], [], ""], 0.5,
 
-	["CUP_hgun_Mk23", "", "", "", ["CUP_12Rnd_45ACP_mk23","CUP_12Rnd_45ACP_mk23"], [], ""],
+	["CUP_hgun_M9", "", "", "", ["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], ""], 1.25,
+	["CUP_hgun_M9A1", "", "", "", ["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], ""], 0.75,
 
-	["CUP_hgun_P30L_blk", "", "", "", ["CUP_17Rnd_9x19_P30L","CUP_17Rnd_9x19_P30L"], [], ""],
-	["CUP_hgun_P30L_Match_blk", "", "", "", ["CUP_17Rnd_9x19_P30L","CUP_17Rnd_9x19_P30L"], [], ""],
+	["CUP_hgun_Mk23", "", "", "", ["CUP_12Rnd_45ACP_mk23","CUP_12Rnd_45ACP_mk23"], [], ""], 0.1,
 
-	["CUP_hgun_M17_Black", "", "", "", ["CUP_hgun_M17_Black","CUP_17Rnd_9x19_M17_Green"], [], ""],
+	["CUP_hgun_P30L_blk", "", "", "", ["CUP_17Rnd_9x19_P30L","CUP_17Rnd_9x19_P30L"], [], ""], 0.25,
+	["CUP_hgun_P30L_Match_blk", "", "", "", ["CUP_17Rnd_9x19_P30L","CUP_17Rnd_9x19_P30L"], [], ""], 0.1,
 
-	["CUP_hgun_Glock17_blk", "", "", "", ["CUP_17Rnd_9x19_glock17","CUP_17Rnd_9x19_glock17"], [], ""]
+	["CUP_hgun_M17_Black", "", "", "", ["CUP_hgun_M17_Black","CUP_17Rnd_9x19_M17_Green"], [], ""], 1,
+
+	["CUP_hgun_Glock17_blk", "", "", "", ["CUP_17Rnd_9x19_glock17","CUP_17Rnd_9x19_glock17"], [], ""], 1.5
 ];
+
 (_policeLoadoutData get "SMGs") append [
-    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""],
+    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6,
 
-	["CUP_sgun_SPAS12","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""],
+	["CUP_sgun_SPAS12","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""], 1,
 
-	["CUP_sgun_M1014_Entry_vfg","","","",["CUP_6Rnd_12Gauge_Pellets_No00_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Bird","CUP_6Rnd_12Gauge_Slug"], [], ""],
-	["CUP_sgun_M1014_Entry","","","",["CUP_6Rnd_12Gauge_Pellets_No00_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Bird","CUP_6Rnd_12Gauge_Slug"], [], ""],
-	["CUP_sgun_M1014_solidstock","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""],
-	["CUP_sgun_M1014_vfg","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""],
-	["CUP_sgun_M1014","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""],
+	["CUP_sgun_M1014_Entry_vfg","","","",["CUP_6Rnd_12Gauge_Pellets_No00_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Bird","CUP_6Rnd_12Gauge_Slug"], [], ""], 0.25,
+	["CUP_sgun_M1014_Entry","","","",["CUP_6Rnd_12Gauge_Pellets_No00_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Buck","CUP_6Rnd_12Gauge_Pellets_No4_Bird","CUP_6Rnd_12Gauge_Slug"], [], ""], 0.75,
+	["CUP_sgun_M1014_solidstock","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""], 0.75,
+	["CUP_sgun_M1014_vfg","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""], 0.5,
+	["CUP_sgun_M1014","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""], 1.5,
 
-	["CUP_sgun_CZ584_RIS","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""],
-	["CUP_sgun_CZ584","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""],
+	["CUP_sgun_CZ584_RIS","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""], 0.2,
+	["CUP_sgun_CZ584","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""], 0.2
 
-	["CUP_smg_BallisticShield_Sa61","","CUP_acc_SF_XC1","",["CUP_50Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_10Rnd_B_765x17_Ball_M"], [], "CUP_decal_BallisticShield_Police_worn"],
-	["CUP_smg_BallisticShield_PP19","","CUP_acc_Flashlight","",["CUP_30Rnd_9x19_Vityaz","CUP_30Rnd_9x19AP_Vityaz","CUP_10Rnd_9x19_Saiga9","CUP_10Rnd_9x19_Saiga9"], [], "CUP_decal_BallisticShield_Police_worn"],
-	["CUP_hgun_BallisticShield_PMM","","CUP_acc_LCU_PM_Laser","",["CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M"], [], "CUP_decal_BallisticShield_Police_worn"],
-	["CUP_smg_BallisticShield_MP7","","CUP_acc_Flashlight","",["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_20Rnd_46x30_MP7"], [], "CUP_decal_BallisticShield_Police_worn"],
-	["CUP_hgun_BallisticShield_Armed_M9","","CUP_acc_Glock17_Flashlight","",["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], "CUP_decal_BallisticShield_Police_worn"]
+	["CUP_smg_BallisticShield_Sa61","","CUP_acc_SF_XC1","",["CUP_50Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_10Rnd_B_765x17_Ball_M"], [], "CUP_decal_BallisticShield_Police_worn"], 0.2,
+	["CUP_smg_BallisticShield_PP19","","CUP_acc_Flashlight","",["CUP_30Rnd_9x19_Vityaz","CUP_30Rnd_9x19AP_Vityaz","CUP_10Rnd_9x19_Saiga9","CUP_10Rnd_9x19_Saiga9"], [], "CUP_decal_BallisticShield_Police_worn"], 0.2,
+	["CUP_hgun_BallisticShield_PMM","","CUP_acc_LCU_PM_Laser","",["CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M","CUP_12Rnd_9x18_PMM_M"], [], "CUP_decal_BallisticShield_Police_worn"], 0.2,
+	["CUP_smg_BallisticShield_MP7","","CUP_acc_Flashlight","",["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_20Rnd_46x30_MP7"], [], "CUP_decal_BallisticShield_Police_worn"], 0.5,
+	["CUP_hgun_BallisticShield_Armed_M9","","CUP_acc_Glock17_Flashlight","",["CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9","CUP_15Rnd_9x19_M9"], [], "CUP_decal_BallisticShield_Police_worn"], 0.5
 ];

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -450,6 +450,7 @@ _cupEliteSMGXM8Optics = ["CUP_optic_ISM_PCAP", 10];
 ];
 //////////////////////////////////////////////////////
 _militarySlRifleSights append ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
+_cupMilitarySlRifleOptics = ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
 _cupMilitarySlG36Optics = ["CUP_optic_Eotech553_Black", 1, "CUP_optic_HensoldtZO_low", 2];
 
 _cupMilitaryG36Optics = ["CUP_optic_G36DualOptics_3D", 4, "CUP_optic_G36Optics_3D", 2, "CUP_optic_G36Optics_Holo_3D", 1];
@@ -477,6 +478,7 @@ _cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""] 0.75
 ];
 _militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
+_cupMilitaryRifleOptics = ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
 _cupMilitaryG36RISOptics = ["CUP_optic_HoloBlack", 4, "CUP_optic_Eotech553_Black", 2, "CUP_optic_HensoldtZO_low", 1];
 
 (_militaryLoadoutData get "rifles") append [
@@ -564,8 +566,9 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1
 ];
 _militaryMarksmanSights append ["CUP_optic_LeupoldMk4", 3, "CUP_optic_LeupoldM3LR", 1];
+
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_M14_DMR", "",_cupMilitaryAttachments,_cupMilitaryMarksmanOptics ,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
+    ["CUP_srifle_M14_DMR", "",_cupMilitaryAttachments, _militaryMarksmanSights ,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
 _cupMilitarySniperCamo = ["CUP_Mxx_camo", 1, "CUP_Mxx_camo_half", 1.5, "", 1];
 _militarySniperSights append ["CUP_optic_LeupoldMk4_20x40_LRT", 3];
@@ -573,6 +576,7 @@ _militarySniperSights append ["CUP_optic_LeupoldMk4_20x40_LRT", 3];
 	["CUP_srifle_M40A3","",_cupMilitarySniperCamo, _militarySniperSights,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
 _militarySMGSights append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
+_cupMilitarySMGOptics = ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
 (_militaryLoadoutData get "SMGs") append [
     ["CUP_smg_MP7","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_40Rnd_46x30_MP7_Green_Tracer"], [], ""], 2,
 

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -551,77 +551,79 @@ _militarySMGSights append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black"
 	["CUP_smg_MP5A5_Rail","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 5
 ];
 /////////////
-
+_militiaSlRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
+_militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
 (_militiaLoadoutData get "slRifles") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5 // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];
 (_militiaLoadoutData get "rifles") append [
-    ["CUP_arifle_G3A3_modern_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
-	["CUP_arifle_G3A3_modern_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 2,
+    ["CUP_arifle_G3A3_modern_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
+	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 2,
 	
-	["CUP_arifle_G3A3_ris_vfg_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
-	["CUP_arifle_G3A3_ris_vfg", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
+	["CUP_arifle_G3A3_ris_vfg_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
+	["CUP_arifle_G3A3_ris_vfg", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
 
-	["CUP_arifle_G3A3_ris_black", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.5,
-	["CUP_arifle_G3A3_ris", "","","",["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1,
+	["CUP_arifle_G3A3_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.5,
+	["CUP_arifle_G3A3_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1,
 
-	["CUP_arifle_Steyr_Stg58_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
-	["CUP_arifle_Steyr_Stg58", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
+	["CUP_arifle_Steyr_Stg58_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
+	["CUP_arifle_Steyr_Stg58", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
 
-	["CUP_arifle_IMI_Romat", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
+	["CUP_arifle_IMI_Romat", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
 
-	["CUP_arifle_Gewehr1_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_Gewehr1", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_Gewehr1_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_Gewehr1", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
 
-	["CUP_arifle_Fort222", "","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
+	["CUP_arifle_Fort222", "",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
 
-	["CUP_Famas_F1_Rail", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
+	["CUP_Famas_F1_Rail", "",_militiaAttachments,_militiaRifleSights,["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
 	["CUP_Famas_F1", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.1,
 
-	["CUP_arifle_FNFAL_OSW_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
-	["CUP_arifle_FNFAL_OSW", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5061_wooden_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_FNFAL5061_wooden", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL_OSW_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
+	["CUP_arifle_FNFAL_OSW", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5061_wooden_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL5061_wooden", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
 
-	["CUP_arifle_FNFAL_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
-	["CUP_arifle_FNFAL", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5062_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5062", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_FNFAL5061_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.75,
-	["CUP_arifle_FNFAL5061", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.15,
-	["CUP_arifle_FNFAL5060_railed", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 2,
-	["CUP_arifle_FNFAL5060", "","","",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
+	["CUP_arifle_FNFAL", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5062_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL5062", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.75,
+	["CUP_arifle_FNFAL5061", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.15,
+	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 2,
+	["CUP_arifle_FNFAL5060", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
 
 	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""], 0.25,
 
-	["CUP_arifle_M16A1", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 6,
+	["CUP_arifle_M16A1", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 6,
 
-	["CUP_srifle_M14", "","","",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
+	["CUP_srifle_M14", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
 ];
 (_militiaLoadoutData get "carbines") append [
-	["CUP_arifle_Fort224_Grippod","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.1,
-	["CUP_arifle_Fort224","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
-	["CUP_arifle_Fort221","","","",["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
+	["CUP_arifle_Fort224_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.1,
+	["CUP_arifle_Fort224","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
+	["CUP_arifle_Fort221","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
 
-	["CUP_arifle_X95_Grippod","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.75,
-	["CUP_arifle_X95","","","",["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1.5,
+	["CUP_arifle_X95_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_X95","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1.5,
 
-	["CUP_arifle_M4A1","","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
+	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""]
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""] // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6
+    ["CUP_smg_MP5A5","", _militiaAttachments,_militiaSMGsights,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6
 ];
 (_militiaLoadoutData get "designatedGrenadeLaunchers") append [
     ["CUP_glaunch_M79", "", "", "", ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203"], [], ""], 5
 ];
+_militiaMGSights = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
 (_militiaLoadoutData get "machineGuns") append [
-    ["CUP_lmg_Mk48_nohg_wdl", "", "", "", ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
+    ["CUP_lmg_Mk48_nohg_wdl", "", _militiaAttachments, _militiaMGSights, ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
 
 	["CUP_lmg_minimipara", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
-	["CUP_lmg_minimi_railed", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
+	["CUP_lmg_minimi_railed", "", "", _militiaMGSights, ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 	["CUP_lmg_minimi", "", "", "", ["CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green"], [], ""], 6,
 
 	["CUP_lmg_MG3", "", "", "", ["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
@@ -633,20 +635,23 @@ _militarySMGSights append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black"
 	["CUP_lmg_M249_E2", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1,
 	["CUP_lmg_M249_E1", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 
-	["CUP_lmg_M240", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 0.75,
+	["CUP_lmg_M240", "", "", _militiaMGSights, ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 0.75,
 	["CUP_lmg_M240_norail", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 1
 ];
+
+_militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "Leupold Mk4 CQ/T 1-3x14mm", 7.5] // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["CUP_arifle_IMI_Romat_railed", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
+    ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
 
 	["CUP_srifle_M21", "","","CUP_optic_artel_m14",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 4,
-	["CUP_srifle_M21_ris", "","","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
+	["CUP_srifle_M21_ris", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
 
 ];
+_militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5]
 (_militiaLoadoutData get "sniperRifles") append [
     ["CUP_srifle_Remington700","","","CUP_optic_Remington",["CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700"], [], ""], 1,
-	["CUP_srifle_LeeEnfield_rail","","","CUP_optic_SB_11_4x20_PM",["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
-	["CUP_srifle_M24_blk","","","CUP_optic_SB_11_4x20_PM",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 2
+	["CUP_srifle_LeeEnfield_rail","","",_militiaSniperSights,["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
+	["CUP_srifle_M24_blk","","",_militiaSniperSights,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 2
 ];
 ///////////
 

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -59,7 +59,7 @@ _cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_gree
 	["CUP_arifle_XM8_Sharpshooter_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
 	["CUP_arifle_XM8_Sharpshooter_FG_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
-	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
+	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_Sharpshooter_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 ];
@@ -280,7 +280,7 @@ _eliteMGOptics append ["CUP_optic_G33_HWS_BLK", 1.5, "CUP_optic_Eotech553_Black"
 	["CUP_arifle_XM8_SAW_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
 	["CUP_arifle_XM8_SAW_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 	["CUP_arifle_XM8_SAW_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
-	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.5
+	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.5,
 	["CUP_arifle_XM8_SAW_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.25,
 	["CUP_arifle_XM8_SAW_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_SAW", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
@@ -396,7 +396,7 @@ _cupEliteXM8CarbineOptics = ["CUP_optic_RCO_PCAP", 1, "CUP_optic_ISM_PCAP", 4];
 	["CUP_arifle_ACRC_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
 	["CUP_arifle_ACR_EGLM_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
-	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""] 0.75
+	["CUP_arifle_ACR_EGLM_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75
 	
 ];
 _eliteMarksmanOptics append ["CUP_optic_SB_11_4x20_PM", 5, "CUP_optic_AN_PVS_10_black", 0.5];
@@ -678,7 +678,7 @@ _militiaMGSights = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 
 	["CUP_lmg_M240_norail", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 1
 ];
 
-_militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "Leupold Mk4 CQ/T 1-3x14mm", 7.5] // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
+_militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "CUP_optic_LeupoldMk4_CQ_T", 7.5]; // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
 (_militiaLoadoutData get "marksmanRifles") append [
     ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
 
@@ -686,7 +686,7 @@ _militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "Leupold Mk4 CQ/T
 	["CUP_srifle_M21_ris", "","",_militiaMarksmanSight,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
 
 ];
-_militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5]
+_militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5];
 (_militiaLoadoutData get "sniperRifles") append [
     ["CUP_srifle_Remington700","","","CUP_optic_Remington",["CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700"], [], ""], 1,
 	["CUP_srifle_LeeEnfield_rail","","",_militiaSniperSights,["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
@@ -728,7 +728,7 @@ _militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5]
 	["CUP_sgun_M1014","","","",["CUP_8Rnd_12Gauge_Pellets_No00_Buck","CUP_8Rnd_12Gauge_Pellets_No4_Buck","CUP_8Rnd_12Gauge_Slug","CUP_8Rnd_12Gauge_Slug"], [], ""], 1.5,
 
 	["CUP_sgun_CZ584_RIS","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""], 0.2,
-	["CUP_sgun_CZ584","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""], 0.2
+	["CUP_sgun_CZ584","","","",["CUP_1Rnd_12Gauge_Pellets_No00_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Buck","CUP_1Rnd_12Gauge_Pellets_No4_Bird","CUP_1Rnd_12Gauge_Slug"], ["CUP_1Rnd_762x51_CZ584","CUP_1Rnd_762x51_CZ584"], ""], 0.2,
 
 	["CUP_smg_BallisticShield_Sa61","","CUP_acc_SF_XC1","",["CUP_50Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_20Rnd_B_765x17_Ball_M","CUP_10Rnd_B_765x17_Ball_M"], [], "CUP_decal_BallisticShield_Police_worn"], 0.2,
 	["CUP_smg_BallisticShield_PP19","","CUP_acc_Flashlight","",["CUP_30Rnd_9x19_Vityaz","CUP_30Rnd_9x19AP_Vityaz","CUP_10Rnd_9x19_Saiga9","CUP_10Rnd_9x19_Saiga9"], [], "CUP_decal_BallisticShield_Police_worn"], 0.2,

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -451,7 +451,7 @@ _cupEliteSMGXM8Optics = ["CUP_optic_ISM_PCAP", 10];
 	["CUP_smg_EVO","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 0.5
 ];
 //////////////////////////////////////////////////////
-_militarySlRifleSights append ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
+_militarySlRifleOptics append ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
 _cupMilitarySlRifleOptics = ["CUP_optic_RCO", 6, "CUP_optic_Eotech553_Black", 2];
 _cupMilitarySlG36Optics = ["CUP_optic_Eotech553_Black", 1, "CUP_optic_HensoldtZO_low", 2];
 
@@ -479,7 +479,7 @@ _cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "
 
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75
 ];
-_militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
+_militaryRifleOptics append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
 _cupMilitaryRifleOptics = ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
 _cupMilitaryG36RISOptics = ["CUP_optic_HoloBlack", 4, "CUP_optic_Eotech553_Black", 2, "CUP_optic_HensoldtZO_low", 1];
 
@@ -569,17 +569,17 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 
 	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1
 ];
-_militaryMarksmanSights append ["CUP_optic_LeupoldMk4", 3, "CUP_optic_LeupoldM3LR", 1];
+_militaryMarksmanOptics append ["CUP_optic_LeupoldMk4", 3, "CUP_optic_LeupoldM3LR", 1];
 
 (_militaryLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_M14_DMR", "",_cupMilitaryAttachments, _militaryMarksmanSights ,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
+    ["CUP_srifle_M14_DMR", "",_cupMilitaryAttachments, _militaryMarksmanOptics ,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
 _cupMilitarySniperCamo = ["CUP_Mxx_camo", 1, "CUP_Mxx_camo_half", 1.5, "", 1];
-_militarySniperSights append ["CUP_optic_LeupoldMk4_20x40_LRT", 3];
+_militarySniperOptics append ["CUP_optic_LeupoldMk4_20x40_LRT", 3];
 (_militaryLoadoutData get "sniperRifles") append [
-	["CUP_srifle_M40A3","",_cupMilitarySniperCamo, _militarySniperSights,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
+	["CUP_srifle_M40A3","",_cupMilitarySniperCamo, _militarySniperOptics,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 5
 ];
-_militarySMGSights append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
+_militarySMGOptics append ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
 _cupMilitarySMGOptics = ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 3];
 (_militaryLoadoutData get "SMGs") append [
     ["CUP_smg_MP7","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7","CUP_40Rnd_46x30_MP7_Green_Tracer","CUP_40Rnd_46x30_MP7_Green_Tracer"], [], ""], 2,
@@ -591,64 +591,64 @@ _cupMilitarySMGOptics = ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 
 	["CUP_smg_MP5A5_Rail","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 5
 ];
 /////////////
-_militiaSlRifleSights append ["CUP_optic_Aimpoint_5000", 2.5, "CUP_optic_AC11704_Black", 0.75, "CUP_optic_HoloBlack", 0.75];
-_militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_Black", 0.2, "CUP_optic_HoloBlack", 0.2];
+_militiaSlRifleOptics append ["CUP_optic_Aimpoint_5000", 2.5, "CUP_optic_AC11704_Black", 0.75, "CUP_optic_HoloBlack", 0.75];
+_militiaRifleOptics append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_Black", 0.2, "CUP_optic_HoloBlack", 0.2];
 (_militiaLoadoutData get "slRifles") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5 // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5 // No optic since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];
 _cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 (_militiaLoadoutData get "rifles") append [
-    ["CUP_arifle_G3A3_modern_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
-	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1.75,
+    ["CUP_arifle_G3A3_modern_ris_black", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
+	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1.75,
 	
-	["CUP_arifle_G3A3_ris_vfg_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
-	["CUP_arifle_G3A3_ris_vfg", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
+	["CUP_arifle_G3A3_ris_vfg_black", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
+	["CUP_arifle_G3A3_ris_vfg", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
 
-	["CUP_arifle_G3A3_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.5,
-	["CUP_arifle_G3A3_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1,
+	["CUP_arifle_G3A3_ris_black", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.5,
+	["CUP_arifle_G3A3_ris", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1,
 
-	["CUP_arifle_Steyr_Stg58_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
+	["CUP_arifle_Steyr_Stg58_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
 	["CUP_arifle_Steyr_Stg58", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.1,
 
 	["CUP_arifle_IMI_Romat", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
 
-	["CUP_arifle_Gewehr1_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
+	["CUP_arifle_Gewehr1_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 	["CUP_arifle_Gewehr1", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 
-	["CUP_arifle_Fort222", "",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
+	["CUP_arifle_Fort222", "",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
 
-	["CUP_Famas_F1_Rail", "",_militiaAttachments,_militiaRifleSights,["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
+	["CUP_Famas_F1_Rail", "",_militiaAttachments,_militiaRifleOptics,["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
 	["CUP_Famas_F1", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.1,
 
-	["CUP_arifle_FNFAL_OSW_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
+	["CUP_arifle_FNFAL_OSW_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
 	["CUP_arifle_FNFAL_OSW", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
-	["CUP_arifle_FNFAL5061_wooden_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
+	["CUP_arifle_FNFAL5061_wooden_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 	["CUP_arifle_FNFAL5061_wooden", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 
-	["CUP_arifle_FNFAL_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
+	["CUP_arifle_FNFAL_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
 	["CUP_arifle_FNFAL", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
-	["CUP_arifle_FNFAL5062_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
+	["CUP_arifle_FNFAL5062_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
 	["CUP_arifle_FNFAL5062", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
-	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.75,
+	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.75,
 	["CUP_arifle_FNFAL5061", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.15,
-	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1.5,
+	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1.5,
 	["CUP_arifle_FNFAL5060", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
 
 	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""], 0.25,
 
-	["CUP_arifle_M16A1", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 5, //relatively high because this is one of the only non-battle rifles
+	["CUP_arifle_M16A1", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 5, //relatively high because this is one of the only non-battle rifles
 
-	["CUP_srifle_M14", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
+	["CUP_srifle_M14", "",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
 ];
 (_militiaLoadoutData get "carbines") append [
-	["CUP_arifle_Fort224_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.1,
-	["CUP_arifle_Fort224","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
-	["CUP_arifle_Fort221","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
+	["CUP_arifle_Fort224_Grippod","",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.1,
+	["CUP_arifle_Fort224","",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
+	["CUP_arifle_Fort221","",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
 
-	["CUP_arifle_X95_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.5,
-	["CUP_arifle_X95","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1,
+	["CUP_arifle_X95_Grippod","",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_X95","",_militiaAttachments,_militiaRifleOptics,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1,
 
-	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2
+	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleOptics,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 8
@@ -659,12 +659,12 @@ _cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 (_militiaLoadoutData get "designatedGrenadeLaunchers") append [
     ["CUP_glaunch_M79", "", "", "", ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203"], [], ""], 5
 ];
-_militiaMGSights = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
+_militiaMGOptics = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
 (_militiaLoadoutData get "machineGuns") append [
-    ["CUP_lmg_Mk48_nohg_wdl", "", _militiaAttachments, _militiaMGSights, ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
+    ["CUP_lmg_Mk48_nohg_wdl", "", _militiaAttachments, _militiaMGOptics, ["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
 
 	["CUP_lmg_minimipara", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
-	["CUP_lmg_minimi_railed", "", "", _militiaMGSights, ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
+	["CUP_lmg_minimi_railed", "", "", _militiaMGOptics, ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 	["CUP_lmg_minimi", "", "", "", ["CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green","CUP_60Rnd_556x45_SureFire_Tracer_Green"], [], ""], 6,
 
 	["CUP_lmg_MG3", "", "", "", ["CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_120Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.5,
@@ -676,23 +676,23 @@ _militiaMGSights = ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 
 	["CUP_lmg_M249_E2", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1,
 	["CUP_lmg_M249_E1", "", "", "", ["CUP_100Rnd_TE4_Green_Tracer_556x45_M249","CUP_100Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 1.5,
 
-	["CUP_lmg_M240", "", "", _militiaMGSights, ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 0.75,
+	["CUP_lmg_M240", "", "", _militiaMGOptics, ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 0.75,
 	["CUP_lmg_M240_norail", "", "", "", ["CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_White_Tracer_762x51_Belt_M"], [], ""], 1
 ];
 
-_militiaMarksmanSights append ["CUP_optic_SB_11_4x20_PM", 0.5, "CUP_optic_LeupoldMk4_CQ_T", 7.5]; // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
+_militiaMarksmanOptics append ["CUP_optic_SB_11_4x20_PM", 0.5, "CUP_optic_LeupoldMk4_CQ_T", 7.5]; // Shortdot is pretty good for early game DMR scopes, so make it pretty rare.
 (_militiaLoadoutData get "marksmanRifles") append [
-    ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
+    ["CUP_arifle_IMI_Romat_railed", "","",_militiaMarksmanOptics,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.2,
 
 	["CUP_srifle_M21", "","","CUP_optic_artel_m14",["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 4,
-	["CUP_srifle_M21_ris", "","",_militiaMarksmanSights,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
+	["CUP_srifle_M21_ris", "","",_militiaMarksmanOptics,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 2
 
 ];
-_militiaSniperSights append ["CUP_optic_SB_11_4x20_PM", 7.5];
+_militiaSniperOptics append ["CUP_optic_SB_11_4x20_PM", 7.5];
 (_militiaLoadoutData get "sniperRifles") append [
     ["CUP_srifle_Remington700","","","CUP_optic_Remington",["CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700","CUP_6Rnd_762x51_R700"], [], ""], 1,
-	["CUP_srifle_LeeEnfield_rail","","",_militiaSniperSights,["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
-	["CUP_srifle_M24_blk","","",_militiaSniperSights,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 2
+	["CUP_srifle_LeeEnfield_rail","","",_militiaSniperOptics,["CUP_10x_303_M","CUP_10x_303_M","CUP_10x_303_M"], [], "CUP_bipod_Harris_1A2_L_BLK"], 0.25,
+	["CUP_srifle_M24_blk","","",_militiaSniperOptics,["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"], 2
 ];
 ///////////
 

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -1,9 +1,36 @@
-(_loadoutData get "lightATLaunchers") append [
-    ["CUP_launch_BF3", "", "", "", [], [], ""],
-    ["CUP_launch_M136", "", "", "", [], [], ""],
-    ["CUP_launch_M72A6", "", "", "", [""], [], ""],
-	["CUP_launch_HCPF3", "", "", "", [], [], ""],
-	["CUP_launch_PzF3", "", "", "", [], [], ""],
+//given CUP has proper disposable AT we'll remove the MAAWS as a light launcher entirely
+_militiaLoadoutData set ["lightATLaunchers", [
+	["CUP_launch_M72A6", "", "", "", [""], [], ""], 10
+]];
+_militiaLoadoutData set ["ATLaunchers", [
+	["CUP_launch_MAAWS", "", "", "", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 9,
+	["CUP_launch_MAAWS", "", "", "CUP_optic_MAAWS_Scope", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 1
+]];
+_militiaLoadoutData set ["missileATLaunchers", [
+	["CUP_launch_M47", "", "", "", ["CUP_Dragon_EP1_M", "CUP_Dragon_EP1_M"], [], ""], 10
+	]];
+_militiaLoadoutData set ["AALaunchers", [
+	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""], 10
+]];
+
+_militaryLoadoutData set ["lightATLaunchers", [
+	["CUP_launch_M72A6", "", "", "", [""], [], ""], 5, 
+	["CUP_launch_M136", "", "", "", [], [], ""], 5
+]];
+(_militaryloadoutData get "AALaunchers") append [
+	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""], 6
+];
+
+_eliteLoadoutData set ["lightATLaunchers", [
+	["CUP_launch_HCPF3", "", "", "", [], [], ""], 3,
+	["CUP_launch_PzF3", "", "", "", [], [], ""], 6,
+	["CUP_launch_BF3", "", "", "", [], [], ""], 1
+]];
+
+/*(_loadoutData get "lightATLaunchers") append [
+    
+	
+	
 	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V", ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""],
 	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V2", ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""],
 	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V3", ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""],
@@ -13,10 +40,10 @@
 	["CUP_launch_RPG7V", "", "", "", ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""],
 	["CUP_launch_RPG7V", "", "", "", ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""],
 	["CUP_launch_RPG7V", "", "", "", ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""]
-];
-(_loadoutData get "ATLaunchers") append [
+];*/
+/*(_loadoutData get "ATLaunchers") append [
     ["CUP_launch_Javelin", "", "", "", ["CUP_Javelin_M", "CUP_Javelin_M"], [], ""],
-    ["CUP_launch_M47", "", "", "", ["CUP_Dragon_EP1_M", "CUP_Dragon_EP1_M"], [], ""],
+    
 	["CUP_launch_APILAS", "", "", "", ["CUP_APILAS_M", "CUP_APILAS_M"], [], ""],
 	["CUP_launch_MAAWS", "", "", "", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""],
 	["CUP_launch_MAAWS", "", "", "CUP_optic_MAAWS_Scope", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""],
@@ -24,80 +51,100 @@
 	["CUP_launch_Mk153Mod0", "", "", "", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""],
 	["CUP_launch_Mk153Mod0_blk", "", "", "CUP_optic_ACOG_TA01NSN_RMR_OD", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""],
 	["CUP_launch_Mk153Mod0_blk", "", "", "", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""]
-];
+];*/
 
-(_loadoutData get "AALaunchers") append [
+/*(_loadoutData get "AALaunchers") append [
     ["CUP_launch_9K32Strela", "", "", "", [], [], ""],
 	["CUP_launch_Igla", "", "", "", [], [], ""],
 	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""]
-];
+];*/
+
+// General TODO:
+// - Set up overrides on categories where vanilla weapons just straight up won't appear (e.g., elites, SF)
+// - This means basically checking to see if vanilla weapons are present in the loadoutData (since OTHER compats might also have overridden them, and we don't want to override THOSE)
 
 ////////////////////////////////////
-(_sfLoadoutData get "slRifles") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
-	["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	["CUP_arifle_xm29_blk", "UP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
+_cupSFRifleOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 5, "CUP_optic_Elcan_SpecterDR_RMR_od", 2, "CUP_optic_Eotech553_OD", 3];
+_cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 8, "CUP_optic_ISM_PCAP_green", 2]
+_cupSFSlRifleOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 7, "CUP_optic_Elcan_SpecterDR_RMR_od", 3];
+_cupSFSlRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 4, "CUP_optic_ISM_PCAP_green", 6];
+_cupSFAttachments = ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 6, "CUP_acc_ANPEQ_15_OD", 4];
+
+
+(_sfLoadoutData get "slRifles") append [
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8", _cupSFAttachments, _cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+
+	//["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	//["CUP_arifle_xm29_blk", "UP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
 
 ];
 (_sfLoadoutData get "rifles") append [
-    ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"]
+    ["CUP_arifle_XM8_Carbine_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"]
 ];
-(_sfLoadoutData get "machineGuns") append [
-    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"]
-];
+
+
 (_sfLoadoutData get "carbines") append [
-	["CUP_arifle_XM8_Carbine_FG_Rail_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Carbine_FG_Rail","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Carbine_Rail_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Railed","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
-	["CUP_arifle_XM8_Carbine_FG_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_FG","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
-	["CUP_arifle_xm29_ke_rail_olive","CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_rail_blk","CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_olive","CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""]
+	//["CUP_arifle_xm29_ke_rail_olive","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
+	//["CUP_arifle_xm29_ke_rail_blk","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
+	//["CUP_arifle_xm29_ke_olive","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
+	//["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""]
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
 
-	["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	["CUP_arifle_xm29_blk", "CUP_muzzle_snds_G36_black","CUP_acc_ANPEQ_15_Flashlight_OD_L","",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
+	//["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
+	//["CUP_arifle_xm29_blk", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
 
 ];
-(_sfLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_RSASS_Jungle","CUP_muzzle_snds_socom762rc","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_srifle_RSASS_Black","CUP_muzzle_snds_socom762rc","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
-	["CUP_srifle_Mk12SPR","CUP_muzzle_snds_Mk12","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
+_cupSFMGOptics = [];
+//TODO: add Mk48 LMGs or some other belt feds
+(_sfLoadoutData get "machineGuns") append [
+    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_FG_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_FG", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"]
+];
+_cupSFMarksmanOptics = [];
+(_sfLoadoutData get "marksmanRifles") append [
+    ["CUP_srifle_RSASS_Jungle","CUP_muzzle_snds_socom762rc",_cupSFAttachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_srifle_RSASS_Black","CUP_muzzle_snds_socom762rc",_cupSFAttachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	
+	//underpowered
+	//["CUP_srifle_Mk12SPR","CUP_muzzle_snds_Mk12","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
 
 	["CUP_srifle_M110_black","CUP_muzzle_snds_M110_black","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"],
 	["CUP_srifle_m110_kac_black","CUP_muzzle_snds_M110_black","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"]
 ];
+_cupSFSniperOptics = [];
 (_sfLoadoutData get "sniperRifles") append [
     ["CUP_srifle_M2010_blk","muzzle_snds_B","acc_pointer_IR","CUP_optic_LeupoldMk4",["CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_TE1_Red_Tracer_762x67_M2010_M"], [], "CUP_bipod_VLTOR_Modpod_black"],
 
@@ -106,30 +153,38 @@
 
 	["CUP_srifle_AWM_blk","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
 	["CUP_srifle_AWM_wdl","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
-
-	["CUP_srifle_G22_blk","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_G22_wdl","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	
+	//redundant
+	//["CUP_srifle_G22_blk","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	//["CUP_srifle_G22_wdl","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
 
 	["CUP_srifle_AS50","","CUP_acc_ANPEQ_15_Black","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M", "CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M"], [], ""]
 ];
 (_sfLoadoutData get "designatedGrenadeLaunchers") append [
-    ["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""]
+    //["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""]
 ];
-(_sfLoadoutData get "SMGs") append [
-    ["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+(_sfLoadoutData get "SMGs") append [ //TODO: change all this to P90s, though it barely matters since SF SMGs literally never spawn
+    ["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
+	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
 	["CUP_smg_PS90_olive","muzzle_snds_570","CUP_acc_ANPEQ_15_Top_Flashlight_OD_L","CUP_optic_Eotech553_OD",["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""],
 	["CUP_smg_EVO","CUP_muzzle_snds_MP5","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""]
 ];
 ////////////////////////////////////////////////
+
+//Elite loadout TODO:
+// - Build lists of optics, attachments, etc
+// - standardize on 6.8mm ACRs for rifles, Mk20s are gone now
+// - LMGs are Mk200s supplanted by the modern LMGs (Mk48, M249)
+// - rationalize other categories
+// - set weights on EVERYTHING
 
 (_eliteLoadoutData get "slRifles") append [
     ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
@@ -393,6 +448,10 @@
 ];
 //////////////////////////////////////////////////////
 
+//Military TODO:
+//- Standardize on some G3s and G36s complementing Mk20s
+//- LMGs are M240/M249/MG36, maybe some Mk200
+
 (_militaryLoadoutData get "slRifles") append [
     ["CUP_arifle_DSA_SA58_OSW_M203", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
@@ -513,6 +572,10 @@
 ];
 /////////////
 
+//militia TODO:
+//- holy shit trim that list of guns down
+//- Override base Mk20/TRG21 spawns, instead go for majority M16 with some FALs and a few M14s
+
 (_militiaLoadoutData get "slRifles") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
 ];
@@ -610,7 +673,9 @@
 	["CUP_srifle_M24_blk","","","CUP_optic_SB_11_4x20_PM",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"]
 ];
 ///////////
-
+//Police TODO:
+//- Trim down pistol list to modern CZ75s and Glocks
+//- Trim down SMG list somewhat, no shields, occasional M4
 (_policeLoadoutData get "sidearms") append [
     ["CUP_hgun_Browning_HP", "", "", "", ["CUP_13Rnd_9x19_Browning_HP","CUP_13Rnd_9x19_Browning_HP"], [], ""],
 	["CUP_hgun_CZ75", "", "", "", ["CUP_hgun_CZ75","CUP_hgun_CZ75"], [], ""],

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -54,14 +54,14 @@ _cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_gree
 
 (_sfLoadoutData get "rifles") append [
     ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
-	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 	["CUP_arifle_XM8_Sharpshooter_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
 	["CUP_arifle_XM8_Sharpshooter_FG_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 	["CUP_arifle_XM8_Sharpshooter_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
-	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 ];
 
 (_sfLoadoutData get "machineGuns") append [
@@ -141,8 +141,8 @@ _cupSFSniperOptics = ["CUP_optic_LeupoldMk4_20x40_LRT", 5, "CUP_optic_LeupoldMk4
 
 	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 1.25,
 	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 1.25,
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
+	["CUP_arifle_XM8_Compact_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
+	["CUP_arifle_XM8_Compact","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
 
 	["CUP_smg_PS90_olive","muzzle_snds_570","CUP_acc_ANPEQ_15_Top_Flashlight_OD_L","CUP_optic_Eotech553_OD",["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""], 1,
 	["CUP_smg_EVO","CUP_muzzle_snds_MP5","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 3
@@ -211,9 +211,9 @@ _cupEliteGreenRifleBipods = ["CUP_bipod_VLTOR_Modpod_od", 1, "", 2];
 	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 0.75,
 	["CUP_arifle_XM8_Sharpshooter_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 1.5,
 	["CUP_arifle_XM8_Sharpshooter_FG_Green", "",_cupEliteGreenAttachments ,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 0.25,
+	["CUP_arifle_XM8_Sharpshooter_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 0.5,
 	["CUP_arifle_XM8_Sharpshooter_Green", "",_cupEliteGreenAttachments ,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteGreenRifleBipods], 0.75,
 	["CUP_arifle_XM8_Sharpshooter", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 1.5,
-	["CUP_arifle_XM8_Sharpshooter_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], _cupEliteRifleBipods], 0.5,
 
 	["CUP_arifle_Mk20_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.2,
 	["CUP_arifle_Mk20_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
@@ -224,21 +224,23 @@ _cupEliteGreenRifleBipods = ["CUP_bipod_VLTOR_Modpod_od", 1, "", 2];
 	["CUP_arifle_Mk17_STD_FG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.2,
 	["CUP_arifle_Mk17_STD_FG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.1,
 
-	["CUP_arifle_Mk17_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.25,
 	["CUP_arifle_Mk17_STD_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.75,
+	["CUP_arifle_Mk17_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.25,
+	
 	["CUP_arifle_Mk17_STD_AFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenRifleBipods], 0.2,
 	["CUP_arifle_Mk17_STD_AFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteRifleBipods], 0.1,
 
 	["CUP_arifle_Mk16_SV_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 0.5,
 	["CUP_arifle_Mk16_SV_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_arifle_Mk16_STD_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 1.75,
-	["CUP_arifle_Mk16_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.75,
+	["CUP_arifle_Mk16_STD_SFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_Mk16_STD_SFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.25,
+
 	["CUP_arifle_Mk16_STD_FG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 0.5,
 	["CUP_arifle_Mk16_STD_FG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.25,
 
-	["CUP_arifle_Mk16_STD_SFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.5,
-	["CUP_arifle_Mk16_STD_SFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.25,
+	["CUP_arifle_Mk16_STD_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteGreenRifleBipods], 1.75,
+	["CUP_arifle_Mk16_STD_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], _cupEliteRifleBipods], 0.75,
 
 	["CUP_arifle_Mk16_STD_AFG_woodland", "",_cupEliteGreenAttachments ,_cupEliteGreenRifleOptics ,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.5,
 	["CUP_arifle_Mk16_STD_AFG_black", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], [], ""], 0.25,
@@ -277,16 +279,16 @@ _eliteMGOptics append ["CUP_optic_G33_HWS_BLK", 1.5, "CUP_optic_Eotech553_Black"
 	["CUP_arifle_XM8_SAW_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
 	["CUP_arifle_XM8_SAW_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 	["CUP_arifle_XM8_SAW_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
-	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.5
 	["CUP_arifle_XM8_SAW_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.25,
+	["CUP_arifle_XM8_SAW_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_SAW", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
 
-	["CUP_lmg_Mk48_wdl", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 3,
 	["CUP_lmg_Mk48_nohg_wdl", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.75,
 	["CUP_lmg_Mk48_nohg_od", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.75,
 	["CUP_lmg_Mk48_nohg", "",_cupEliteAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 0.25,
 
+	["CUP_lmg_Mk48_wdl", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 3,
 	["CUP_lmg_Mk48_od", "",_cupEliteGreenAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1.5,
 	["CUP_lmg_Mk48", "",_cupEliteAttachments,_cupEliteMGOptics762,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1.5,
 
@@ -324,10 +326,9 @@ _cupEliteXM8CarbineOptics = ["CUP_optic_RCO_PCAP", 1, "CUP_optic_ISM_PCAP", 4];
 	["CUP_arifle_xm29_ke_blk","",_cupEliteAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.1,
 
 	["CUP_arifle_Mk17_CQC_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 1,
+	["CUP_arifle_Mk17_CQC_Black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.5,
 	["CUP_arifle_Mk17_CQC_FG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.25,
 	["CUP_arifle_Mk17_CQC_FG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.1,
-	["CUP_arifle_Mk17_CQC_Black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.5,
-
 	["CUP_arifle_Mk17_CQC_SFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
 	["CUP_arifle_Mk17_CQC_SFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
@@ -335,14 +336,14 @@ _cupEliteXM8CarbineOptics = ["CUP_optic_RCO_PCAP", 1, "CUP_optic_ISM_PCAP", 4];
 	["CUP_arifle_Mk17_CQC_AFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
 
 	["CUP_arifle_Mk16_CQC_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 2,
+	["CUP_arifle_Mk16_CQC_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 1,
 	["CUP_arifle_Mk16_CQC_FG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.5,
 	["CUP_arifle_Mk16_CQC_FG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.25,
-	["CUP_arifle_Mk16_CQC_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 1,
-	["CUP_arifle_Mk16_CQC_AFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.2,
-	["CUP_arifle_Mk16_CQC_AFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.1,
-
 	["CUP_arifle_Mk16_CQC_SFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.2,
 	["CUP_arifle_Mk16_CQC_SFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], ""], 0.1,
+
+	["CUP_arifle_Mk16_CQC_AFG_woodland", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteGreenCarbineBipods], 0.2,
+	["CUP_arifle_Mk16_CQC_AFG_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_762x51_B_SCAR_bkl","CUP_20Rnd_TE1_Green_Tracer_762x51_SCAR_bkl"], [], _cupEliteCarbineBipods], 0.1,
 
 	["CUP_arifle_SBR_od", "",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL_Tracer_Green"], [], ""], 0.5,
 	["CUP_arifle_SBR_black", "",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL","CUP_30Rnd_556x45_PMAG_OD_RPL_Tracer_Green"], [], ""], 0.25,
@@ -442,8 +443,8 @@ _cupEliteSMGXM8Optics = ["CUP_optic_ISM_PCAP", 10];
 
 	["CUP_arifle_XM8_Compact_FG_Green","",_cupEliteGreenAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.2,
 	["CUP_arifle_XM8_Compact_FG","",_cupEliteAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 0.1,
-	["CUP_arifle_XM8_Compact_FG_Green","",_cupEliteGreenAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
-	["CUP_arifle_XM8_Compact_FG","",_cupEliteAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Compact_Green","",_cupEliteGreenAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Compact","",_cupEliteAttachments,_cupEliteSMGXM8Optics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 
 	["CUP_smg_PS90_olive","",_cupEliteGreenAttachments,_cupEliteCarbineOptics,["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""], 1,
 	["CUP_smg_EVO","",_cupEliteAttachments,_cupEliteCarbineOptics,["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 0.5
@@ -646,7 +647,7 @@ _militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_
 	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""] // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 5 // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];
 (_militiaLoadoutData get "SMGs") append [
     ["CUP_smg_MP5A5","", _militiaAttachments,_militiaSMGsights,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -268,7 +268,7 @@ _cupEliteGreenRifleBipods = ["CUP_bipod_VLTOR_Modpod_od", 1, "", 2];
 	["CUP_arifle_ACR_blk_68", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag","CUP_30Rnd_680x43_Stanag_Tracer_Green"], [], ""], 3,
 	["CUP_arifle_ACR_blk_556", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green","CUP_30Rnd_556x45_PMAG_BLACK_PULL_Tracer_Green"], [], ""], 1,
 
-	["CUP_sgun_AA12", "",cupEliteAttachments,"",["CUP_20Rnd_B_AA12_Buck_4","CUP_20Rnd_B_AA12_Buck_00","CUP_20Rnd_B_AA12_Slug","CUP_20Rnd_B_AA12_HE"], [], ""], 0.5
+	["CUP_sgun_AA12", "",_cupEliteAttachments,"",["CUP_20Rnd_B_AA12_Buck_4","CUP_20Rnd_B_AA12_Buck_00","CUP_20Rnd_B_AA12_Slug","CUP_20Rnd_B_AA12_HE"], [], ""], 0.5
 ];
 
 _cupEliteMGOptics = ["CUP_optic_ElcanM145", 5, "CUP_optic_G33_HWS_BLK", 2, "CUP_optic_Eotech553_Black", 0.5, "CUP_optic_Elcan_SpecterDR_KF_RMR_black", 0.75, "CUP_optic_Elcan_SpecterDR_RMR_black", 1.5, "CUP_optic_Elcan_SpecterDR_black", 2.5, "CUP_optic_Elcan_SpecterDR_KF_black", 0.5];
@@ -388,7 +388,7 @@ _cupEliteXM8CarbineOptics = ["CUP_optic_RCO_PCAP", 1, "CUP_optic_ISM_PCAP", 4];
 	["CUP_CZ_BREN2_556_11_GL", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green","CUP_30Rnd_556x45_Stanag_Mk16_woodland_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.25,
 
 	["CUP_CZ_BREN2_762_14_GL_Grn", "",_cupEliteGreenAttachments,_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.2,
-	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.1,
+	["CUP_CZ_BREN2_762_14_GL", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_762x39_CZ807","CUP_30Rnd_762x39_CZ807","CUP_30Rnd_TE1_Green_Tracer_762x39_CZ807"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.1,
 
 	["CUP_arifle_CZ805_GL_blk", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_30Rnd_556x45_CZ805","CUP_30Rnd_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805","CUP_30Rnd_TE1_Green_Tracer_556x45_CZ805"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -277,7 +277,7 @@ _eliteMGOptics append ["CUP_optic_G33_HWS_BLK", 1.5, "CUP_optic_Eotech553_Black"
 	["CUP_arifle_XM8_SAW_FG_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.1,
 	["CUP_arifle_XM8_SAW_Rail_Green", "",_cupEliteGreenAttachments,_cupEliteGreenRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 	["CUP_arifle_XM8_SAW_Rail", "",_cupEliteAttachments,_cupEliteRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 1,
-	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_SAW_FG_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.5,
 	["CUP_arifle_XM8_SAW_Green", "",_cupEliteGreenAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_SAW_FG", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.25,
 	["CUP_arifle_XM8_SAW", "",_cupEliteAttachments,_cupEliteXM8Optics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
@@ -646,10 +646,10 @@ _militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_
 	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""] // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
+    ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 8
 ];
 (_militiaLoadoutData get "SMGs") append [
-    ["CUP_smg_MP5A5","", _militiaAttachments,_militiaSMGsights,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 6
+    ["CUP_smg_MP5A5","","","",["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 8
 ];
 (_militiaLoadoutData get "designatedGrenadeLaunchers") append [
     ["CUP_glaunch_M79", "", "", "", ["CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203"], [], ""], 5

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -61,7 +61,7 @@ _cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_gree
 	["CUP_arifle_XM8_Sharpshooter_FG_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 	["CUP_arifle_XM8_Sharpshooter_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
-	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 ];
 
 (_sfLoadoutData get "machineGuns") append [
@@ -89,7 +89,7 @@ _cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_gree
 	["CUP_arifle_xm29_ke_rail_olive","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.75,
 	["CUP_arifle_xm29_ke_rail_blk","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.75,
 	["CUP_arifle_xm29_ke_olive","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.5,
-	["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""] 0.5
+	["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.5
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
     ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 3,
@@ -100,9 +100,10 @@ _cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_gree
 
 	["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 1,
 	["CUP_arifle_xm29_blk", "CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 1
-
 ];
+
 _cupSFBlackAttachments = ["CUP_acc_ANPEQ_15_Top_Flashlight_Black_L", 2, "CUP_acc_ANPEQ_15_Flashlight_Black_L", 1];
+
 (_sfLoadoutData get "marksmanRifles") append [
     ["CUP_srifle_RSASS_Jungle","CUP_muzzle_snds_socom762rc",_cupSFXM8Attachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 3,
 	["CUP_srifle_RSASS_Black","CUP_muzzle_snds_socom762rc",_cupSFXM8Attachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
@@ -476,7 +477,7 @@ _cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "
 	
 	["CUP_arifle_G36A_AG36_RIS", "",_cupMilitaryAttachments,_cupMilitarySlG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.5,
 
-	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""] 0.75
+	["CUP_arifle_AG36", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 0.75
 ];
 _militaryRifleSights append ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
 _cupMilitaryRifleOptics = ["CUP_optic_RCO", 1.5, "CUP_optic_Eotech553_Black", 2.5, "CUP_optic_HoloBlack", 5];
@@ -593,6 +594,7 @@ _militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_B
 (_militiaLoadoutData get "slRifles") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5 // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];
+_cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 (_militiaLoadoutData get "rifles") append [
     ["CUP_arifle_G3A3_modern_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
 	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 2,
@@ -608,27 +610,27 @@ _militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_B
 
 	["CUP_arifle_IMI_Romat", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
 
-	["CUP_arifle_Gewehr1_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_Gewehr1", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_Gewehr1_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
+	["CUP_arifle_Gewehr1", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 
 	["CUP_arifle_Fort222", "",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.2,
 
 	["CUP_Famas_F1_Rail", "",_militiaAttachments,_militiaRifleSights,["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.25,
 	["CUP_Famas_F1", "","","",["CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas","CUP_25Rnd_556x45_Famas_Tracer_Green"], [], ""], 0.1,
 
-	["CUP_arifle_FNFAL_OSW_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
-	["CUP_arifle_FNFAL_OSW", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5061_wooden_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_FNFAL5061_wooden", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
+	["CUP_arifle_FNFAL_OSW_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
+	["CUP_arifle_FNFAL_OSW", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
+	["CUP_arifle_FNFAL5061_wooden_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
+	["CUP_arifle_FNFAL5061_wooden", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 
-	["CUP_arifle_FNFAL_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 1,
-	["CUP_arifle_FNFAL", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5062_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
-	["CUP_arifle_FNFAL5062", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.1,
-	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.75,
-	["CUP_arifle_FNFAL5061", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.15,
-	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 2,
-	["CUP_arifle_FNFAL5060", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], "CUP_bipod_FNFAL"], 0.25,
+	["CUP_arifle_FNFAL_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1,
+	["CUP_arifle_FNFAL", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
+	["CUP_arifle_FNFAL5062_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
+	["CUP_arifle_FNFAL5062", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
+	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.75,
+	["CUP_arifle_FNFAL5061", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.15,
+	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 2,
+	["CUP_arifle_FNFAL5060", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
 
 	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""], 0.25,
 

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -463,7 +463,7 @@ _cupMilitaryAttachments = ["CUP_acc_Flashlight", 6, "CUP_acc_ANPEQ_2_grey", 2, "
 (_militaryLoadoutData get "slRifles") append [
     ["CUP_arifle_DSA_SA58_OSW_M203", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
-	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 3,
+	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 2,
 	["CUP_arifle_M4A1_BUIS_GL", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1,
 
 	["CUP_arifle_M16A4_GL", "",_cupMilitaryAttachments,_cupMilitarySlRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 2,
@@ -489,52 +489,53 @@ _cupMilitaryG36RISOptics = ["CUP_optic_HoloBlack", 4, "CUP_optic_Eotech553_Black
    	["CUP_arifle_DSA_SA58_DMR", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 0.25,
    	["CUP_arifle_DSA_SA58", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], ""], 1,
 
-	["CUP_arifle_M4A3_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1,
-	["CUP_arifle_M4A1", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4,
-	["CUP_arifle_M4A1_standard_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.25,
-	["CUP_arifle_M4A1_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.75,
+	["CUP_arifle_M4A3_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_M4A1", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2,
+	["CUP_arifle_M4A1_standard_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_M4A1_black", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1,
 
-	["CUP_arifle_M16A4_Grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 1.5,
-	["CUP_arifle_M16A4_Base", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4,
+	["CUP_arifle_M16A4_Grip", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_M16A4_Base", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2,
 
 	["CUP_arifle_M16A2", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2,
 	["CUP_arifle_M16A1E1", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 0.5,
 
 	["CUP_arifle_L85A2_G", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
-	["CUP_arifle_L85A2_NG", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
-	["CUP_arifle_L85A2", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 1,
+	["CUP_arifle_L85A2_NG", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 0.75,
+	["CUP_arifle_L85A2", "",_cupMilitaryAttachments,_cupMilitaryL85Optics ,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], [], ""], 0.75,
 
-	["CUP_arifle_G36KA3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
-	["CUP_arifle_G36KA3_afg", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36KA3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.75,
+	["CUP_arifle_G36KA3_afg", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.75,
 	["CUP_arifle_G36KA3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
 	["CUP_arifle_G36K_KSK_VFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 	["CUP_arifle_G36K_KSK_AFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 	["CUP_arifle_G36K_KSK", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 
-	["CUP_arifle_G36K_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2.5,
+	["CUP_arifle_G36K_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 	["CUP_arifle_G36A_RIS", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
 
-	["CUP_arifle_G36K", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.75,
+	["CUP_arifle_G36K", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1,
 	["CUP_arifle_G36E", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
-	["CUP_arifle_G36A", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
+	["CUP_arifle_G36A", "",_cupMilitaryAttachments,_cupMilitaryG36Optics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.75,
 
-	["CUP_arifle_G36A3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2,
+	["CUP_arifle_G36A3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
 	["CUP_arifle_G36A3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2
 
 ];
 (_militaryLoadoutData get "carbines") append [
-	["CUP_arifle_Colt727", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 3,
+	["CUP_arifle_Colt727", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2,
 
 	["CUP_arifle_G36CA3_grip", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
 	["CUP_arifle_G36CA3_afg", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
-	["CUP_arifle_G36CA3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
+	["CUP_arifle_G36CA3", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.25,
 
-	["CUP_arifle_G36C_VFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1,
-	["CUP_arifle_G36C_VFG_Carry", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 1.5,
-	["CUP_arifle_G36C", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 4
+	["CUP_arifle_G36C_VFG", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36C_VFG_Carry", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 0.5,
+	["CUP_arifle_G36C", "",_cupMilitaryAttachments,_cupMilitaryG36RISOptics,["CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36_wdl","CUP_30Rnd_556x45_G36","CUP_30Rnd_TE1_Green_Tracer_556x45_G36"], [], ""], 2
 ];
 _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
+
 (_militaryLoadoutData get "machineGuns") append [
     ["CUP_lmg_m249_pip4", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_200Rnd_TE4_Green_Tracer_556x45_M249_Pouch","CUP_200Rnd_TE4_Green_Tracer_556x45_M249","CUP_200Rnd_TE4_Green_Tracer_556x45_M249"], [], ""], 3,
 
@@ -548,13 +549,14 @@ _cupMilitaryMGOptics = ["CUP_optic_ACOG2", 4, "CUP_optic_ACOG_TA31_KF", 1];
 
 	["CUP_M60A4_EP1", "",_cupMilitaryAttachments,_cupMilitaryMGOptics,["CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M","CUP_100Rnd_TE4_LRT4_Green_Tracer_762x51_Belt_M"], [], ""], 1
 ];
+
 (_militaryLoadoutData get "grenadeLaunchers") append [
     ["CUP_arifle_DSA_SA58_OSW_M203", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1,
 
-	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 4,
-	["CUP_arifle_M4A1_BUIS_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
+	["CUP_arifle_M4A1_GL_carryhandle", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
+	["CUP_arifle_M4A1_BUIS_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.75,
 
-	["CUP_arifle_M16A4_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2.5,
+	["CUP_arifle_M16A4_GL", "",_cupMilitaryAttachments,_cupMilitaryRifleOptics,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 2,
 	
 	["CUP_arifle_L85A2_GL", "",_cupMilitaryAttachments,_cupMilitaryL85Optics,["CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 0.5,
 
@@ -597,7 +599,7 @@ _militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_B
 _cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 (_militiaLoadoutData get "rifles") append [
     ["CUP_arifle_G3A3_modern_ris_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.75,
-	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 2,
+	["CUP_arifle_G3A3_modern_ris", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 1.75,
 	
 	["CUP_arifle_G3A3_ris_vfg_black", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.1,
 	["CUP_arifle_G3A3_ris_vfg", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_762x51_G3","CUP_20Rnd_TE1_Green_Tracer_762x51_G3"], [], ""], 0.2,
@@ -629,12 +631,12 @@ _cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 	["CUP_arifle_FNFAL5062", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.1,
 	["CUP_arifle_FNFAL5061_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.75,
 	["CUP_arifle_FNFAL5061", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.15,
-	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 2,
+	["CUP_arifle_FNFAL5060_railed", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 1.5,
 	["CUP_arifle_FNFAL5060", "",_militiaAttachments,"",["CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_762x51_FNFAL_M","CUP_20Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], [], _cupFALbipods], 0.25,
 
 	["CUP_arifle_AUG_A1", "","","",["CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_556x45_AUG","CUP_30Rnd_TE1_Green_Tracer_556x45_AUG"], [], ""], 0.25,
 
-	["CUP_arifle_M16A1", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 6,
+	["CUP_arifle_M16A1", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 5, //relatively high because this is one of the only non-battle rifles
 
 	["CUP_srifle_M14", "",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR","CUP_20Rnd_TE1_Green_Tracer_762x51_DMR"], [], ""], 1.5
 ];
@@ -643,10 +645,10 @@ _cupFALbipods = [ "CUP_bipod_FNFAL", 1, "", 5];
 	["CUP_arifle_Fort224","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.25,
 	["CUP_arifle_Fort221","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_545x39_Fort224_M","CUP_30Rnd_Subsonic_545x39_Fort224_M","CUP_30Rnd_TE1_Green_Tracer_545x39_Fort224_M"], [], ""], 0.5,
 
-	["CUP_arifle_X95_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.75,
-	["CUP_arifle_X95","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1.5,
+	["CUP_arifle_X95_Grippod","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 0.5,
+	["CUP_arifle_X95","",_militiaAttachments,_militiaRifleSights,["CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95","CUP_30Rnd_556x45_X95_Tracer_Green"], [], ""], 1,
 
-	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 4
+	["CUP_arifle_M4A1","",_militiaAttachments,_militiaRifleSights,["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], ""], 2
 ];
 (_militiaLoadoutData get "grenadeLaunchers") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 8

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -587,8 +587,8 @@ _cupMilitarySMGOptics = ["CUP_optic_HoloBlack", 7, "CUP_optic_Eotech553_black", 
 	["CUP_smg_MP5A5_Rail","",_cupMilitaryAttachments,_cupMilitarySMGOptics,["CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_9x19_MP5","CUP_30Rnd_Green_Tracer_9x19_MP5"], [], ""], 5
 ];
 /////////////
-_militiaSlRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
-_militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.25, "CUP_optic_AC11704_Black", 0.25, "CUP_optic_HoloBlack", 0.25];
+_militiaSlRifleSights append ["CUP_optic_Aimpoint_5000", 2.5, "CUP_optic_AC11704_Black", 0.75, "CUP_optic_HoloBlack", 0.75];
+_militiaRifleSights append ["CUP_optic_Aimpoint_5000", 0.5, "CUP_optic_AC11704_Black", 0.2, "CUP_optic_HoloBlack", 0.2];
 (_militiaLoadoutData get "slRifles") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 5 // No optics since it uses a barrel mounted leaf sight for grenade launcher aiming.
 ];

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -699,7 +699,7 @@ _militiaSniperOptics append ["CUP_optic_SB_11_4x20_PM", 7.5];
 (_policeLoadoutData get "sidearms") append [
     ["CUP_hgun_Browning_HP", "", "", "", ["CUP_13Rnd_9x19_Browning_HP","CUP_13Rnd_9x19_Browning_HP"], [], ""], 1,
 
-	["CUP_hgun_CZ75", "", "", "", ["CUP_hgun_CZ75","CUP_hgun_CZ75"], [], ""], 1.5,
+	["CUP_hgun_CZ75", "", "", "", ["CUP_16Rnd_9x19_cz75","CUP_16Rnd_9x19_cz75"], [], ""], 1.5,
 	["CUP_hgun_Compact", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_10Rnd_9x19_Compact"], [], ""], 2,
 	["CUP_hgun_Duty", "", "", "", ["16Rnd_9x21_Mag","16Rnd_9x21_green_Mag"], [], ""], 3,
 	["CUP_hgun_Phantom", "", "", "", ["CUP_18Rnd_9x19_Phantom","CUP_18Rnd_9x19_Phantom"], [], ""], 2,

--- a/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/MOD_content/CUP/Vanilla_AAF/Weapons_AAF.sqf
@@ -1,190 +1,153 @@
-//given CUP has proper disposable AT we'll remove the MAAWS as a light launcher entirely
-_militiaLoadoutData set ["lightATLaunchers", [
-	["CUP_launch_M72A6", "", "", "", [""], [], ""], 10
-]];
-_militiaLoadoutData set ["ATLaunchers", [
-	["CUP_launch_MAAWS", "", "", "", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 9,
-	["CUP_launch_MAAWS", "", "", "CUP_optic_MAAWS_Scope", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 1
-]];
-_militiaLoadoutData set ["missileATLaunchers", [
-	["CUP_launch_M47", "", "", "", ["CUP_Dragon_EP1_M", "CUP_Dragon_EP1_M"], [], ""], 10
-	]];
-_militiaLoadoutData set ["AALaunchers", [
-	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""], 10
-]];
+_CUPRPGOptics = ["CUP_optic_PGO7V", 3, "CUP_optic_PGO7V2", 2, "CUP_optic_PGO7V3", 1];
 
-_militaryLoadoutData set ["lightATLaunchers", [
-	["CUP_launch_M72A6", "", "", "", [""], [], ""], 5, 
-	["CUP_launch_M136", "", "", "", [], [], ""], 5
-]];
-(_militaryloadoutData get "AALaunchers") append [
-	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""], 6
+(_loadoutData get "lightATLaunchers") append [
+    ["CUP_launch_BF3", "", "", "", [], [], ""], 0.5,
+    ["CUP_launch_M136", "", "", "", [], [], ""], 2.5,
+    ["CUP_launch_M72A6", "", "", "", [""], [], ""], 5,
+	["CUP_launch_HCPF3", "", "", "", [], [], ""], 0.5,
+	["CUP_launch_PzF3", "", "", "", [], [], ""], 1,
+	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""], 1.75,
+	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""], 0.5,
+	["CUP_launch_RPG7V", "", "", _CUPRPGOptics, ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""], 0.25
 ];
 
-_eliteLoadoutData set ["lightATLaunchers", [
-	["CUP_launch_HCPF3", "", "", "", [], [], ""], 3,
-	["CUP_launch_PzF3", "", "", "", [], [], ""], 6,
-	["CUP_launch_BF3", "", "", "", [], [], ""], 1
-]];
+_CUPMAAAWSOptics = ["CUP_optic_MAAWS_Scope", 2, "", 1];
+_CUPSMAWOptics = ["CUP_optic_ACOG_TA01NSN_RMR_OD", 2, "", 1];
 
-/*(_loadoutData get "lightATLaunchers") append [
-    
-	
-	
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V", ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V2", ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V3", ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V", ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V3", ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "CUP_optic_PGO7V2", ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "", ["CUP_OG7_M","CUP_PG7V_M","CUP_PG7VL_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "", ["CUP_PG7VM_M","RPG7_F","CUP_PG7VR_M"], [], ""],
-	["CUP_launch_RPG7V", "", "", "", ["CUP_TBG7V_M","CUP_TBG7V_M","CUP_OG7_M"], [], ""]
-];*/
-/*(_loadoutData get "ATLaunchers") append [
-    ["CUP_launch_Javelin", "", "", "", ["CUP_Javelin_M", "CUP_Javelin_M"], [], ""],
-    
-	["CUP_launch_APILAS", "", "", "", ["CUP_APILAS_M", "CUP_APILAS_M"], [], ""],
-	["CUP_launch_MAAWS", "", "", "", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""],
-	["CUP_launch_MAAWS", "", "", "CUP_optic_MAAWS_Scope", ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""],
-	["CUP_launch_Mk153Mod0", "", "", "CUP_optic_ACOG_TA01NSN_RMR_OD", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""],
-	["CUP_launch_Mk153Mod0", "", "", "", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""],
-	["CUP_launch_Mk153Mod0_blk", "", "", "CUP_optic_ACOG_TA01NSN_RMR_OD", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""],
-	["CUP_launch_Mk153Mod0_blk", "", "", "", ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""]
-];*/
+(_loadoutData get "ATLaunchers") append [
+    ["CUP_launch_Javelin", "", "", "", ["CUP_Javelin_M", "CUP_Javelin_M"], [], ""], 0.5,
+    ["CUP_launch_M47", "", "", "", ["CUP_Dragon_EP1_M", "CUP_Dragon_EP1_M"], [], ""], 2,
+	["CUP_launch_APILAS", "", "", "", ["CUP_APILAS_M", "CUP_APILAS_M"], [], ""], 1,
+	["CUP_launch_MAAWS", "", "", _CUPMAAAWSOptics, ["CUP_MAAWS_HEDP_M", "CUP_MAAWS_HEAT_M"], [], ""], 2.5,
+	["CUP_launch_Mk153Mod0", "", "", _CUPSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 1.75,
+	["CUP_launch_Mk153Mod0_blk", "", "", _CUPSMAWOptics, ["CUP_SMAW_HEDP_M", "CUP_SMAW_HEAA_M", "CUP_SMAW_NE_M"], [], ""], 0.75
+];
 
-/*(_loadoutData get "AALaunchers") append [
-    ["CUP_launch_9K32Strela", "", "", "", [], [], ""],
-	["CUP_launch_Igla", "", "", "", [], [], ""],
-	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""]
-];*/
-
-// General TODO:
-// - Set up overrides on categories where vanilla weapons just straight up won't appear (e.g., elites, SF)
-// - This means basically checking to see if vanilla weapons are present in the loadoutData (since OTHER compats might also have overridden them, and we don't want to override THOSE)
+(_loadoutData get "AALaunchers") append [
+    ["CUP_launch_9K32Strela", "", "", "", [], [], ""], 1,
+	["CUP_launch_Igla", "", "", "", [], [], ""], 1,
+	["CUP_launch_FIM92Stinger", "", "", "", [], [], ""], 5
+];
 
 ////////////////////////////////////
 
-_cupSFRifleOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 5, "CUP_optic_Elcan_SpecterDR_RMR_od", 2, "CUP_optic_Eotech553_OD", 3];
-_cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 8, "CUP_optic_ISM_PCAP_green", 2]
 _cupSFSlRifleOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 7, "CUP_optic_Elcan_SpecterDR_RMR_od", 3];
 _cupSFSlRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 4, "CUP_optic_ISM_PCAP_green", 6];
-_cupSFAttachments = ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 6, "CUP_acc_ANPEQ_15_OD", 4];
+
+_cupSFXM8Attachments = ["CUP_acc_ANPEQ_15_Flashlight_OD_L", 6, "CUP_acc_ANPEQ_15_OD", 4];
 
 
 (_sfLoadoutData get "slRifles") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8", _cupSFAttachments, _cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFSlRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments, _cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 3,
+	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments, _cupSFSlRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 3,
 
-	//["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	//["CUP_arifle_xm29_blk", "UP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
+	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments, _cupSFSlRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFSlRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""], 1.5,
+
+	["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 2.25,
+	["CUP_arifle_xm29_blk", "UP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 2.25
 
 ];
+
+_cupSFRifleOptics = ["CUP_optic_Elcan_SpecterDR_KF_RMR_od", 6, "CUP_optic_Elcan_SpecterDR_RMR_od", 2, "CUP_optic_HensoldtZO_low_RDS_od", 4];
+_cupSFRifleOptics_XM8 = ["CUP_optic_AMO_PCAP_green", 6, "CUP_optic_ISM_PCAP_green", 2];
+
 (_sfLoadoutData get "rifles") append [
-    ["CUP_arifle_XM8_Carbine_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_FG_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Carbine_FG", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"]
+    ["CUP_arifle_XM8_Sharpshooter_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Sharpshooter_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Sharpshooter_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Sharpshooter_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+
+	["CUP_arifle_XM8_Sharpshooter_FG_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Sharpshooter_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Sharpshooter", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Sharpshooter_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
 ];
 
+(_sfLoadoutData get "machineGuns") append [
+    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_SAW_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_SAW_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_SAW_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
+	["CUP_arifle_XM8_SAW_FG_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_SAW_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_SAW_FG", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_SAW", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"], 1
+];
 (_sfLoadoutData get "carbines") append [
-	["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 2,
+	["CUP_arifle_XM8_Carbine_FG_Rail","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 2,
+	["CUP_arifle_XM8_Carbine_Rail_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Railed","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+	["CUP_arifle_XM8_Carbine_FG_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Carbine_FG","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Carbine_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
+	["CUP_arifle_XM8_Carbine","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 1,
 
-	//["CUP_arifle_xm29_ke_rail_olive","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	//["CUP_arifle_xm29_ke_rail_blk","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	//["CUP_arifle_xm29_ke_olive","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""],
-	//["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black",_cupSFAttachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""]
+	["CUP_arifle_xm29_ke_rail_olive","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.75,
+	["CUP_arifle_xm29_ke_rail_blk","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.75,
+	["CUP_arifle_xm29_ke_olive","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""], 0.5,
+	["CUP_arifle_xm29_ke_blk","CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"CUP_optic_G36Optics_RDS_3D",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag"], [], ""] 0.5
 ];
 (_sfLoadoutData get "grenadeLaunchers") append [
-    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
-	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""],
+    ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 3,
+	["CUP_arifle_XM8_Carbine_GL_Rail", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 3,
 
-	//["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""],
-	//["CUP_arifle_xm29_blk", "CUP_muzzle_snds_G36_black",_cupSFAttachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""]
+	["CUP_arifle_XM8_Carbine_GL_Green", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
+	["CUP_arifle_XM8_Carbine_GL", "CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8 ,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203"], ""], 1.5,
+
+	["CUP_arifle_xm29_olive", "CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 1,
+	["CUP_arifle_xm29_blk", "CUP_muzzle_snds_G36_black",_cupSFXM8Attachments,"",["CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green","CUP_30Rnd_556x45_Stanag_L85_Tracer_Green"], ["CUP_6Rnd_HE_Grenade_M","CUP_6Rnd_HE_Grenade_M"], ""], 1
 
 ];
-
-_cupSFMGOptics = [];
-//TODO: add Mk48 LMGs or some other belt feds
-(_sfLoadoutData get "machineGuns") append [
-    ["CUP_arifle_XM8_SAW_FG_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Rail", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_Green", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW_FG", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_SAW", "CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_AMO_PCAP_green",["CUP_100Rnd_556x45_BetaCMag","CUP_100Rnd_556x45_BetaCMag"], [], "CUP_bipod_VLTOR_Modpod_od"]
-];
-_cupSFMarksmanOptics = [];
+_cupSFBlackAttachments = ["CUP_acc_ANPEQ_15_Top_Flashlight_Black_L", 2, "CUP_acc_ANPEQ_15_Flashlight_Black_L", 1];
 (_sfLoadoutData get "marksmanRifles") append [
-    ["CUP_srifle_RSASS_Jungle","CUP_muzzle_snds_socom762rc",_cupSFAttachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_srifle_RSASS_Black","CUP_muzzle_snds_socom762rc",_cupSFAttachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	
-	//underpowered
-	//["CUP_srifle_Mk12SPR","CUP_muzzle_snds_Mk12","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"],
+    ["CUP_srifle_RSASS_Jungle","CUP_muzzle_snds_socom762rc",_cupSFXM8Attachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 3,
+	["CUP_srifle_RSASS_Black","CUP_muzzle_snds_socom762rc",_cupSFXM8Attachments,"CUP_optic_SB_11_4x20_PM_od",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
-	["CUP_srifle_M110_black","CUP_muzzle_snds_M110_black","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_m110_kac_black","CUP_muzzle_snds_M110_black","CUP_acc_ANPEQ_15_Top_Flashlight_Black_L","CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"]
+	["CUP_srifle_Mk12SPR","CUP_muzzle_snds_Mk12",_cupSFBlackAttachments,"CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.5,
+
+	["CUP_srifle_M110_black","CUP_muzzle_snds_M110_black",_cupSFBlackAttachments,"CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"], 4,
+	["CUP_srifle_m110_kac_black","CUP_muzzle_snds_M110_black",_cupSFBlackAttachments,"CUP_optic_SB_11_4x20_PM",["CUP_20Rnd_762x51_B_M110","CUP_20Rnd_762x51_B_M110", "CUP_20Rnd_762x51_B_M110","CUP_20Rnd_TE1_Green_Tracer_762x51_M110"], [], "CUP_bipod_VLTOR_Modpod_black"], 2.5
 ];
-_cupSFSniperOptics = [];
+
+_cupSFSniperOptics = ["CUP_optic_LeupoldMk4_20x40_LRT", 5, "CUP_optic_LeupoldMk4", 1, "CUP_optic_LeupoldM3LR", 2];
+
 (_sfLoadoutData get "sniperRifles") append [
-    ["CUP_srifle_M2010_blk","muzzle_snds_B","acc_pointer_IR","CUP_optic_LeupoldMk4",["CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_TE1_Red_Tracer_762x67_M2010_M"], [], "CUP_bipod_VLTOR_Modpod_black"],
+    ["CUP_srifle_M2010_blk","muzzle_snds_B","acc_pointer_IR",_cupSFSniperOptics,["CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_762x67_M2010_M","CUP_5Rnd_TE1_Red_Tracer_762x67_M2010_M"], [], "CUP_bipod_VLTOR_Modpod_black"], 3,
 
-	["CUP_srifle_M107_Pristine","CUP_muzzle_mfsup_Suppressor_M107_Black","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_M107_Base","CUP_muzzle_mfsup_Suppressor_M107_Black","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_srifle_M107_Pristine","CUP_muzzle_mfsup_Suppressor_M107_Black","",_cupSFSniperOptics,["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"], 2.5,
+	["CUP_srifle_M107_Base","CUP_muzzle_mfsup_Suppressor_M107_Black","",_cupSFSniperOptics,["CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107","CUP_10Rnd_127x99_M107"], [], "CUP_bipod_VLTOR_Modpod_black"], 2.5,
 
-	["CUP_srifle_AWM_blk","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	["CUP_srifle_AWM_wdl","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	
-	//redundant
-	//["CUP_srifle_G22_blk","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
-	//["CUP_srifle_G22_wdl","CUP_muzzle_snds_AWM","","CUP_optic_LeupoldM3LR",["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"],
+	["CUP_srifle_AWM_blk","CUP_muzzle_snds_AWM","",_cupSFSniperOptics,["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"], 2,
+	["CUP_srifle_AWM_wdl","CUP_muzzle_snds_AWM","",_cupSFSniperOptics,["CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1","CUP_5Rnd_86x70_L115A1"], [], "CUP_bipod_VLTOR_Modpod_black"], 2,
 
-	["CUP_srifle_AS50","","CUP_acc_ANPEQ_15_Black","CUP_optic_LeupoldMk4_20x40_LRT",["CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M", "CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M"], [], ""]
+	["CUP_srifle_G22_blk","CUP_muzzle_snds_AWM","",_cupSFSniperOptics,["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.75,
+	["CUP_srifle_G22_wdl","CUP_muzzle_snds_AWM","",_cupSFSniperOptics,["CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22", "CUP_5Rnd_762x67_G22","CUP_5Rnd_762x67_G22"], [], "CUP_bipod_VLTOR_Modpod_black"], 0.75,
+
+	["CUP_srifle_AS50","","CUP_acc_ANPEQ_15_Black",_cupSFSniperOptics,["CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M", "CUP_5Rnd_127x99_as50_M","CUP_5Rnd_127x99_as50_M"], [], ""], 4
 ];
 (_sfLoadoutData get "designatedGrenadeLaunchers") append [
-    //["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""]
+    ["CUP_glaunch_6G30", "", "", "", ["CUP_6Rnd_HE_GP25_M"], [], ""], 2
 ];
-(_sfLoadoutData get "SMGs") append [ //TODO: change all this to P90s, though it barely matters since SF SMGs literally never spawn
-    ["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_HensoldtZO_low_RDS_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
 
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""],
-	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_ISM_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
-	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFAttachments,"CUP_optic_RCO_PCAP_green",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"],
+(_sfLoadoutData get "SMGs") append [
+    ["CUP_arifle_XM8_Compact_FG_Rail_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 2,
+	["CUP_arifle_XM8_Compact_FG_Rail","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 2,
+	["CUP_arifle_XM8_Compact_Rail_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
+	["CUP_arifle_XM8_Compact_Rail","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 2,
 
-	["CUP_smg_PS90_olive","muzzle_snds_570","CUP_acc_ANPEQ_15_Top_Flashlight_OD_L","CUP_optic_Eotech553_OD",["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""],
-	["CUP_smg_EVO","CUP_muzzle_snds_MP5","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""]
+	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 1.25,
+	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], ""], 1.25,
+	["CUP_arifle_XM8_Compact_FG_Green","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
+	["CUP_arifle_XM8_Compact_FG","CUP_muzzle_snds_XM8",_cupSFXM8Attachments,_cupSFRifleOptics_XM8,["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], [], "CUP_bipod_VLTOR_Modpod_od"], 0.75,
+
+	["CUP_smg_PS90_olive","muzzle_snds_570","CUP_acc_ANPEQ_15_Top_Flashlight_OD_L","CUP_optic_Eotech553_OD",["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","CUP_50Rnd_570x28_Green_Tracer_P90_M","CUP_50Rnd_570x28_Green_Tracer_P90_M"], [], ""], 1,
+	["CUP_smg_EVO","CUP_muzzle_snds_MP5","CUP_acc_ANPEQ_15_Flashlight_Black_L","CUP_optic_HoloBlack",["CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO","CUP_30Rnd_9x19_EVO"], [], ""], 3
 ];
 ////////////////////////////////////////////////
-
-//Elite loadout TODO:
-// - Build lists of optics, attachments, etc
-// - standardize on 6.8mm ACRs for rifles, Mk20s are gone now
-// - LMGs are Mk200s supplanted by the modern LMGs (Mk48, M249)
-// - rationalize other categories
-// - set weights on EVERYTHING
 
 (_eliteLoadoutData get "slRifles") append [
     ["CUP_arifle_XM8_Carbine_GL_Rail_Green", "","CUP_acc_ANPEQ_15_Flashlight_OD_L","CUP_optic_Elcan_SpecterDR_KF_RMR_od",["CUP_30Rnd_TE1_Green_Tracer_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8","CUP_30Rnd_556x45_XM8"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
@@ -448,10 +411,6 @@ _cupSFSniperOptics = [];
 ];
 //////////////////////////////////////////////////////
 
-//Military TODO:
-//- Standardize on some G3s and G36s complementing Mk20s
-//- LMGs are M240/M249/MG36, maybe some Mk200
-
 (_militaryLoadoutData get "slRifles") append [
     ["CUP_arifle_DSA_SA58_OSW_M203", "","CUP_acc_Flashlight","CUP_optic_RCO",["CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_762x51_FNFAL_M","CUP_30Rnd_TE1_Green_Tracer_762x51_FNFAL_M"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""],
 
@@ -572,10 +531,6 @@ _cupSFSniperOptics = [];
 ];
 /////////////
 
-//militia TODO:
-//- holy shit trim that list of guns down
-//- Override base Mk20/TRG21 spawns, instead go for majority M16 with some FALs and a few M14s
-
 (_militiaLoadoutData get "slRifles") append [
     ["CUP_arifle_M16A1GL", "","","",["CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag","CUP_20Rnd_556x45_Stanag_Tracer_Green"], ["CUP_1Rnd_HEDP_M203","CUP_1Rnd_HE_M203","CUP_1Rnd_StarFlare_Red_M203","CUP_1Rnd_StarCluster_Red_M203","CUP_FlareRed_M203","CUP_1Rnd_SmokeRed_M203"], ""]
 ];
@@ -673,9 +628,7 @@ _cupSFSniperOptics = [];
 	["CUP_srifle_M24_blk","","","CUP_optic_SB_11_4x20_PM",["CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24","CUP_5Rnd_762x51_M24"], [], "CUP_bipod_Harris_1A2_L_BLK"]
 ];
 ///////////
-//Police TODO:
-//- Trim down pistol list to modern CZ75s and Glocks
-//- Trim down SMG list somewhat, no shields, occasional M4
+
 (_policeLoadoutData get "sidearms") append [
     ["CUP_hgun_Browning_HP", "", "", "", ["CUP_13Rnd_9x19_Browning_HP","CUP_13Rnd_9x19_Browning_HP"], [], ""],
 	["CUP_hgun_CZ75", "", "", "", ["CUP_hgun_CZ75","CUP_hgun_CZ75"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -568,7 +568,7 @@ _policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE", 6, "V_Rangemaster_belt
 private _helmets = ["H_Cap_police", 10];
 
 _policeLoadoutData set ["helmets", _helmets];
-_policeSMGSights = ["optic_Aco_smg, 3, "", 7];
+_policeSMGSights = ["optic_Aco_smg", 3, "", 7];
 _policeAttachments = ["acc_flashlight", 6, "", 4];
 _policeLoadoutData set ["SMGs", [
 ["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -480,13 +480,13 @@ _eliteLoadoutData set ["SMGs", [
 ["SMG_02_F", "", _eliteAccessories, _eliteP90Optics, [], [], ""], 0.5
 ]];
 
-_eliteMGOptics = ["optic_NVS", 0.75, "optic_MRCO", 5, "optic_Holosight_blk_F", 2.5, "optic_Hamr", 1.75];
+_eliteMGOptics = ["optic_NVS", 0.75, "optic_MRCO", 4, "optic_Holosight_blk_F", 2.75, "optic_Hamr", 2.5];
 
 _eliteLoadoutData set ["machineGuns", [
     ["LMG_Mk200_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 10
 ]];
 
-_eliteMarksmanOptics = ["optic_DMS", 6, "optic_NVS", 2, "optic_SOS", 2];
+_eliteMarksmanOptics = ["optic_DMS", 6, "optic_NVS", 1, "optic_SOS", 3];
 
 _eliteLoadoutData set ["marksmanRifles", [
    ["srifle_EBR_F", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10
@@ -495,7 +495,7 @@ _eliteLoadoutData set ["marksmanRifles", [
 _eliteSniperOptics = ["optic_LRPS", 5, "optic_SOS", 2, "optic_TWS", 3];
 
 _eliteLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", _eliteSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
+["srifle_GM6_F", "", "", _eliteSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 10
 ]];
 _eliteLoadoutData set ["sidearms", [
 ["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""], 10

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -589,7 +589,7 @@ _policeLoadoutData set ["helmets", _helmets];
 _policeSMGSights = ["optic_Aco_smg", 3, "", 7];
 _policeAttachments = ["acc_flashlight", 6, "", 4];
 _policeLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5
+["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5,
 ["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
 ["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -375,16 +375,16 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_sfLoadoutData set ["vests", ["V_TacVest_oli", 1, "V_PlateCarrierIA2_dgtl", 2, "V_PlateCarrierIA1_dgtl", 2]];
-_sfLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1, "V_PlateCarrierIAGL_oli", 1.5]];
-_sfLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl","B_Kitbag_sgg"]];
-_sfLoadoutData set ["helmets", ["H_HelmetIA", 4, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 1, "H_Cap_headphones", 1,"H_Booniehat_khk_hs", 0.5, "H_Booniehat_oli", 1, "H_Booniehat_dgtl", 2,"H_Watchcap_camo", 1,"H_Shemag_olive", 0.5, "H_Shemag_olive_hs", 0.5]];
-_sfLoadoutData set ["uniforms", ["U_I_CombatUniform", 2, "U_I_CombatUniform_shortsleeve", 3]];
+_sfLoadoutData set ["vests", ["V_TacVest_oli", 2, "V_PlateCarrierIA2_dgtl", 4, "V_PlateCarrierIA1_dgtl", 4]];
+_sfLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 4, "V_PlateCarrierIAGL_oli", 6]];
+_sfLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 1, "B_Carryall_oli", 1, "B_AssaultPack_dgtl", 3, "B_Kitbag_sgg", 3]];
+_sfLoadoutData set ["helmets", ["H_HelmetIA", 5, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.25, "H_Cap_headphones", 0.25,"H_Booniehat_khk_hs", 0.25, "H_Booniehat_oli", 0.5, "H_Booniehat_dgtl", 1.5, "H_Watchcap_camo", 0.25,"H_Shemag_olive", 0.5, "H_Shemag_olive_hs", 0.5]];
+_sfLoadoutData set ["uniforms", ["U_I_CombatUniform", 4, "U_I_CombatUniform_shortsleeve", 6]];
 _sfLoadoutData set ["binoculars", ["Rangefinder"]];
 
 _sfAccessories = ["acc_pointer_IR", 10];
 _sfTlOptics = ["optic_ACO_grn", 1, "optic_Holosight_blk_F", 2, "optic_Hamr", 4, "optic_MRCO", 3];
-_sfRifleOptics = ["optic_ACO_grn", 0.75, "optic_Holosight_blk_F", 1.75, "optic_Hamr", 1.5, "optic_MRCO", 1];
+_sfRifleOptics = ["optic_ACO_grn", 1.5, "optic_Holosight_blk_F", 3.5, "optic_Hamr", 3, "optic_MRCO", 2];
 
 _sfLoadoutData set ["slRifles", [
 ["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.75,
@@ -393,29 +393,29 @@ _sfLoadoutData set ["slRifles", [
 ["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
 ]];
 _sfLoadoutData set ["rifles", [
-["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.66,
-["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.34
+["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.5,
+["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.5
 ]];
 _sfLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.66,
-["arifle_Mk20C_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.34
+["arifle_Mk20C_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.5,
+["arifle_Mk20C_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.5
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 6.66,
-["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3.34
+["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 6.5,
+["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3.5
 ]];
 
 _sfSMGoptics = ["optic_Aco_smg", 3, "optic_Holosight", 7];
 _sfP90optics = ["optic_Aco_smg", 3, "optic_Holosight_blk_F", 7];
 _sfLoadoutData set ["SMGs", [
-["SMG_01_F", "muzzle_snds_acp", "", _sfSMGoptics, [], [], ""], 4,
-["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 4,
-["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 6,
-["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
-["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
-["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 3.5,
+["SMG_01_F", "muzzle_snds_acp", "", _sfSMGoptics, [], [], ""], 2,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 2,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
+["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 1.5,
 ]];
 
 _sfMGOptics = ["optic_tws_mg", 2.5, "optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_Hamr", 3, "optic_ACO_grn", 1];
@@ -432,7 +432,7 @@ _sfLoadoutData set ["sniperRifles", [
 ["srifle_GM6_F", "", "", _sfSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
 _sfLoadoutData set ["sidearms", [
-["hgun_ACPC2_F", "muzzle_snds_acp", "acc_flashlight_pistol", "", [], [], ""], 1
+["hgun_ACPC2_F", "muzzle_snds_acp", "acc_flashlight_pistol", "", [], [], ""], 10
 ]];
 
 /////////////////////////////////
@@ -467,17 +467,17 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 10
 ]];
 
-_eliteSMGoptics = ["optic_Aco_smg", 4, "optic_Holosight", 6];
-_eliteP90optics = ["optic_Aco_smg", 4, "optic_Holosight_blk_F", 6];
+_eliteSMGOptics = ["optic_Aco_smg", 4, "optic_Holosight", 6];
+_eliteP90Optics = ["optic_Aco_smg", 4, "optic_Holosight_blk_F", 6];
 
 _eliteLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", _eliteSMGoptics, [], [], ""], 2,
+["SMG_01_F", "", "acc_flashlight_smg_01", _eliteSMGOptics, [], [], ""], 2,
 ["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25, 
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3.5,
-["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25
-["SMG_02_F", "", _eliteAccessories, _eliteP90optics, [], [], ""], 0.5
+["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3.5,
+["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25
+["SMG_02_F", "", _eliteAccessories, _eliteP90Optics, [], [], ""], 0.5
 ]];
 
 _eliteMGOptics = ["optic_NVS", 0.75, "optic_MRCO", 5, "optic_Holosight_blk_F", 2.5, "optic_Hamr", 1.75];
@@ -628,8 +628,10 @@ _militiaMarksmanSights = ["optic_MRCO", 10];
 _militiaLoadoutData set ["marksmanRifles", [
     ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanSights, [], [], "bipod_03_F_blk"], 10
 ]];
+
+_militiaSniperSights = ["optic_SOS", 10];
 _militiaLoadoutData set ["sniperRifles", [
-    ["srifle_EBR_F", "", "", "optic_SOS", [], [], "bipod_03_F_blk"], 10
+    ["srifle_EBR_F", "", "", _militiaSniperSights, [], [], "bipod_03_F_blk"], 10
 ]];
 
 _militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F", 10]];
@@ -640,17 +642,17 @@ _militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F", 10]];
 
 
 private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData; 
-_crewLoadoutData set ["uniforms", ["U_I_CombatUniform", "U_I_CombatUniform_shortsleeve"]];
+_crewLoadoutData set ["uniforms", ["U_I_CombatUniform", 4, "U_I_CombatUniform_shortsleeve", 6],];
 if (_hasTanks) then {
-    _crewLoadoutData set ["uniforms", ["U_Tank_green_F"]];
+    _crewLoadoutData set ["uniforms", ["U_Tank_green_F", 10]];
 };
-_crewLoadoutData set ["vests", ["V_BandollierB_oli", 1]];
-_crewLoadoutData set ["helmets", ["H_HelmetCrew_I", 1]];
+_crewLoadoutData set ["vests", ["V_BandollierB_oli", 10]];
+_crewLoadoutData set ["helmets", ["H_HelmetCrew_I", 10]];
 
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_pilotLoadoutData set ["uniforms", ["U_I_HeliPilotCoveralls", 1, "U_I_pilotCoveralls", 1]];
-_pilotLoadoutData set ["vests", ["V_TacVest_oli", 1]];
-_pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", 1, "H_CrewHelmetHeli_I", 1]];
+_pilotLoadoutData set ["uniforms", ["U_I_HeliPilotCoveralls", 5, "U_I_pilotCoveralls", 5]];
+_pilotLoadoutData set ["vests", ["V_TacVest_oli", 10]];
+_pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", 5, "H_CrewHelmetHeli_I", 5]];
 
 ////
 if (_hasMarksman) then {

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -434,61 +434,63 @@ _sfLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _eliteLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_eliteLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", "U_I_CombatUniform"]];
+_eliteLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 1, "U_I_CombatUniform", 1]];
 _eliteLoadoutData set ["slUniforms", ["U_I_OfficerUniform"]];
-_eliteLoadoutData set ["vests", ["V_TacVest_oli", "V_PlateCarrierIA2_dgtl", "V_PlateCarrierIA1_dgtl"]];
-_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl","V_PlateCarrierIAGL_oli"]];
+_eliteLoadoutData set ["vests", ["V_TacVest_oli", 1, "V_PlateCarrierIA2_dgtl", 1.5, "V_PlateCarrierIA1_dgtl", 1.5]];
+_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1,"V_PlateCarrierIAGL_oli", 1.5]];
 _eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl","B_Kitbag_sgg"]];
-_eliteLoadoutData set ["helmets", ["H_HelmetIA","H_Cap_blk_Raven","H_Cap_oli_hs","H_Cap_headphones","H_Booniehat_khk_hs","H_Booniehat_oli","H_Booniehat_dgtl","H_Watchcap_camo","H_Shemag_olive","H_Shemag_olive_hs"]];
+_eliteLoadoutData set ["helmets", ["H_HelmetIA", 8, "H_Cap_blk_Raven", 1.5, "H_Cap_oli_hs", 1, "H_Cap_headphones", 1.5, "H_Booniehat_khk_hs", 0.5, "H_Booniehat_oli", 1, "H_Booniehat_dgtl", 2, "H_Watchcap_camo", 0.5, "H_Watchcap_camo", 0.5]];
+
 _eliteLoadoutData set ["binoculars", ["Rangefinder"]];
 _eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl"]];
 
+_eliteSlOptics = ["optic_MRCO", 1, "optic_Hamr", 2, "optic_Holosight_blk_F", 0.5];
+_eliteRifleOptics = ["optic_Holosight_blk_F", 3, "optic_MRCO", 1, "optic_Hamr", 0.5];
+_eliteAccessories = ["acc_pointer_IR", 1];
+
 _eliteLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "", "acc_pointer_IR", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_GL_F", "", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "", "acc_pointer_IR", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""]
+["arifle_Mk20_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
+["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1.5
 ]];
 _eliteLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "", "acc_pointer_IR", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _eliteLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20C_F", "", "acc_pointer_IR", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20C_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _eliteLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
 ]];
+
+_eliteSMGoptics = ["optic_Aco_smg", 1, "optic_Holosight", 2];
+_eliteP90optics = ["optic_Aco_smg", 1, "optic_Holosight_blk_F", 2];
 
 _eliteLoadoutData set ["SMGs", [
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_03_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03_TR_camo", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_pointer_IR", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "", _eliteSMGoptics, [], [], ""], 2,
+["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5, 
+["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
+["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5
+["SMG_02_F", "", _eliteAccessories, _eliteP90optics, [], [], ""], 0.5
 ]];
+
+_eliteMGOptics = ["optic_NVS", 0.5, "optic_MRCO", 3, "optic_Holosight_blk_F", 2, "optic_Hamr", 1];
 
 _eliteLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "", "acc_pointer_IR", "optic_NVS", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "", "acc_pointer_IR", "optic_MRCO", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "", "acc_pointer_IR", "optic_Hamr", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""]
+    ["LMG_Mk200_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1.5
 ]];
 
+_eliteMarksmanOptics = ["optic_DMS", 2, "optic_NVS", 1, "optic_Hamr", 1];
+
 _eliteLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", "acc_pointer_IR", "optic_DMS", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""],
-    ["srifle_EBR_F", "", "acc_pointer_IR", "optic_NVS", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""],
-    ["srifle_EBR_F", "", "acc_pointer_IR", "optic_Hamr", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""]
+   ["srifle_EBR_F", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1
 ]];
+
+_eliteSniperOptics = ["optic_LRPS", 3, "optic_SOS", 1, "optic_TWS", 1.5];
+
 _eliteLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", "optic_SOS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""],
-["srifle_GM6_F", "", "", "optic_LRPS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""]
+["srifle_GM6_F", "", "", _eliteSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
 _eliteLoadoutData set ["sidearms", [
 ["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""]
@@ -499,58 +501,52 @@ _eliteLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_militaryLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", "U_I_CombatUniform", "U_BG_Guerilla1_2_F"]];
+_militaryLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 2, "U_I_CombatUniform", 2, "U_BG_Guerilla1_2_F", 1]];
 _militaryLoadoutData set ["slUniforms", ["U_I_OfficerUniform"]];
-_militaryLoadoutData set ["vests", ["V_TacVest_oli", "V_PlateCarrierIA2_dgtl", "V_PlateCarrierIA1_dgtl"]];
-_militaryLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl","V_PlateCarrierIAGL_oli"]];
-_militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl","B_Kitbag_sgg"]];
-_militaryLoadoutData set ["helmets", ["H_HelmetIA","H_Cap_blk_Raven","H_Cap_oli_hs","H_Cap_headphones","H_Booniehat_khk_hs","H_Booniehat_oli","H_Booniehat_dgtl","H_Watchcap_camo"]];
+_militaryLoadoutData set ["vests", ["V_TacVest_oli", 0.5, "V_PlateCarrierIA2_dgtl", 1.5, "V_PlateCarrierIA1_dgtl", 1]];
+_militaryLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 2,"V_PlateCarrierIAGL_oli", 1]];
+_militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 1, "B_FieldPack_oli", 0.5, "B_Carryall_oli", 0.75, "B_AssaultPack_dgtl", 1,"B_Kitbag_sgg", 1]];
+_militaryLoadoutData set ["helmets", ["H_HelmetIA", 5,"H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 0.5]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
+_militaryRifleSights = ["optic_ACO_grn", 2, "optic_Holosight_blk_F", 1, "", 0.25]; //weighted list
+_militarySlRifleSights = ["optic_Hamr", 1, "optic_MRCO", 2, "optic_Holosight_blk_F", 0.5]; //unweighted list
+_militaryAttachments = ["acc_flashlight", 2, "", 1, "acc_pointer_IR", 0.1];
+
 _militaryLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", "acc_flashlight", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_GL_F", "", "acc_flashlight", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""]
+["arifle_Mk20_F", "", _militaryAttachments, _militarySlRifleSights , ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militarySlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1
 ]];
 _militaryLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "", "acc_flashlight", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _militaryLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20C_F", "", "acc_flashlight", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20C_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "", "acc_flashlight", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
 ]];
+_militarySMGSights = ["optic_Holosight_smg_blk_F", 3, "optic_Aco_grn_smg", 2];
 _militaryLoadoutData set ["SMGs", [
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_03_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03_TR_camo", "", "acc_flashlight", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_smg", [], [], ""], 6,
+["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.2,
+["SMG_03C_TR_camo", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_TR_black", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.1,
+["SMG_02_F", "", _militaryAttachments, _militarySMGSights, [], [], ""], 2
 ]];
-
+_militaryMGSights = ["optic_MRCO", 1.5, "optic_Holosight_blk_F", 2, "optic_ACO_grn", 4, "optic_Hamr", 0.5];
 _militaryLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "", "acc_flashlight", "optic_Hamr", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""]
+    ["LMG_Mk200_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1
 ]];
 
+_militaryMarksmanSights = ["optic_SOS", 2.5, "optic_MRCO", 1, "optic_Hamr", 1.5];
 _militaryLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", "acc_flashlight", "optic_SOS", [], [], ""],
-    ["srifle_EBR_F", "", "acc_flashlight", "optic_Hamr", [], [], ""]
+    ["srifle_EBR_F", "", _militaryAttachments, _militaryMarksmanSights, [], [], "bipod_03_F_blk"], 1
 ]];
-
+_militarySniperSights = ["optic_SOS", 1.5, "optic_LRPS", 1];
 _militaryLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", "optic_SOS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""],
-["srifle_GM6_F", "", "", "optic_LRPS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""]
+["srifle_GM6_F", "", "", _militarySniperSights , ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
 _militaryLoadoutData set ["sidearms", [
 ["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""]
@@ -566,14 +562,15 @@ _policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE","V_Rangemaster_belt"]];
 private _helmets = ["H_Cap_police"];
 
 _policeLoadoutData set ["helmets", _helmets];
+_policeSMGSights = ["optic_Aco_smg", 1, "", 2];
+_policeAttachments = ["acc_flashlight", 1, "", 2];
 _policeLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_03_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5
+["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 2,
+["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25
+["SMG_02_F", "", _policeAttachments, _policeSMGSights, [], [], ""], 6
 ]];
 _policeLoadoutData set ["sidearms", ["hgun_Rook40_F"]];
 
@@ -582,48 +579,55 @@ _policeLoadoutData set ["sidearms", ["hgun_Rook40_F"]];
 ////////////////////////////////
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", "U_I_CombatUniform_shortsleeve", "U_BG_Guerilla1_2_F"]];
-_militiaLoadoutData set ["vests", ["V_BandollierB_oli", "V_Chestrig_oli", "V_TacVest_oli"]];
-_militiaLoadoutData set ["Hvests", ["V_TacVest_oli"]];
-_militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_AssaultPack_dgtl"]];
-_militiaLoadoutData set ["helmets", ["H_HelmetIA", "H_Booniehat_dgtl", "H_Cap_blk_Raven"]];
+_militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", 1, "U_I_CombatUniform_shortsleeve", 1, "U_BG_Guerilla1_2_F", 1.5]];
+_militiaLoadoutData set ["vests", ["V_BandollierB_oli", 0.5, "V_Chestrig_oli", 2, "V_TacVest_oli", 1.5]];
+_militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 1]];
+_militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 2, "B_AssaultPack_dgtl", 1]];
+_militiaLoadoutData set ["helmets", ["H_HelmetIA", 2, "H_Booniehat_dgtl", 1.5, "H_Cap_blk_Raven", 1]];
+
+_militiaRifleSights = ["optic_ACO_grn", 1, "", 4];
+_militiaSlRifleSights = ["optic_ACO_grn", 1, "optic_MRCO", 1.5, "", 1];
+_militiaAttachments = ["acc_flashlight", 1, "", 1.5];
 
 _militiaLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""]
+["arifle_Mk20_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3,
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
 ]];
 _militiaLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_TRG21_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3,
+["arifle_TRG21_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _militiaLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_TRG20_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20C_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3, 
+["arifle_TRG20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
-["arifle_TRG21_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
-]];
-_militiaLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_03_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "", "acc_flashlight", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
-]];
-_militiaLoadoutData set ["machineGuns", [
-["LMG_Mk200_F", "", "acc_flashlight", "", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"]
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3,
+["arifle_TRG21_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
 ]];
 
+_militiaSMGsights = ["optic_Aco_smg", 1, "", 2];
+
+_militiaLoadoutData set ["SMGs", [
+["SMG_01_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 2,
+["SMG_03_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03_TR_camo", "", _militiaAttachments, _militiaSMGsights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
+["SMG_03C_TR_camo", "", _militiaAttachments, _militiaSMGsights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_02_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 6
+]];
+
+_militiaMGSights = ["optic_ACO_grn", 1, "", 5];
+_militiaLoadoutData set ["machineGuns", [
+["LMG_Mk200_F", "", _militiaAttachments, "", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 1
+]];
+
+_militiaMarksmanSights = ["optic_MRCO", 1];
 _militiaLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", "acc_flashlight", "optic_MRCO", [], [], ""]
+    ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanSights, [], [], "bipod_03_F_blk"], 1
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-    ["srifle_EBR_F", "", "", "optic_SOS", [], [], ""]
+    ["srifle_EBR_F", "", "", "optic_SOS", [], [], ""], 1
 ]];
 
 _militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F"]];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -514,7 +514,7 @@ _militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2.5, "B_FieldPack_
 _militaryLoadoutData set ["helmets", ["H_HelmetIA", 6.9, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 1.25]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
-_militaryRifleSights = ["optic_ACO_grn", 6, "optic_Holosight_blk_F", 3, "", 1];
+_militaryRifleSights = ["optic_ACO_grn", 4, "optic_Holosight_blk_F", 2, "", 0.5];
 _militarySlRifleSights = ["optic_Hamr", 2, "optic_MRCO", 6, "optic_Holosight_blk_F", 2];
 _militaryAttachments = ["acc_flashlight", 7, "", 2, "acc_pointer_IR", 1];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -253,6 +253,10 @@ if (_hasSOG) then {
 //       Loadouts       //
 //////////////////////////
 
+// Note on loadout array weighting:
+// If a given loadoutData variable has a weighted array, make sure all mod/DLC compats also have a weighted array for the same.
+// To simplify work on mod/DLC compats, the weighted arrays here are made to sum up to 10. This is so that compats have a consistent base to work off but is not strictly necessary.
+
 private _loadoutData = call _fnc_createLoadoutData;
 _loadoutData set ["slRifles", []];
 _loadoutData set ["rifles", []];
@@ -434,66 +438,66 @@ _sfLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _eliteLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_eliteLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 1, "U_I_CombatUniform", 1]];
-_eliteLoadoutData set ["slUniforms", ["U_I_OfficerUniform"]];
-_eliteLoadoutData set ["vests", ["V_TacVest_oli", 1, "V_PlateCarrierIA2_dgtl", 1.5, "V_PlateCarrierIA1_dgtl", 1.5]];
-_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1,"V_PlateCarrierIAGL_oli", 1.5]];
-_eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl","B_Kitbag_sgg"]];
-_eliteLoadoutData set ["helmets", ["H_HelmetIA", 8, "H_Cap_blk_Raven", 1.5, "H_Cap_oli_hs", 1, "H_Cap_headphones", 1.5, "H_Booniehat_khk_hs", 0.5, "H_Booniehat_oli", 1, "H_Booniehat_dgtl", 2, "H_Watchcap_camo", 0.5, "H_Watchcap_camo", 0.5]];
+_eliteLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 5, "U_I_CombatUniform", 5]];
+_eliteLoadoutData set ["slUniforms", ["U_I_OfficerUniform", 10]];
+_eliteLoadoutData set ["vests", ["V_PlateCarrierIA2_dgtl", 3.75, "V_PlateCarrierIA1_dgtl", 3.75, "V_PlateCarrierIAGL_dgtl", 1.5,"V_PlateCarrierIAGL_oli", 1]];
+_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1.5,"V_PlateCarrierIAGL_oli", 1]];
+_eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 0.5, "B_Carryall_oli", 1, "B_AssaultPack_dgtl", 3,"B_Kitbag_sgg", 3.5]];
+_eliteLoadoutData set ["helmets", ["H_HelmetIA", 6.75, "H_Cap_blk_Raven", 0.5, "H_Cap_oli_hs", 0.25, "H_Cap_headphones", 0.25, "H_Booniehat_oli", 0.5, "H_Booniehat_dgtl", 1.25, "H_Watchcap_camo", 0.25, "H_Watchcap_camo", 0.25]];
 
 _eliteLoadoutData set ["binoculars", ["Rangefinder"]];
 _eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl"]];
 
-_eliteSlOptics = ["optic_MRCO", 1, "optic_Hamr", 2, "optic_Holosight_blk_F", 0.5];
-_eliteRifleOptics = ["optic_Holosight_blk_F", 3, "optic_MRCO", 1, "optic_Hamr", 0.5];
-_eliteAccessories = ["acc_pointer_IR", 1];
+_eliteSlOptics = ["optic_MRCO", 3, "optic_Hamr", 6, "optic_Holosight_blk_F", 1];
+_eliteRifleOptics = ["optic_Holosight_blk_F", 7, "optic_MRCO", 2, "optic_Hamr", 1];
+_eliteAccessories = ["acc_pointer_IR", 10];
 
 _eliteLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
-["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1.5
+["arifle_Mk20_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 4,
+["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteSlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 6
 ]];
 _eliteLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _eliteLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20C_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _eliteLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
+["arifle_Mk20_GL_F", "", _eliteAccessories, _eliteRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 10
 ]];
 
-_eliteSMGoptics = ["optic_Aco_smg", 1, "optic_Holosight", 2];
-_eliteP90optics = ["optic_Aco_smg", 1, "optic_Holosight_blk_F", 2];
+_eliteSMGoptics = ["optic_Aco_smg", 4, "optic_Holosight", 6];
+_eliteP90optics = ["optic_Aco_smg", 4, "optic_Holosight_blk_F", 6];
 
 _eliteLoadoutData set ["SMGs", [
-["SMG_01_F", "", "", _eliteSMGoptics, [], [], ""], 2,
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5, 
-["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
-["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5
+["SMG_01_F", "", "acc_flashlight_smg_01", _eliteSMGoptics, [], [], ""], 2,
+["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25, 
+["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3.5,
+["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25
 ["SMG_02_F", "", _eliteAccessories, _eliteP90optics, [], [], ""], 0.5
 ]];
 
-_eliteMGOptics = ["optic_NVS", 0.5, "optic_MRCO", 3, "optic_Holosight_blk_F", 2, "optic_Hamr", 1];
+_eliteMGOptics = ["optic_NVS", 0.75, "optic_MRCO", 5, "optic_Holosight_blk_F", 2.5, "optic_Hamr", 1.75];
 
 _eliteLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1.5
+    ["LMG_Mk200_F", "", _eliteAccessories, _eliteMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 10
 ]];
 
-_eliteMarksmanOptics = ["optic_DMS", 2, "optic_NVS", 1, "optic_Hamr", 1];
+_eliteMarksmanOptics = ["optic_DMS", 6, "optic_NVS", 2, "optic_SOS", 2];
 
 _eliteLoadoutData set ["marksmanRifles", [
-   ["srifle_EBR_F", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 1
+   ["srifle_EBR_F", "", _eliteAccessories, _eliteMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], "bipod_03_F_blk"], 10
 ]];
 
-_eliteSniperOptics = ["optic_LRPS", 3, "optic_SOS", 1, "optic_TWS", 1.5];
+_eliteSniperOptics = ["optic_LRPS", 5, "optic_SOS", 2, "optic_TWS", 3];
 
 _eliteLoadoutData set ["sniperRifles", [
 ["srifle_GM6_F", "", "", _eliteSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
 _eliteLoadoutData set ["sidearms", [
-["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""]
+["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""], 10
 ]];
 
 /////////////////////////////////
@@ -501,55 +505,55 @@ _eliteLoadoutData set ["sidearms", [
 /////////////////////////////////
 
 private _militaryLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_militaryLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 2, "U_I_CombatUniform", 2, "U_BG_Guerilla1_2_F", 1]];
-_militaryLoadoutData set ["slUniforms", ["U_I_OfficerUniform"]];
-_militaryLoadoutData set ["vests", ["V_TacVest_oli", 0.5, "V_PlateCarrierIA2_dgtl", 1.5, "V_PlateCarrierIA1_dgtl", 1]];
-_militaryLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 2,"V_PlateCarrierIAGL_oli", 1]];
+_militaryLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 3, "U_I_CombatUniform", 3, "U_BG_Guerilla1_2_F", 2]];
+_militaryLoadoutData set ["slUniforms", ["U_I_OfficerUniform", 10]];
+_militaryLoadoutData set ["vests", ["V_TacVest_oli", 2, "V_PlateCarrierIA2_dgtl", 5, "V_PlateCarrierIA1_dgtl", 3]];
+_militaryLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 7,"V_PlateCarrierIAGL_oli", 3]];
 _militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 1, "B_FieldPack_oli", 0.5, "B_Carryall_oli", 0.75, "B_AssaultPack_dgtl", 1,"B_Kitbag_sgg", 1]];
-_militaryLoadoutData set ["helmets", ["H_HelmetIA", 5,"H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 0.5]];
+_militaryLoadoutData set ["helmets", ["H_HelmetIA", 6.9, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 1.25]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
-_militaryRifleSights = ["optic_ACO_grn", 2, "optic_Holosight_blk_F", 1, "", 0.25]; //weighted list
-_militarySlRifleSights = ["optic_Hamr", 1, "optic_MRCO", 2, "optic_Holosight_blk_F", 0.5]; //unweighted list
-_militaryAttachments = ["acc_flashlight", 2, "", 1, "acc_pointer_IR", 0.1];
+_militaryRifleSights = ["optic_ACO_grn", 6, "optic_Holosight_blk_F", 3, "", 1];
+_militarySlRifleSights = ["optic_Hamr", 2, "optic_MRCO", 6, "optic_Holosight_blk_F", 2];
+_militaryAttachments = ["acc_flashlight", 7, "", 2, "acc_pointer_IR", 1];
 
 _militaryLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", _militaryAttachments, _militarySlRifleSights , ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
-["arifle_Mk20_GL_F", "", _militaryAttachments, _militarySlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1
+["arifle_Mk20_F", "", _militaryAttachments, _militarySlRifleSights , ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 4,
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militarySlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 6
 ]];
 _militaryLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _militaryLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20C_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 10
 ]];
-_militarySMGSights = ["optic_Holosight_smg_blk_F", 3, "optic_Aco_grn_smg", 2];
+_militarySMGSights = ["optic_Holosight_smg_blk_F", 4, "optic_Aco_grn_smg", 6];
 _militaryLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_smg", [], [], ""], 6,
-["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.2,
-["SMG_03C_TR_camo", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
-["SMG_03C_TR_black", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.1,
-["SMG_02_F", "", _militaryAttachments, _militarySMGSights, [], [], ""], 2
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_smg", [], [], ""], 5,
+["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25,
+["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
+["SMG_03C_TR_camo", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
+["SMG_02_F", "", _militaryAttachments, _militarySMGSights, [], [], ""], 2.5
 ]];
-_militaryMGSights = ["optic_MRCO", 1.5, "optic_Holosight_blk_F", 2, "optic_ACO_grn", 4, "optic_Hamr", 0.5];
+_militaryMGSights = ["optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_ACO_grn", 5, "optic_Hamr", 1];
 _militaryLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1
+    ["LMG_Mk200_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 10
 ]];
 
-_militaryMarksmanSights = ["optic_SOS", 2.5, "optic_MRCO", 1, "optic_Hamr", 1.5];
+_militaryMarksmanSights = ["optic_DMS", 3, "optic_MRCO", 2.5, "optic_Hamr", 4.5];
 _militaryLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", _militaryAttachments, _militaryMarksmanSights, [], [], "bipod_03_F_blk"], 1
+    ["srifle_EBR_F", "", _militaryAttachments, _militaryMarksmanSights, [], [], "bipod_03_F_blk"], 10
 ]];
-_militarySniperSights = ["optic_SOS", 1.5, "optic_LRPS", 1];
+_militarySniperSights = ["optic_SOS", 6, "optic_LRPS", 4];
 _militaryLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", _militarySniperSights , ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
+["srifle_GM6_F", "", "", _militarySniperSights , ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 10
 ]];
 _militaryLoadoutData set ["sidearms", [
-["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""]
+["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""], 10
 ]];
 
 ///////////////////////////////
@@ -557,80 +561,77 @@ _militaryLoadoutData set ["sidearms", [
 ///////////////////////////////
 
 private _policeLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_policeLoadoutData set ["uniforms", ["U_Marshal"]];
-_policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE","V_Rangemaster_belt"]];
-private _helmets = ["H_Cap_police"];
+_policeLoadoutData set ["uniforms", ["U_Marshal", 10]];
+_policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE", 6, "V_Rangemaster_belt", 4]];
+private _helmets = ["H_Cap_police", 10];
 
 _policeLoadoutData set ["helmets", _helmets];
-_policeSMGSights = ["optic_Aco_smg", 1, "", 2];
-_policeAttachments = ["acc_flashlight", 1, "", 2];
+_policeSMGSights = ["optic_Aco_smg", 3, "", 7];
+_policeAttachments = ["acc_flashlight", 6, "", 4];
 _policeLoadoutData set ["SMGs", [
 ["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5
-["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 2,
+["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
-["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25
+["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
+["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75
 ["SMG_02_F", "", _policeAttachments, _policeSMGSights, [], [], ""], 6
 ]];
-_policeLoadoutData set ["sidearms", ["hgun_Rook40_F"]];
+_policeLoadoutData set ["sidearms", ["hgun_Rook40_F", 10]];
 
 ////////////////////////////////
 //    Militia Loadout Data    //
 ////////////////////////////////
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", 1, "U_I_CombatUniform_shortsleeve", 1, "U_BG_Guerilla1_2_F", 1.5]];
+_militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", 3, "U_I_CombatUniform_shortsleeve", 3, "U_BG_Guerilla1_2_F", 4]];
 _militiaLoadoutData set ["vests", ["V_BandollierB_oli", 0.5, "V_Chestrig_oli", 2, "V_TacVest_oli", 1.5]];
 _militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 1]];
 _militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 2, "B_AssaultPack_dgtl", 1]];
 _militiaLoadoutData set ["helmets", ["H_HelmetIA", 2, "H_Booniehat_dgtl", 1.5, "H_Cap_blk_Raven", 1]];
 
-_militiaRifleSights = ["optic_ACO_grn", 1, "", 4];
-_militiaSlRifleSights = ["optic_ACO_grn", 1, "optic_MRCO", 1.5, "", 1];
-_militiaAttachments = ["acc_flashlight", 1, "", 1.5];
+_militiaRifleSights = ["optic_ACO_grn", 2, "", 8];
+_militiaSlRifleSights = ["optic_ACO_grn", 3.5, "optic_MRCO", 4.5, "", 2];
+_militiaAttachments = ["acc_flashlight", 4, "", 6];
 
 _militiaLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3,
-["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
+["arifle_Mk20_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6,
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4
 ]];
 _militiaLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3,
-["arifle_TRG21_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5,
+["arifle_TRG21_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
 ]];
 _militiaLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3, 
-["arifle_TRG20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20C_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5, 
+["arifle_TRG20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3,
-["arifle_TRG21_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 7.5,
+["arifle_TRG21_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 2.5
 ]];
 
-_militiaSMGsights = ["optic_Aco_smg", 1, "", 2];
+_militiaSMGsights = ["optic_Aco_smg", 3, "", 7];
 
 _militiaLoadoutData set ["SMGs", [
-["SMG_01_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 2,
-["SMG_03_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
-["SMG_03C_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03_TR_camo", "", _militiaAttachments, _militiaSMGsights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
-["SMG_03C_TR_camo", "", _militiaAttachments, _militiaSMGsights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_02_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 6
+["SMG_01_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 1,
+["SMG_03C_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
+["SMG_02_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 7.5
 ]];
 
-_militiaMGSights = ["optic_ACO_grn", 1, "", 5];
+_militiaMGSights = ["optic_ACO_grn", 1.5, "", 8.5];
 _militiaLoadoutData set ["machineGuns", [
-["LMG_Mk200_F", "", _militiaAttachments, "", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 1
+["LMG_Mk200_F", "", _militiaAttachments, "", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 10
 ]];
 
-_militiaMarksmanSights = ["optic_MRCO", 1];
+_militiaMarksmanSights = ["optic_MRCO", 10];
 _militiaLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanSights, [], [], "bipod_03_F_blk"], 1
+    ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanSights, [], [], "bipod_03_F_blk"], 10
 ]];
 _militiaLoadoutData set ["sniperRifles", [
-    ["srifle_EBR_F", "", "", "optic_SOS", [], [], ""], 1
+    ["srifle_EBR_F", "", "", "optic_SOS", [], [], "bipod_03_F_blk"], 10
 ]];
 
-_militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F"]];
+_militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F", 10]];
 
 //////////////////////////
 //    Misc Loadouts     //

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -426,17 +426,17 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3.5
 ]];
 
-_sfSMGoptics = ["optic_Aco_smg", 3, "optic_Holosight", 7];
-_sfP90optics = ["optic_Aco_smg", 3, "optic_Holosight_blk_F", 7];
+_sfSMGOptics = ["optic_Aco_smg", 3, "optic_Holosight", 7];
+_sfP90Optics = ["optic_Aco_smg", 3, "optic_Holosight_blk_F", 7];
 _sfLoadoutData set ["SMGs", [
-["SMG_01_F", "muzzle_snds_acp", "", _sfSMGoptics, [], [], ""], 2,
+["SMG_01_F", "muzzle_snds_acp", "", _sfSMGOptics, [], [], ""], 2,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 2,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
-["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
-["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 1.5
+["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
+["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90Optics, [], [], ""], 1.5
 ]];
 
 _sfMGOptics = ["optic_tws_mg", 2.5, "optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_Hamr", 3, "optic_ACO_grn", 1];
@@ -535,44 +535,44 @@ _militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2.5, "B_FieldPack_
 _militaryLoadoutData set ["helmets", ["H_HelmetIA", 6.9, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 1.25]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
-_militaryRifleSights = ["optic_ACO_grn", 6, "optic_Holosight_blk_F", 3, "", 1];
-_militarySlRifleSights = ["optic_Hamr", 2, "optic_MRCO", 6, "optic_Holosight_blk_F", 2];
+_militaryRifleOptics = ["optic_ACO_grn", 6, "optic_Holosight_blk_F", 3, "", 1];
+_militarySlRifleOptics = ["optic_Hamr", 2, "optic_MRCO", 6, "optic_Holosight_blk_F", 2];
 _militaryAttachments = ["acc_flashlight", 7, "", 2, "acc_pointer_IR", 1];
 
 _militaryLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", _militaryAttachments, _militarySlRifleSights , ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 4,
-["arifle_Mk20_GL_F", "", _militaryAttachments, _militarySlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 6
+["arifle_Mk20_F", "", _militaryAttachments, _militarySlRifleOptics , ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 4,
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militarySlRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 6
 ]];
 _militaryLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
+["arifle_Mk20_F", "", _militaryAttachments, _militaryRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _militaryLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
+["arifle_Mk20C_F", "", _militaryAttachments, _militaryRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 10
 ]];
 _militaryLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", _militaryAttachments, _militaryRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 10
+["arifle_Mk20_GL_F", "", _militaryAttachments, _militaryRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 10
 ]];
-_militarySMGSights = ["optic_Holosight_smg_blk_F", 4, "optic_Aco_grn_smg", 6];
+_militarySMGOptics = ["optic_Holosight_smg_blk_F", 4, "optic_Aco_grn_smg", 6];
 _militaryLoadoutData set ["SMGs", [
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_smg", [], [], ""], 5,
 ["SMG_03C_camo", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25,
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
-["SMG_03C_TR_camo", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_03C_TR_black", "", _militaryAttachments, _militarySMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
-["SMG_02_F", "", _militaryAttachments, _militarySMGSights, [], [], ""], 2.5
+["SMG_03C_TR_camo", "", _militaryAttachments, _militarySMGOptics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_03C_TR_black", "", _militaryAttachments, _militarySMGOptics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
+["SMG_02_F", "", _militaryAttachments, _militarySMGOptics, [], [], ""], 2.5
 ]];
-_militaryMGSights = ["optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_ACO_grn", 5, "optic_Hamr", 1];
+_militaryMGOptics = ["optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_ACO_grn", 5, "optic_Hamr", 1];
 _militaryLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "", _militaryAttachments, _militaryMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 10
+    ["LMG_Mk200_F", "", _militaryAttachments, _militaryMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 10
 ]];
 
-_militaryMarksmanSights = ["optic_DMS", 3, "optic_MRCO", 2.5, "optic_Hamr", 4.5];
+_militaryMarksmanOptics = ["optic_DMS", 3, "optic_MRCO", 2.5, "optic_Hamr", 4.5];
 _militaryLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", _militaryAttachments, _militaryMarksmanSights, [], [], "bipod_03_F_blk"], 10
+    ["srifle_EBR_F", "", _militaryAttachments, _militaryMarksmanOptics, [], [], "bipod_03_F_blk"], 10
 ]];
-_militarySniperSights = ["optic_SOS", 6, "optic_LRPS", 4];
+_militarySniperOptics = ["optic_SOS", 6, "optic_LRPS", 4];
 _militaryLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", _militarySniperSights , ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 10
+["srifle_GM6_F", "", "", _militarySniperOptics , ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 10
 ]];
 _militaryLoadoutData set ["sidearms", [
 ["hgun_ACPC2_F", "", "acc_flashlight_pistol", "", [], [], ""], 10
@@ -588,15 +588,15 @@ _policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE", 6, "V_Rangemaster_belt
 private _helmets = ["H_Cap_police", 10];
 
 _policeLoadoutData set ["helmets", _helmets];
-_policeSMGSights = ["optic_Aco_smg", 3, "", 7];
+_policeSMGOptics = ["optic_Aco_smg", 3, "", 7];
 _policeAttachments = ["acc_flashlight", 6, "", 4];
 _policeLoadoutData set ["SMGs", [
-["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5,
+["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGOptics, [], [], ""], 1.5,
 ["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
-["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_02_F", "", _policeAttachments, _policeSMGSights, [], [], ""], 6
+["SMG_03_TR_black", "", _policeAttachments, _policeSMGOptics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
+["SMG_03C_TR_black", "", _policeAttachments, _policeSMGOptics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
+["SMG_02_F", "", _policeAttachments, _policeSMGOptics, [], [], ""], 6
 ]];
 _policeLoadoutData set ["sidearms", ["hgun_Rook40_F", 10]];
 
@@ -611,48 +611,48 @@ _militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 10]];
 _militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 4, "B_FieldPack_oli", 4, "B_AssaultPack_dgtl", 2]];
 _militiaLoadoutData set ["helmets", ["H_HelmetIA", 4, "H_Booniehat_dgtl", 3, "H_Cap_blk_Raven", 2]];
 
-_militiaRifleSights = ["optic_ACO_grn", 2, "", 8];
-_militiaSlRifleSights = ["optic_ACO_grn", 3.5, "optic_MRCO", 4.5, "", 2];
+_militiaRifleOptics = ["optic_ACO_grn", 2, "", 8];
+_militiaSlRifleOptics = ["optic_ACO_grn", 3.5, "optic_MRCO", 4.5, "", 2];
 _militiaAttachments = ["acc_flashlight", 4, "", 6];
 
 _militiaLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6,
-["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaSlRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4
+["arifle_Mk20_F", "", _militiaAttachments, _militiaSlRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6,
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaSlRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4
 ]];
 _militiaLoadoutData set ["rifles", [
-["arifle_Mk20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5,
-["arifle_TRG21_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
+["arifle_Mk20_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5,
+["arifle_TRG21_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
 ]];
 _militiaLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5, 
-["arifle_TRG20_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
+["arifle_Mk20C_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 7.5, 
+["arifle_TRG20_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.5
 ]];
 _militiaLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 7.5,
-["arifle_TRG21_GL_F", "", _militiaAttachments, _militiaRifleSights, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 2.5
+["arifle_Mk20_GL_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 7.5,
+["arifle_TRG21_GL_F", "", _militiaAttachments, _militiaRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 2.5
 ]];
 
-_militiaSMGsights = ["optic_Aco_smg", 3, "", 7];
+_militiaSMGOptics = ["optic_Aco_smg", 3, "", 7];
 
 _militiaLoadoutData set ["SMGs", [
-["SMG_01_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 1,
+["SMG_01_F", "", _militiaAttachments, _militiaSMGOptics, [], [], ""], 1,
 ["SMG_03C_camo", "", _militiaAttachments, "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
-["SMG_02_F", "", _militiaAttachments, _militiaSMGsights, [], [], ""], 7.5
+["SMG_02_F", "", _militiaAttachments, _militiaSMGOptics, [], [], ""], 7.5
 ]];
 
-_militiaMGSights = ["optic_ACO_grn", 1.5, "", 8.5];
+_militiaMGOptics = ["optic_ACO_grn", 1.5, "", 8.5];
 _militiaLoadoutData set ["machineGuns", [
-["LMG_Mk200_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 10
+["LMG_Mk200_F", "", _militiaAttachments, _militiaMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 10
 ]];
 
-_militiaMarksmanSights = ["optic_MRCO", 10];
+_militiaMarksmanOptics = ["optic_MRCO", 10];
 _militiaLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanSights, [], [], "bipod_03_F_blk"], 10
+    ["srifle_EBR_F", "", _militiaAttachments, _militiaMarksmanOptics, [], [], "bipod_03_F_blk"], 10
 ]];
 
-_militiaSniperSights = ["optic_SOS", 10];
+_militiaSniperOptics = ["optic_SOS", 10];
 _militiaLoadoutData set ["sniperRifles", [
-    ["srifle_EBR_F", "", "", _militiaSniperSights, [], [], "bipod_03_F_blk"], 10
+    ["srifle_EBR_F", "", "", _militiaSniperOptics, [], [], "bipod_03_F_blk"], 10
 ]];
 
 _militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F", 10]];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -268,20 +268,21 @@ _loadoutData set ["machineGuns", []];
 _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
-_loadoutData set ["lightATLaunchers", [
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1
+//SMAWs as disposable AT is pretty powerful so remove the HEAT75 rounds from spawn pool and rationalize things a bit
+_loadoutData set ["lightATLaunchers", [ 
+    ["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 5,
+    ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 5
 ]];
-_loadoutData set ["ATLaunchers", ["launch_NLAW_F"], 1];
+_loadoutData set ["ATLaunchers", [
+    "launch_NLAW_F", 5,
+    ["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 3,
+    ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 2]];
+    
 _loadoutData set ["missileATLaunchers", [
-["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""]
+    ["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""], 10
 ]];
 _loadoutData set ["AALaunchers", [
-["launch_I_Titan_F", "", "acc_pointer_IR", "", ["Titan_AA"], [], ""]
+    ["launch_I_Titan_F", "", "acc_pointer_IR", "", ["Titan_AA"], [], ""], 10
 ]];
 _loadoutData set ["sidearms", []];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -586,10 +586,10 @@ _policeLoadoutData set ["sidearms", ["hgun_Rook40_F", 10]];
 
 private _militiaLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
 _militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", 3, "U_I_CombatUniform_shortsleeve", 3, "U_BG_Guerilla1_2_F", 4]];
-_militiaLoadoutData set ["vests", ["V_BandollierB_oli", 0.5, "V_Chestrig_oli", 2, "V_TacVest_oli", 1.5]];
-_militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 1]];
-_militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 2, "B_AssaultPack_dgtl", 1]];
-_militiaLoadoutData set ["helmets", ["H_HelmetIA", 2, "H_Booniehat_dgtl", 1.5, "H_Cap_blk_Raven", 1]];
+_militiaLoadoutData set ["vests", ["V_BandollierB_oli", 1.25, "V_Chestrig_oli", 5, "V_TacVest_oli", 3.75]];
+_militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 10]];
+_militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 4, "B_FieldPack_oli", 4, "B_AssaultPack_dgtl", 2]];
+_militiaLoadoutData set ["helmets", ["H_HelmetIA", 4.5, "H_Booniehat_dgtl", 2.5, "H_Cap_blk_Raven", 2.5]];
 
 _militiaRifleSights = ["optic_ACO_grn", 2, "", 8];
 _militiaSlRifleSights = ["optic_ACO_grn", 3.5, "optic_MRCO", 4.5, "", 2];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -621,7 +621,7 @@ _militiaLoadoutData set ["SMGs", [
 
 _militiaMGSights = ["optic_ACO_grn", 1.5, "", 8.5];
 _militiaLoadoutData set ["machineGuns", [
-["LMG_Mk200_F", "", _militiaAttachments, "", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 10
+["LMG_Mk200_F", "", _militiaAttachments, _militiaMGSights, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_03_F_blk"], 10
 ]];
 
 _militiaMarksmanSights = ["optic_MRCO", 10];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -661,7 +661,7 @@ _militiaLoadoutData set ["sidearms", ["hgun_ACPC2_F", 10]];
 
 
 private _crewLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData; 
-_crewLoadoutData set ["uniforms", ["U_I_CombatUniform", 4, "U_I_CombatUniform_shortsleeve", 6],];
+_crewLoadoutData set ["uniforms", ["U_I_CombatUniform", 4, "U_I_CombatUniform_shortsleeve", 6]];
 if (_hasTanks) then {
     _crewLoadoutData set ["uniforms", ["U_Tank_green_F", 10]];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -274,7 +274,7 @@ _loadoutData set ["lightATLaunchers", [
 ["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 2,
 ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1.75,
 ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1,
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1.5,
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1.5
 ]];
 _loadoutData set ["ATLaunchers", ["launch_NLAW_F"], 10];
 _loadoutData set ["missileATLaunchers", [
@@ -434,7 +434,7 @@ _sfLoadoutData set ["SMGs", [
 ["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3,
 ["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
 ["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 1.5,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 1.5
 ]];
 
 _sfMGOptics = ["optic_tws_mg", 2.5, "optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_Hamr", 3, "optic_ACO_grn", 1];
@@ -495,7 +495,7 @@ _eliteLoadoutData set ["SMGs", [
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
 ["SMG_03C_TR_camo", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 3.5,
 ["SMG_03C_TR_khaki", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
-["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25
+["SMG_03C_TR_black", "", _eliteAccessories, _eliteP90Optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.25,
 ["SMG_02_F", "", _eliteAccessories, _eliteP90Optics, [], [], ""], 0.5
 ]];
 
@@ -593,7 +593,7 @@ _policeLoadoutData set ["SMGs", [
 ["SMG_03_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.5,
 ["SMG_03C_black", "", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
 ["SMG_03_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.25,
-["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75
+["SMG_03C_TR_black", "", _policeAttachments, _policeSMGSights, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 0.75,
 ["SMG_02_F", "", _policeAttachments, _policeSMGSights, [], [], ""], 6
 ]];
 _policeLoadoutData set ["sidearms", ["hgun_Rook40_F", 10]];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -269,14 +269,14 @@ _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
 _loadoutData set ["lightATLaunchers", [
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""],
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""],
-["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""],
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""],
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""],
-["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""]
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1
 ]];
-_loadoutData set ["ATLaunchers", ["launch_NLAW_F"]];
+_loadoutData set ["ATLaunchers", ["launch_NLAW_F"], 1];
 _loadoutData set ["missileATLaunchers", [
 ["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""]
 ]];
@@ -401,6 +401,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 
+_sfSMGoptics = ["optic_Aco_smg", 1, "optic_Holosight", 2];
+_sfP90optics = ["optic_Aco_smg", 1, "optic_Holosight_blk_F", 2];
 _sfLoadoutData set ["SMGs", [
 ["SMG_01_F", "muzzle_snds_acp", "", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "muzzle_snds_acp", "", "optic_Aco_smg", [], [], ""],
@@ -643,13 +645,13 @@ _crewLoadoutData set ["uniforms", ["U_I_CombatUniform", "U_I_CombatUniform_short
 if (_hasTanks) then {
     _crewLoadoutData set ["uniforms", ["U_Tank_green_F"]];
 };
-_crewLoadoutData set ["vests", ["V_BandollierB_oli"]];
-_crewLoadoutData set ["helmets", ["H_HelmetCrew_I"]];
+_crewLoadoutData set ["vests", ["V_BandollierB_oli", 1]];
+_crewLoadoutData set ["helmets", ["H_HelmetCrew_I", 1]];
 
 private _pilotLoadoutData = _militaryLoadoutData call _fnc_copyLoadoutData;
-_pilotLoadoutData set ["uniforms", ["U_I_HeliPilotCoveralls","U_I_pilotCoveralls"]];
-_pilotLoadoutData set ["vests", ["V_TacVest_oli"]];
-_pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", "H_CrewHelmetHeli_I"]];
+_pilotLoadoutData set ["uniforms", ["U_I_HeliPilotCoveralls", 1, "U_I_pilotCoveralls", 1]];
+_pilotLoadoutData set ["vests", ["V_TacVest_oli", 1]];
+_pilotLoadoutData set ["helmets", ["H_PilotHelmetHeli_I", 1, "H_CrewHelmetHeli_I", 1]];
 
 ////
 if (_hasMarksman) then {

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -329,7 +329,7 @@ _loadoutData set ["slHat", ["H_Beret_blk", "H_MilCap_dgtl"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
 
 _loadoutData set ["glasses", ["G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted"]];
-_loadoutData set ["goggles", ["G_Combat", "G_Lowprofile"]];
+_loadoutData set ["goggles", ["G_Combat", 1, "G_Lowprofile", 1]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla
@@ -371,62 +371,63 @@ _loadoutData set ["items_unarmed_extras", []];
 ///////////////////////////////////////
 
 private _sfLoadoutData = _loadoutData call _fnc_copyLoadoutData; 
-_sfLoadoutData set ["vests", ["V_TacVest_oli", "V_PlateCarrierIA2_dgtl", "V_PlateCarrierIA1_dgtl"]];
-_sfLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl","V_PlateCarrierIAGL_oli"]];
+_sfLoadoutData set ["vests", ["V_TacVest_oli", 1, "V_PlateCarrierIA2_dgtl", 2, "V_PlateCarrierIA1_dgtl", 2]];
+_sfLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1, "V_PlateCarrierIAGL_oli", 1.5]];
 _sfLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl","B_Kitbag_sgg"]];
-_sfLoadoutData set ["helmets", ["H_HelmetIA","H_Cap_blk_Raven","H_Cap_oli_hs","H_Cap_headphones","H_Booniehat_khk_hs","H_Booniehat_oli","H_Booniehat_dgtl","H_Watchcap_camo","H_Shemag_olive","H_Shemag_olive_hs"]];
-_sfLoadoutData set ["uniforms", ["U_I_CombatUniform", "U_I_CombatUniform_shortsleeve"]];
+_sfLoadoutData set ["helmets", ["H_HelmetIA", 4, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 1, "H_Cap_headphones", 1,"H_Booniehat_khk_hs", 0.5, "H_Booniehat_oli", 1, "H_Booniehat_dgtl", 2,"H_Watchcap_camo", 1,"H_Shemag_olive", 0.5, "H_Shemag_olive_hs", 0.5]];
+_sfLoadoutData set ["uniforms", ["U_I_CombatUniform", 2, "U_I_CombatUniform_shortsleeve", 3]];
 _sfLoadoutData set ["binoculars", ["Rangefinder"]];
 
+_sfAccessories = ["acc_pointer_IR", 1];
+_sfTlOptics = ["optic_ACO_grn", 0.5, "optic_Holosight_blk_F", 1, "optic_Hamr", 2, "optic_MRCO", 1.5];
+_sfRifleOptics = ["optic_ACO_grn", 0.75, "optic_Holosight_blk_F", 1.75, "optic_Hamr", 1.5, "optic_MRCO", 1];
+
 _sfLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "muzzle_snds_M", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_GL_F", "muzzle_snds_M", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Hamr", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""]
+["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
+["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 0.5,
+["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1.5,
+["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 0.75
 ]];
 _sfLoadoutData set ["rifles", [
-["arifle_Mk20_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2,
+["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _sfLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""],
-["arifle_Mk20C_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_lush_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""]
+["arifle_Mk20C_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2,
+["arifle_Mk20C_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
-["arifle_Mk20_GL_F", "muzzle_snds_M", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 2,
+["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
 ]];
 
 _sfLoadoutData set ["SMGs", [
-["SMG_01_F", "muzzle_snds_acp", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "muzzle_snds_acp", "", "optic_Aco_smg", [], [], ""],
-["SMG_03_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03_TR_camo", "muzzle_snds_570", "acc_pointer_IR", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "muzzle_snds_570", "acc_pointer_IR", "optic_Holosight_blk_F", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_03C_TR_camo", "muzzle_snds_570", "acc_pointer_IR", "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "muzzle_snds_acp", "", "optic_Holosight_smg", [], [], ""], 4,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 4,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
+["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 6,
+["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
+["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, "optic_Holosight_smg_blk_F", [], [], ""], 1.5,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, "optic_Aco_smg", [], [], ""], 2
 ]];
 
+_sfMGOptics = ["optic_tws_mg", 2, "optic_MRCO", 2, "optic_Holosight_blk_F", 1.5, "optic_Hamr", 3, "optic_ACO_grn", 1];
 _sfLoadoutData set ["machineGuns", [
-    ["LMG_Mk200_F", "muzzle_snds_H", "acc_pointer_IR", "optic_NVS", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "muzzle_snds_H", "acc_pointer_IR", "optic_MRCO", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Holosight_blk_F", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""],
-    ["LMG_Mk200_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr", ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""]
+    ["LMG_Mk200_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1
 ]];
 
+_sfMarksmanOptics = ["optic_TWS", 4, "optic_Nightstalker", 1.5, "optic_DMS", 2, "optic_SOS", 1];
 _sfLoadoutData set ["marksmanRifles", [
-    ["srifle_EBR_F", "muzzle_snds_B", "acc_pointer_IR", "optic_DMS", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""],
-    ["srifle_EBR_F", "muzzle_snds_B", "acc_pointer_IR", "optic_NVS", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""],
-    ["srifle_EBR_F", "muzzle_snds_B", "acc_pointer_IR", "optic_Hamr", ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""]
+    ["srifle_EBR_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""], 1
 ]];
+_sfSniperOptics = ["optic_SOS", 0.75, "optic_LRPS", 2, "optic_Nightstalker", 1];
 _sfLoadoutData set ["sniperRifles", [
-["srifle_GM6_F", "", "", "optic_SOS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""],
-["srifle_GM6_F", "", "", "optic_LRPS", ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""]
+["srifle_GM6_F", "", "", _sfSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
 _sfLoadoutData set ["sidearms", [
-["hgun_ACPC2_F", "muzzle_snds_acp", "acc_flashlight_pistol", "", [], [], ""]
+["hgun_ACPC2_F", "muzzle_snds_acp", "acc_flashlight_pistol", "", [], [], ""], 1
 ]];
 
 /////////////////////////////////

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -332,8 +332,27 @@ _loadoutData set ["helmets", []];
 _loadoutData set ["slHat", ["H_Beret_blk", "H_MilCap_dgtl"]];
 _loadoutData set ["sniHats", ["H_Booniehat_dgtl"]];
 
-_loadoutData set ["glasses", ["G_Shades_Black", "G_Shades_Blue", "G_Shades_Green", "G_Shades_Red", "G_Aviator", "G_Spectacles", "G_Spectacles_Tinted", "G_Sport_BlackWhite", "G_Sport_Blackyellow", "G_Sport_Greenblack", "G_Sport_Checkered", "G_Sport_Red", "G_Squares", "G_Squares_Tinted"]];
-_loadoutData set ["goggles", ["G_Combat", 1, "G_Lowprofile", 1]];
+_loadoutData set ["glasses", [
+    "G_Shades_Black", 1.5,
+    "G_Shades_Blue", 0.5,
+    "G_Shades_Green", 0.5,
+    "G_Shades_Red", 0.5,
+    "G_Aviator", 1,
+    "G_Spectacles", 1.25,
+    "G_Spectacles_Tinted", 0.75,
+    "G_Sport_Blackred", 0.34,
+    "G_Sport_BlackWhite", 0.34,
+    "G_Sport_Blackyellow", 0.33,
+    "G_Sport_Greenblack", 0.33,
+    "G_Sport_Checkered", 0.33,
+    "G_Sport_Red", 0.33,
+    "G_Squares", 1.25,
+    "G_Squares_Tinted", 0.75
+]];
+_loadoutData set ["goggles", [
+    "G_Combat", 4, 
+    "G_Lowprofile", 6
+]];
 
 //Item *set* definitions. These are added in their entirety to unit loadouts. No randomisation is applied.
 _loadoutData set ["items_medical_basic", ["BASIC"] call A3A_fnc_itemset_medicalSupplies]; //this line defines the basic medical loadout for vanilla

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -268,21 +268,20 @@ _loadoutData set ["machineGuns", []];
 _loadoutData set ["marksmanRifles", []];
 _loadoutData set ["sniperRifles", []];
 
-//SMAWs as disposable AT is pretty powerful so remove the HEAT75 rounds from spawn pool and rationalize things a bit
-_loadoutData set ["lightATLaunchers", [ 
-    ["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 5,
-    ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 5
+_loadoutData set ["lightATLaunchers", [
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 2.25,
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1.5,
+["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 2,
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HE_F", "MRAWS_HEAT55_F"], [], ""], 1.75,
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1,
+["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1.5,
 ]];
-_loadoutData set ["ATLaunchers", [
-    "launch_NLAW_F", 5,
-    ["launch_MRAWS_green_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 3,
-    ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 2]];
-    
+_loadoutData set ["ATLaunchers", ["launch_NLAW_F"], 10];
 _loadoutData set ["missileATLaunchers", [
-    ["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""], 10
+["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""], 10
 ]];
 _loadoutData set ["AALaunchers", [
-    ["launch_I_Titan_F", "", "acc_pointer_IR", "", ["Titan_AA"], [], ""], 10
+["launch_I_Titan_F", "", "acc_pointer_IR", "", ["Titan_AA"], [], ""], 10
 ]];
 _loadoutData set ["sidearms", []];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -444,12 +444,11 @@ private _eliteLoadoutData = _loadoutData call _fnc_copyLoadoutData;
 _eliteLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 5, "U_I_CombatUniform", 5]];
 _eliteLoadoutData set ["slUniforms", ["U_I_OfficerUniform", 10]];
 _eliteLoadoutData set ["vests", ["V_PlateCarrierIA2_dgtl", 3.75, "V_PlateCarrierIA1_dgtl", 3.75, "V_PlateCarrierIAGL_dgtl", 1.5,"V_PlateCarrierIAGL_oli", 1]];
-_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 1.5,"V_PlateCarrierIAGL_oli", 1]];
+_eliteLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 6,"V_PlateCarrierIAGL_oli", 4]];
 _eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2, "B_FieldPack_oli", 0.5, "B_Carryall_oli", 1, "B_AssaultPack_dgtl", 3,"B_Kitbag_sgg", 3.5]];
-_eliteLoadoutData set ["helmets", ["H_HelmetIA", 6.75, "H_Cap_blk_Raven", 0.5, "H_Cap_oli_hs", 0.25, "H_Cap_headphones", 0.25, "H_Booniehat_oli", 0.5, "H_Booniehat_dgtl", 1.25, "H_Watchcap_camo", 0.25, "H_Watchcap_camo", 0.25]];
+_eliteLoadoutData set ["helmets", ["H_HelmetIA", 6.75, "H_Cap_blk_Raven", 0.5, "H_Cap_oli_hs", 0.25, "H_Cap_headphones", 0.25, "H_Booniehat_oli", 0.5, "H_Booniehat_dgtl", 1.25, "H_Watchcap_camo", 0.25, "H_Booniehat_khk_hs", 0.25]];
 
 _eliteLoadoutData set ["binoculars", ["Rangefinder"]];
-_eliteLoadoutData set ["backpacks", ["B_TacticalPack_oli", "B_FieldPack_oli", "B_Carryall_oli", "B_AssaultPack_dgtl"]];
 
 _eliteSlOptics = ["optic_MRCO", 3, "optic_Hamr", 6, "optic_Holosight_blk_F", 1];
 _eliteRifleOptics = ["optic_Holosight_blk_F", 7, "optic_MRCO", 2, "optic_Hamr", 1];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -533,7 +533,7 @@ _militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2.5, "B_FieldPack_
 _militaryLoadoutData set ["helmets", ["H_HelmetIA", 6.9, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 1.25]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
-_militaryRifleSights = ["optic_ACO_grn", 4, "optic_Holosight_blk_F", 2, "", 0.5];
+_militaryRifleSights = ["optic_ACO_grn", 6, "optic_Holosight_blk_F", 3, "", 1];
 _militarySlRifleSights = ["optic_Hamr", 2, "optic_MRCO", 6, "optic_Holosight_blk_F", 2];
 _militaryAttachments = ["acc_flashlight", 7, "", 2, "acc_pointer_IR", 1];
 

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -382,53 +382,52 @@ _sfLoadoutData set ["helmets", ["H_HelmetIA", 4, "H_Cap_blk_Raven", 1, "H_Cap_ol
 _sfLoadoutData set ["uniforms", ["U_I_CombatUniform", 2, "U_I_CombatUniform_shortsleeve", 3]];
 _sfLoadoutData set ["binoculars", ["Rangefinder"]];
 
-_sfAccessories = ["acc_pointer_IR", 1];
-_sfTlOptics = ["optic_ACO_grn", 0.5, "optic_Holosight_blk_F", 1, "optic_Hamr", 2, "optic_MRCO", 1.5];
+_sfAccessories = ["acc_pointer_IR", 10];
+_sfTlOptics = ["optic_ACO_grn", 1, "optic_Holosight_blk_F", 2, "optic_Hamr", 4, "optic_MRCO", 3];
 _sfRifleOptics = ["optic_ACO_grn", 0.75, "optic_Holosight_blk_F", 1.75, "optic_Hamr", 1.5, "optic_MRCO", 1];
 
 _sfLoadoutData set ["slRifles", [
-["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1,
-["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 0.5,
-["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 1.5,
-["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 0.75
+["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2.75,
+["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1.25,
+["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 4,
+["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfTlOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["UGL_FlareWhite_F", "UGL_FlareWhite_F", "1Rnd_SmokeRed_Grenade_shell", "1Rnd_SmokeGreen_Grenade_shell", "1Rnd_SmokeBlue_Grenade_shell"], ""], 2
 ]];
 _sfLoadoutData set ["rifles", [
-["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2,
-["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.66,
+["arifle_Mk20_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.34
 ]];
 _sfLoadoutData set ["carbines", [
-["arifle_Mk20C_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 2,
-["arifle_Mk20C_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 1
+["arifle_Mk20C_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 6.66,
+["arifle_Mk20C_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], [], ""], 3.34
 ]];
 _sfLoadoutData set ["grenadeLaunchers", [
-["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 2,
-["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 1
+["arifle_Mk20_GL_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 6.66,
+["arifle_Mk20_GL_plain_F", "muzzle_snds_M", _sfAccessories, _sfRifleOptics, ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""], 3.34
 ]];
 
-_sfSMGoptics = ["optic_Aco_smg", 1, "optic_Holosight", 2];
-_sfP90optics = ["optic_Aco_smg", 1, "optic_Holosight_blk_F", 2];
+_sfSMGoptics = ["optic_Aco_smg", 3, "optic_Holosight", 7];
+_sfP90optics = ["optic_Aco_smg", 3, "optic_Holosight_blk_F", 7];
 _sfLoadoutData set ["SMGs", [
-["SMG_01_F", "muzzle_snds_acp", "", "optic_Holosight_smg", [], [], ""], 4,
+["SMG_01_F", "muzzle_snds_acp", "", _sfSMGoptics, [], [], ""], 4,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 4,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
 ["SMG_03C_camo", "muzzle_snds_570", "", "", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1,
-["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 6,
-["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
-["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, "optic_Aco_smg", ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
-["SMG_02_F", "muzzle_snds_L", _sfAccessories, "optic_Holosight_smg_blk_F", [], [], ""], 1.5,
-["SMG_02_F", "muzzle_snds_L", _sfAccessories, "optic_Aco_smg", [], [], ""], 2
+["SMG_03C_TR_camo", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 6,
+["SMG_03C_TR_khaki", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
+["SMG_03C_TR_black", "muzzle_snds_570", _sfAccessories, _sfP90optics, ["50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03","50Rnd_570x28_SMG_03"], [], ""], 1.5,
+["SMG_02_F", "muzzle_snds_L", _sfAccessories, _sfP90optics, [], [], ""], 3.5,
 ]];
 
-_sfMGOptics = ["optic_tws_mg", 2, "optic_MRCO", 2, "optic_Holosight_blk_F", 1.5, "optic_Hamr", 3, "optic_ACO_grn", 1];
+_sfMGOptics = ["optic_tws_mg", 2.5, "optic_MRCO", 2, "optic_Holosight_blk_F", 2, "optic_Hamr", 3, "optic_ACO_grn", 1];
 _sfLoadoutData set ["machineGuns", [
     ["LMG_Mk200_F", "muzzle_snds_H", _sfAccessories, _sfMGOptics, ["200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], ""], 1
 ]];
 
-_sfMarksmanOptics = ["optic_TWS", 4, "optic_Nightstalker", 1.5, "optic_DMS", 2, "optic_SOS", 1];
+_sfMarksmanOptics = ["optic_TWS", 4, "optic_Nightstalker", 2, "optic_DMS", 2.5, "optic_SOS", 1.5];
 _sfLoadoutData set ["marksmanRifles", [
     ["srifle_EBR_F", "muzzle_snds_B", _sfAccessories, _sfMarksmanOptics, ["20Rnd_762x51_Mag","20Rnd_762x51_Mag","20Rnd_762x51_Mag"], [], ""], 1
 ]];
-_sfSniperOptics = ["optic_SOS", 0.75, "optic_LRPS", 2, "optic_Nightstalker", 1];
+_sfSniperOptics = ["optic_SOS", 2, "optic_LRPS", 5, "optic_Nightstalker", 3];
 _sfLoadoutData set ["sniperRifles", [
 ["srifle_GM6_F", "", "", _sfSniperOptics, ["5Rnd_127x108_Mag", "5Rnd_127x108_APDS_Mag"], [], ""], 1
 ]];
@@ -511,7 +510,7 @@ _militaryLoadoutData set ["uniforms", ["U_I_CombatUniform_shortsleeve", 3, "U_I_
 _militaryLoadoutData set ["slUniforms", ["U_I_OfficerUniform", 10]];
 _militaryLoadoutData set ["vests", ["V_TacVest_oli", 2, "V_PlateCarrierIA2_dgtl", 5, "V_PlateCarrierIA1_dgtl", 3]];
 _militaryLoadoutData set ["Hvests", ["V_PlateCarrierIAGL_dgtl", 7,"V_PlateCarrierIAGL_oli", 3]];
-_militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 1, "B_FieldPack_oli", 0.5, "B_Carryall_oli", 0.75, "B_AssaultPack_dgtl", 1,"B_Kitbag_sgg", 1]];
+_militaryLoadoutData set ["backpacks", ["B_TacticalPack_oli", 2.5, "B_FieldPack_oli", 1, "B_Carryall_oli", 1.5, "B_AssaultPack_dgtl", 2.5, "B_Kitbag_sgg", 2.5]];
 _militaryLoadoutData set ["helmets", ["H_HelmetIA", 6.9, "H_Cap_blk_Raven", 1, "H_Cap_oli_hs", 0.5, "H_Cap_headphones", 0.1, "H_Booniehat_oli", 0.25, "H_Booniehat_dgtl", 1.25]];
 _militaryLoadoutData set ["binoculars", ["Rangefinder"]];
 
@@ -568,7 +567,7 @@ _policeLoadoutData set ["vests", ["V_TacVest_blk_POLICE", 6, "V_Rangemaster_belt
 private _helmets = ["H_Cap_police", 10];
 
 _policeLoadoutData set ["helmets", _helmets];
-_policeSMGSights = ["optic_Aco_smg", 3, "", 7];
+_policeSMGSights = ["optic_Aco_smg, 3, "", 7];
 _policeAttachments = ["acc_flashlight", 6, "", 4];
 _policeLoadoutData set ["SMGs", [
 ["SMG_01_F", "", "acc_flashlight_smg_01", _policeSMGSights, [], [], ""], 1.5
@@ -589,7 +588,7 @@ _militiaLoadoutData set ["uniforms", ["U_I_CombatUniform", 3, "U_I_CombatUniform
 _militiaLoadoutData set ["vests", ["V_BandollierB_oli", 1.25, "V_Chestrig_oli", 5, "V_TacVest_oli", 3.75]];
 _militiaLoadoutData set ["Hvests", ["V_TacVest_oli", 10]];
 _militiaLoadoutData set ["backpacks", ["B_TacticalPack_oli", 4, "B_FieldPack_oli", 4, "B_AssaultPack_dgtl", 2]];
-_militiaLoadoutData set ["helmets", ["H_HelmetIA", 4.5, "H_Booniehat_dgtl", 2.5, "H_Cap_blk_Raven", 2.5]];
+_militiaLoadoutData set ["helmets", ["H_HelmetIA", 4, "H_Booniehat_dgtl", 3, "H_Cap_blk_Raven", 2]];
 
 _militiaRifleSights = ["optic_ACO_grn", 2, "", 8];
 _militiaSlRifleSights = ["optic_ACO_grn", 3.5, "optic_MRCO", 4.5, "", 2];

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -276,7 +276,9 @@ _loadoutData set ["lightATLaunchers", [
 ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HEAT55_F"], [], ""], 1,
 ["launch_MRAWS_green_rail_F", "", "acc_pointer_IR", "", ["MRAWS_HEAT_F", "MRAWS_HE_F"], [], ""], 1.5
 ]];
-_loadoutData set ["ATLaunchers", ["launch_NLAW_F"], 10];
+_loadoutData set ["ATLaunchers", [
+["launch_NLAW_F"], 10
+]];
 _loadoutData set ["missileATLaunchers", [
 ["launch_I_Titan_short_F", "", "acc_pointer_IR", "", ["Titan_AT"], [], ""], 10
 ]];

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -30,6 +30,29 @@ private _fnc_magClassToEntry = {
 	[_this, getNumber (configFile >> "CfgMagazines" >> _this >> "count")]
 };
 
+//Function for handling for 3 different ways to define how items are distributed in a template, including individual weapon attachments:
+// - Array of choices (e.g. ["M16", "AKM"]), aka the normal way of doing things
+// - Single classname (e.g. "holosight"), useful mostly for attachments within weapons
+// - Array of choices and weights (e.g. ["M16", 1, "AKM", 2])
+private _fnc_parseItemArray = {
+	params ["_attachment"]; 
+	private _choice = "";
+	if((typeName _attachment) == "ARRAY") then {
+		if(count _attachment > 1) then { 
+			if(typeName (_attachment select 1) == "SCALAR") then { //is it a weighted list?
+				_choice = selectRandomWeighted _attachment;
+			} else {
+				_choice = selectRandom _attachment;
+			};
+		} else {
+			_choice = _attachment select 0;
+		};
+	} else {
+		_choice = _attachment;
+	};
+	_choice;
+};
+
 // Converts a weapon array that's valid in the builder to a weapon array valid in a loadout, extracting data in the process.
 // Magazines can be:
 // - A classname - Loads a full magazine into the weapon, uses only that magazine as an available mag.
@@ -99,7 +122,7 @@ private _fnc_parseWeaponFormat = {
 	//String - Literal mag name
 
 	[
-		[_class, _silencer, _pointer, _optic, _magsToUse select 0 select 0, _magsToUse select 1 select 0, _bipod],
+		[_class, ([_silencer] call _fnc_parseItemArray), ([_pointer] call _fnc_parseItemArray), ([_optic] call _fnc_parseItemArray), _magsToUse select 0 select 0, _magsToUse select 1 select 0, (_bipod call _fnc_parseItemArray)],
 		// Available primary mags
 		_magsToUse select 0 select 1,
 		// Available secondary mags
@@ -116,7 +139,7 @@ private _fnc_setHelmet = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _helmet = selectRandom _data;
+	private _helmet = ([_data] call _fnc_parseItemArray);
 	[_finalLoadout, _helmet] call A3A_fnc_loadout_setHelmet;
 };
 
@@ -124,7 +147,7 @@ private _fnc_setFacewear = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _facewear = selectRandom _data;
+	private _facewear = ([_data] call _fnc_parseItemArray);
 	[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 };
 
@@ -133,7 +156,7 @@ private _fnc_setVest = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _vest = selectRandom _data;
+	private _vest = ([_data] call _fnc_parseItemArray);
 	[_finalLoadout, _vest] call A3A_fnc_loadout_setVest
 };
 
@@ -142,7 +165,7 @@ private _fnc_setUniform = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _uniform = selectRandom _data;
+	private _uniform = ([_data] call _fnc_parseItemArray);
 	[_finalLoadout, _uniform] call A3A_fnc_loadout_setUniform
 };
 
@@ -151,7 +174,7 @@ private _fnc_setBackpack = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _backpack = selectRandom _data;
+	private _backpack = ([_data] call _fnc_parseItemArray);
 	[_finalLoadout, _backpack] call A3A_fnc_loadout_setBackpack
 };
 
@@ -163,7 +186,7 @@ private _fnc_setPrimary = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = (selectRandom _data) call _fnc_parseWeaponFormat;
+	private _weaponData = ([_data] call _fnc_parseItemArray) call _fnc_parseWeaponFormat;
 	_primaryPrimaryMags = _weaponData # 1;
 	_primarySecondaryMags = _weaponData # 2;
 	[_finalLoadout, "PRIMARY", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -177,7 +200,7 @@ private _fnc_setLauncher = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = (selectRandom _data) call _fnc_parseWeaponFormat;
+	private _weaponData = (([_data] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
 	_launcherPrimaryMags = _weaponData # 1;
 	_launcherSecondaryMags = _weaponData # 2;
 	[_finalLoadout, "LAUNCHER", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -191,7 +214,7 @@ private _fnc_setHandgun = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = (selectRandom _data) call _fnc_parseWeaponFormat;
+	private _weaponData = (([_data] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
 	_handgunPrimaryMags = _weaponData # 1;
 	_handgunSecondaryMags = _weaponData # 2;
 	[_finalLoadout, "HANDGUN", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -254,7 +277,7 @@ private _fnc_addMap = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _map = selectRandom _data;
+	private _map = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["MAP", _map];
 };
 
@@ -263,7 +286,7 @@ private _fnc_addWatch = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _watch = selectRandom _data;
+	private _watch = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["WATCH", _watch];
 };
 
@@ -272,7 +295,7 @@ private _fnc_addCompass = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _compass = selectRandom _data;
+	private _compass = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["COMPASS", _compass];
 };
 
@@ -281,7 +304,7 @@ private _fnc_addRadio = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _radio = selectRandom _data;
+	private _radio = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["RADIO", _radio];
 };
 
@@ -290,7 +313,7 @@ private _fnc_addGPS = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _gps = selectRandom _data;
+	private _gps = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["GPS", _gps];
 };
 
@@ -299,7 +322,7 @@ private _fnc_addBinoculars = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _binoculars = selectRandom _data;
+	private _binoculars = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["BINOCULARS", _binoculars];
 };
 
@@ -308,7 +331,7 @@ private _fnc_addNVGs = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _nvgs = selectRandom _data;
+	private _nvgs = ([_data] call _fnc_parseItemArray);
 	_equipment pushBack ["NVG", _nvgs];
 };
 


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Firstly, this adds support for constructing faction templates using weighted lists. See [https://community.bistudio.com/wiki/selectRandomWeighted](https://community.bistudio.com/wiki/selectRandomWeighted) for details. This allows template makers to create factions that spawn with an uneven distribution of weapons without making a large number of duplicate entries in the template, which is especially fun for more 'irregular' opponents such as SF and rivals. It also helps gameplay by giving factions common weapons that players can unlock easily, and rare weapons that can be a fun loot drop. This supports everything individual soldiers in a faction can spawn with, but not vehicles as implementing the same for vehicles would involve changes in a lot of different files.

In addition, this adds support for randomly choosing attachments (optics, suppressors, etc) in weapons by detecting if the weapon has a classname or an array, which simplifies faction templates by removing the number of permutations of a given weapon entry needed to have a variety of attachments - especially if e.g. multiple types of optic, accessory, etc all get mixed together. This functionality also supports weighted lists as well as regular arrays of classnames.

### Please specify which Issue this PR Resolves (If Applicable).
(N/A)

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: Create or modify a faction to implements this feature (e.g. by adding weights to their weapon spawn lists, putting arrays in the attachment slots of their weapons, etc). An example of what this looks like in practice is below since it's easier than explaining in words.
![image](https://github.com/user-attachments/assets/ade78de6-4a9a-48e5-be14-c9b360bed216)
In this example, Mk20 rifles spawn at a 3:1 rate compared to TRG-21s, regular soldiers have ACO optics at a 1:4 rate compared to ironsights, team leaders have an equal distribution of ACOs, MRCOs and ironsights. When dealing with DLC compatibility, take care to make sure to keep track of item weights - if a spawn table is weighted, make sure to `append [item, weight]` instead of just `pushBack item`.
Once this is done, load the template in question in to a new Antistasi game and check the inventories of spawned soldiers.
********************************************************
Notes: I am currently working on modifying the vanilla AAF template to provide a thorough example of this implemented, but as that takes a long while I'm putting up this PR now.