### PR TITLE
Fix helmet default unlocks (again)

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentClassToCategories.sqf
@@ -127,7 +127,7 @@ call {
     };
 
     if (_basecategory isEqualTo "Headgear") exitWith {
-        if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 5) then {
+        if (getNumber (configfile >> "CfgWeapons" >> _className >> "ItemInfo" >> "HitpointsProtectionInfo" >> "Head" >> "armor") > 0) then {
             _categories pushBack "ArmoredHeadgear";
         };
     };


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Changed the armor value from 5 back to 0, else helmets with armour values are unlocked at game start

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
