### PR TITLE
Recruit surrendered AI to player squad

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -211,6 +211,13 @@ class Params
         texts[] = {$STR_params_afk_enabled, $STR_params_afk_disabled};
         default = 1;
     };
+    class recruitToPlayerSquad
+    {
+        title = $STR_params_recruitToPlayerSquad;
+        values[] = {1,0};
+        texts[] = {$STR_params_afk_enabled, $STR_params_afk_disabled};
+        default = 1;
+    }
     class enablePunishments
     {
         title = $STR_params_enablePunishments;

--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -73,10 +73,7 @@ _unit globalChat _response;
 if (_joinPlyGroup) then {
 	_unit setVariable ["surrendered", false, true];
 
-	// Dirty way to remove the flee to side on take damage event handler added when unit surrenders
-	private _handler = _unit addEventHandler ["HandleDamage", {}];
-	_unit removeEventHandler ["HandleDamage", _handler];
-	_unit removeEventHandler ["HandleDamage", _handler - 1];
+	_unit removeEventHandler ["HandleDamage", _unit getVariable "A3U_PoW_EH_HandleDamage"];
 
 	[_unit] joinSilent (group _playerX);
 	_unit setCaptive false;

--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -38,7 +38,7 @@ if (_recruiting) then {
 	if (_interrogated) then { _chance = _chance / 2 };
 
 	if (random 100 < _chance) then
-    {
+	{
 		if (count (units _playerX) < 10) then {
 			_joinPlyGroup = true;
 		};
@@ -71,8 +71,25 @@ else {
 sleep 2;
 _unit globalChat _response;
 if (_joinPlyGroup) then {
+	_unit setVariable ["surrendered", false, true];
+
+	// Dirty way to remove the flee to side on take damage event handler added when unit surrenders
+	private _handler = _unit addEventHandler ["HandleDamage", {}];
+	_unit removeEventHandler ["HandleDamage", _handler];
+	_unit removeEventHandler ["HandleDamage", _handler - 1];
+
 	[_unit] joinSilent (group _playerX);
- [_unit, true] call A3A_fnc_FIAinit;
+	_unit setCaptive false;
+	_unit stop false;
+	_unit switchMove "";
+	_unit enableAI "MOVE";
+	_unit enableAI "AUTOTARGET";
+	_unit enableAI "TARGET";
+	_unit enableAI "ANIM";
+	_unit setUnitPos "AUTO";
+	_unit setVariable ["unitType", "loadouts_reb_militia_Unarmed", true];
+	_unit setSpeaker (_unit getVariable "A3U_PoW_speaker");
+	[_unit, true] call A3A_fnc_FIAinit;
 } else {
 	[_unit, _fleeSide] remoteExec ["A3A_fnc_fleeToSide", _unit];
 

--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -39,7 +39,7 @@ if (_recruiting) then {
 
 	if (random 100 < _chance) then
 	{
-		if (count (units _playerX) < 10) then {
+		if ((count units _playerX < 10) && (recruitToPlayerSquad isEqualTo 1)) then {
 			_joinPlyGroup = true;
 		};
 		_modAggro = [1, 30];

--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -71,7 +71,8 @@ else {
 sleep 2;
 _unit globalChat _response;
 if (_joinPlyGroup) then {
-	[_unit] joinSilent (group _playerX) 
+	[_unit] joinSilent (group _playerX);
+ [_unit, true] call A3A_fnc_FIAinit;
 } else {
 	[_unit, _fleeSide] remoteExec ["A3A_fnc_fleeToSide", _unit];
 

--- a/A3A/addons/core/functions/AI/fn_captureX.sqf
+++ b/A3A/addons/core/functions/AI/fn_captureX.sqf
@@ -13,6 +13,7 @@ private _modAggro = [0, 0];
 private _modHR = false;
 private _response = "";
 private _fleeSide = _sideX;
+private _joinPlyGroup = false;
 
 private _unitPrefix = _unit getVariable "unitPrefix";
 
@@ -38,6 +39,9 @@ if (_recruiting) then {
 
 	if (random 100 < _chance) then
     {
+		if (count (units _playerX) < 10) then {
+			_joinPlyGroup = true;
+		};
 		_modAggro = [1, 30];
 		_response = localize "STR_recruit_success_text";
 		_modHR = true;
@@ -66,16 +70,19 @@ else {
 
 sleep 2;
 _unit globalChat _response;
+if (_joinPlyGroup) then {
+	[_unit] joinSilent (group _playerX) 
+} else {
+	[_unit, _fleeSide] remoteExec ["A3A_fnc_fleeToSide", _unit];
 
-[_unit, _fleeSide] remoteExec ["A3A_fnc_fleeToSide", _unit];
+	private _group = group _unit;		// Group should be surrender-specific now
+	sleep 100;
+	if (alive _unit && {!(_unit getVariable ["incapacitated", false])}) then
+	{
+		([_sideX] + _modAggro) remoteExec ["A3A_fnc_addAggression",2];
+		if (_modHR) then { [1,0] remoteExec ["A3A_fnc_resourcesFIA",2] };
+	};
 
-private _group = group _unit;		// Group should be surrender-specific now
-sleep 100;
-if (alive _unit && {!(_unit getVariable ["incapacitated", false])}) then
-{
-	([_sideX] + _modAggro) remoteExec ["A3A_fnc_addAggression",2];
-	if (_modHR) then { [1,0] remoteExec ["A3A_fnc_resourcesFIA",2] };
+	deleteVehicle _unit;
+	deleteGroup _group;
 };
-
-deleteVehicle _unit;
-deleteGroup _group;

--- a/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
+++ b/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
@@ -102,15 +102,17 @@ if (!isNil "_markerX") then { [_markerX, _unitSide] remoteExec ["A3A_fnc_zoneChe
 
 sleep 3;				// Also protects against box kills
 _unit allowDamage true;
-_unit addEventHandler ["HandleDamage", {
-	// If unit gets injured after the delay, run away
-	params ["_unit","_part","_damage"];
-	if (_damage < 0.2) exitWith {};
-	[_unit, "remove"] remoteExec ["A3A_fnc_flagaction", [teamPlayer, civilian], _unit];
-	[_unit, side group _unit] spawn A3A_fnc_fleeToSide;
-	_unit removeEventHandler ["HandleDamage", _thisEventHandler];
-	nil;
-}];
+_unit setVariable ["A3U_PoW_EH_HandleDamage", 
+	_unit addEventHandler ["HandleDamage", {
+		// If unit gets injured after the delay, run away
+		params ["_unit","_part","_damage"];
+		if (_damage < 0.2) exitWith {};
+		[_unit, "remove"] remoteExec ["A3A_fnc_flagaction", [teamPlayer, civilian], _unit];
+		[_unit, side group _unit] spawn A3A_fnc_fleeToSide;
+		_unit removeEventHandler ["HandleDamage", _thisEventHandler];
+		nil;
+	}],
+true];
 
 if (_unit getVariable ["isRival", false]) then {
 	[_unit,"captureRivals"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];

--- a/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
+++ b/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
@@ -102,17 +102,17 @@ if (!isNil "_markerX") then { [_markerX, _unitSide] remoteExec ["A3A_fnc_zoneChe
 
 sleep 3;				// Also protects against box kills
 _unit allowDamage true;
-_unit setVariable ["A3U_PoW_EH_HandleDamage", 
-	_unit addEventHandler ["HandleDamage", {
-		// If unit gets injured after the delay, run away
-		params ["_unit","_part","_damage"];
-		if (_damage < 0.2) exitWith {};
-		[_unit, "remove"] remoteExec ["A3A_fnc_flagaction", [teamPlayer, civilian], _unit];
-		[_unit, side group _unit] spawn A3A_fnc_fleeToSide;
-		_unit removeEventHandler ["HandleDamage", _thisEventHandler];
-		nil;
-	}],
-true];
+private _handlerDamage = _unit addEventHandler ["HandleDamage", {
+	// If unit gets injured after the delay, run away
+	params ["_unit","_part","_damage"];
+	if (_damage < 0.2) exitWith {};
+	[_unit, "remove"] remoteExec ["A3A_fnc_flagaction", [teamPlayer, civilian], _unit];
+	[_unit, side group _unit] spawn A3A_fnc_fleeToSide;
+	_unit removeEventHandler ["HandleDamage", _thisEventHandler];
+	nil;
+}];
+
+_unit setVariable ["A3U_PoW_EH_HandleDamage", _handlerDamage, true];
 
 if (_unit getVariable ["isRival", false]) then {
 	[_unit,"captureRivals"] remoteExec ["A3A_fnc_flagaction",[teamPlayer,civilian],_unit];

--- a/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
+++ b/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
@@ -31,6 +31,8 @@ unassignVehicle _unit;			// stop them getting back into vehicles
 [_unit] orderGetin false;
 _unit setUnitPos "UP";
 _unit playMoveNow "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";		// hands up?
+_unit setVariable ["A3U_PoW_unitType", _unit getVariable "unitType", true]; // in case the original unitType is needed for something else in the future
+_unit setVariable ["A3U_PoW_speaker", speaker _unit, true];
 _unit setSpeaker "NoVoice";
 
 // prevent surrendered units from spawning garrisons

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -5122,6 +5122,13 @@
                 <Korean>플레이어가 AI를 모집하도록 허용</Korean>
                 <French>Autoriser les joueurs à recruter l'IA</French>
             </Key>
+            <Key ID="STR_params_recruitToPlayerSquad">
+                <Original>Enable enemy AI recruits to join player's squad</Original>
+                <Russian>Позволяет вражеским новобранцам ИИ присоединиться к отряду игрока</Russian>
+                <Chinesesimp>允许敌方 AI 新兵加入玩家的小队</Chinesesimp>
+                <Korean>적 AI 신병이 플레이어 분대에 합류할 수 있도록 합니다.</Korean>
+                <French>Permettre aux recrues ennemies de l'IA de rejoindre l'équipe du joueur</French>
+            </Key>
             <Key ID="STR_params_enablePunishments">
                 <Original>Enable invader punishments</Original>
                 <Russian>Включить наказания захватчиков</Russian>


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

I can't stop modding this game...

Here's one mostly for the solo players. 

Scenario: you've just taken the factory across from Kavala port after a brutal battle. In the course of the battle, you lost 80% of your squad. Your HC squads, also having taken heavy casualties, decide to do ARMA AI things and go into Kavala proper to stir up some shit instead of staying in the factory you just told them to garrison in. Now you're taking fire from the port and the HMGs on the outpost next to it, and the AAF is sending an attack wave. It sure would be nice to have some reinforcements about now instead of trying to one many army defend the factory, but your base is located too far away and HC squads will never get there on time. There *are* quite a few surrendered AAF AI in the factory. Too bad recruiting them just makes them run in the direction of your nearest holding and plus up your HR pool instead of actually joining the fight...

---

This PR enables recruiting surrendered AI directly to the player's squad. 

If you:
 -  successfully recruit a surrendered AI **and**
 - there's space in your squad (i.e. your squad / group has less than 10 units) **and**
 - the appropriate game Param is enabled

the AI will join the player's squad. This takes place after all their gear has been looted into the surrender crate, so you can then command the AI to auto-rearm to equip themselves.

Demo: https://imgur.com/a/eZRZiIq

---

### Please specify which Issue this PR Resolves (If Applicable).
This PR solves a minor annoyance for me + a comment I saw on reddit lol.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

Pretty simple one this time, shouldn't take too much extensive testing. Depending on war level, aggro, etc, it may be helpful to change `fn_captureX.sqf` line 40 to `if true then {` so recruitment is always successful.


********************************************************
Notes:

I used google translate for the stringtable translations. Of course, these may or may not be improved with actual speakers' input.

If there's a better way to remove the last added event handler for a certain event (a way to get how many handlers an entity has for a given event?), I'd love to know. Couldn't find anything.