### PR TITLE
AI Arsenal Overhaul

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -73,6 +73,7 @@ class CfgFunctions
         class Ammunition {
             file = QPATHTOFOLDER(functions\Ammunition);
             class ACEpvpReDress {};
+            class addPrimaryAndMags {};
             class allMagazines {};
             class ammunitionTransfer {};
             class arsenalManage {};

--- a/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
@@ -1,0 +1,68 @@
+/*
+    Equip rebel unit with primary weapon or handgun
+    Adds magazines by mass. Uses default magazine of selected weapon
+
+Parameters:
+    0. <OBJECT> Rebel unit to equip with primary weapon.
+    1. <STRING> Weapon classname
+    2. <STRING> Optic type preference ("OpticsClose", "OpticsMid", "OpticsLong")
+    3. <NUMBER> Total mass of primary magazines to add to inventory.
+    4. <NUMBER> Optional: Number of GL mags to add if secondary.
+
+Returns:
+    Nothing
+
+Environment:
+    Scheduled, any machine
+*/
+
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
+params ["_unit", "_weapon", "_opticType", "_totalMagWeight", ["_glMags", 5]];
+
+call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
+
+// Probably shouldn't ever be executed
+if !(primaryWeapon _unit isEqualTo "") then {
+    if (_weapon == primaryWeapon _unit) exitWith {};
+    private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
+    {_unit removeMagazines _x} forEach _magazines;			// Broken, doesn't remove mags globally. Pain to fix.
+    _unit removeWeapon (primaryWeapon _unit);
+};
+
+private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
+
+if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
+    // lookup real underbarrel GL magazine, because not everything is 40mm
+    private _config = configFile >> "CfgWeapons" >> _weapon;
+    private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
+    _glmuzzle = configName (_config >> _glmuzzle);                      // bad-case fix. compatibleMagazines is case-sensitive as of 2.12
+    private _glmag = compatibleMagazines [_weapon, _glmuzzle] select 0;
+    _unit addMagazines [_glmag, 5];
+};
+
+private _magazine = compatibleMagazines _weapon select 0;
+private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
+
+_unit addWeapon _weapon;
+if ("Handguns" in _categories) then {
+    _unit addHandgunItem _magazine;
+} else {
+    _unit addPrimaryWeaponItem _magazine;
+};
+_unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
+
+
+private _compatOptics = A3A_rebelOpticsCache get _weapon;
+if (isNil "_compatOptics") then {
+    private _compatItems = compatibleItems _weapon;
+
+    _compatOptics = _compatItems arrayIntersect (A3A_rebelGear get _opticType);
+    if (_compatOptics isEqualTo [] and _opticType != "OpticsClose") then {
+        private _fallbackType = ["OpticsClose", "OpticsMid"] select (_opticType == "OpticsLong");
+        _compatOptics = _compatItems arrayIntersect (A3A_rebelGear get _fallbackType);
+    };
+    A3A_rebelOpticsCache set [_weapon, _compatOptics];
+};
+if (_compatOptics isNotEqualTo []) then { _unit addPrimaryWeaponItem (selectRandom _compatOptics) };

--- a/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
@@ -33,22 +33,16 @@ if !(primaryWeapon _unit isEqualTo "") then {
 };
 
 private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
-private _allMagazines = if (minWeaps > 0) then {
-    flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 == -1}) select {typeName _x == "STRING"}
-} else {
-    flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 >= 10}) select {typeName _x == "STRING"} // * No unlocks ITEM_MIN is 10
-};
-
 if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
     // lookup real underbarrel GL magazine, because not everything is 40mm
     private _config = configFile >> "CfgWeapons" >> _weapon;
     private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
     _glmuzzle = configName (_config >> _glmuzzle);                      // bad-case fix. compatibleMagazines is case-sensitive as of 2.12
-    private _glmag = ((compatibleMagazines [_weapon, _glmuzzle]) arrayIntersect _allMagazines) select 0;
-    _unit addMagazines [_glmag, 5];
+    private _glmag = (A3A_rebelGear get "Magazines") getOrDefault [_glmuzzle, ""] select 0;
+    if (_glmag != "") then { _unit addMagazines [_glmag, 5] };
 };
 
-private _magazine = selectRandom ((compatibleMagazines _weapon) arrayIntersect _allMagazines);
+private _magazine = selectRandom ((A3A_rebelGear get "Magazines") get _weapon);
 private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
 
 _unit addWeapon _weapon;

--- a/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_addPrimaryAndMags.sqf
@@ -17,6 +17,7 @@ Environment:
 */
 
 #include "..\..\script_component.hpp"
+#include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 FIX_LINE_NUMBERS()
 
 params ["_unit", "_weapon", "_opticType", "_totalMagWeight", ["_glMags", 5]];
@@ -32,17 +33,22 @@ if !(primaryWeapon _unit isEqualTo "") then {
 };
 
 private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
+private _allMagazines = if (minWeaps > 0) then {
+    flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 == -1}) select {typeName _x == "STRING"}
+} else {
+    flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 >= 10}) select {typeName _x == "STRING"} // * No unlocks ITEM_MIN is 10
+};
 
 if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
     // lookup real underbarrel GL magazine, because not everything is 40mm
     private _config = configFile >> "CfgWeapons" >> _weapon;
     private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
     _glmuzzle = configName (_config >> _glmuzzle);                      // bad-case fix. compatibleMagazines is case-sensitive as of 2.12
-    private _glmag = compatibleMagazines [_weapon, _glmuzzle] select 0;
+    private _glmag = ((compatibleMagazines [_weapon, _glmuzzle]) arrayIntersect _allMagazines) select 0;
     _unit addMagazines [_glmag, 5];
 };
 
-private _magazine = compatibleMagazines _weapon select 0;
+private _magazine = selectRandom ((compatibleMagazines _weapon) arrayIntersect _allMagazines);
 private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
 
 _unit addWeapon _weapon;

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -37,15 +37,9 @@ private _fnc_getAvailableMagazines = {
     params ["_class", "_categories", ["_baseClass", ""]];
 
     private _magsCompat = [compatibleMagazines [_baseClass, _class], compatibleMagazines _class] select (_baseClass == "");
-    private _magsAvailable = [];
     {
-        if (_x select 0 in _magsCompat) then { _magsAvailable pushBack _x };
-    } forEach (jna_datalist select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
-
-    if (_magsAvailable isEqualTo []) exitWith { false };
-    {
-        if (_x select 1 == -1 || (minWeaps < 0 && {_x select 1 >= ITEM_MIN})) then { (_rebelGear get "Magazines") getOrDefault [_class, [], true] pushBack (_x select 0); }; 
-    } forEach _magsAvailable;
+        if (_x in _magsCompat) then { (_rebelGear get "Magazines") getOrDefault [_class, [], true] pushBack _x };
+    } forEach (unlockedMagBullet + unlockedMagShotgun + unlockedMagShell + unlockedMagMissile + unlockedMagRocket);
 
     if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
         // lookup real underbarrel GL magazine, because not everything is 40mm

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -1,14 +1,11 @@
 /*
-    Equip unit with random weapon of preferred type using A3A_rebelGear
-    Adds magazines by mass. Uses default magazine of selected weapon
+    Select random rebel weapon of preferred type using A3A_rebelGear
 
 Parameters:
-    0. <OBJECT> Rebel unit to equip with primary weapon.
-    1. <STRING> Preferred weapon type ("Rifles", "MachineGuns" etc).
-    2. <NUMBER> Optional, total mass of carried magazines to add.
+    0. <STRING> Preferred weapon type ("Rifles", "MachineGuns" etc).
 
 Returns:
-    Nothing
+    <STRING> Weapon classname selected
 
 Environment:
     Scheduled, any machine
@@ -17,7 +14,7 @@ Environment:
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_unit", "_weaponType", ["_totalMagWeight", 50]];
+params ["_weaponType"];
 
 call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
 
@@ -27,55 +24,13 @@ if (_pool isEqualTo []) then {
     if (_pool isEqualTo []) then {
         _pool = A3A_rebelGear get "SMGs";
         if (_pool isEqualTo []) then {
-            _pool = (A3A_rebelGear get "Shotguns") + (A3A_rebelGear get "SniperRifles");
+            private _pistolPool = A3A_rebelGear get "Handguns";
+            for "_i" from 1 to (count _pistolPool) step 2 do { 
+                _pistolPool set [_i, 0.5]
+            };
+            _pool = (A3A_rebelGear get "Shotguns") + (A3A_rebelGear get "SniperRifles") + _pistolPool;
         };
     };
 };
 private _weapon = selectRandomWeighted _pool;
-
-// Probably shouldn't ever be executed
-if !(primaryWeapon _unit isEqualTo "") then {
-    if (_weapon == primaryWeapon _unit) exitWith {};
-    private _magazines = getArray (configFile / "CfgWeapons" / (primaryWeapon _unit) / "magazines");
-    {_unit removeMagazines _x} forEach _magazines;			// Broken, doesn't remove mags globally. Pain to fix.
-    _unit removeWeapon (primaryWeapon _unit);
-};
-
-private _categories = _weapon call A3A_fnc_equipmentClassToCategories;
-
-if ("GrenadeLaunchers" in _categories && {"Rifles" in _categories} ) then {
-    // lookup real underbarrel GL magazine, because not everything is 40mm
-    private _config = configFile >> "CfgWeapons" >> _weapon;
-    private _glmuzzle = getArray (_config >> "muzzles") select 1;		// guaranteed by category
-    _glmuzzle = configName (_config >> _glmuzzle);                      // bad-case fix. compatibleMagazines is case-sensitive as of 2.12
-    private _glmag = compatibleMagazines [_weapon, _glmuzzle] select 0;
-	if (!isNil "_glmag") then {
-		_unit addMagazines [_glmag, 5];
-	};
-};
-
-private _magazine = compatibleMagazines _weapon select 0;
-private _magweight = 5 max getNumber (configFile >> "CfgMagazines" >> _magazine >> "mass");
-
-_unit addWeapon _weapon;
-_unit addPrimaryWeaponItem _magazine;
-_unit addMagazines [_magazine, round (random 0.5 + _totalMagWeight / _magWeight)];
-
-
-private _compatOptics = A3A_rebelOpticsCache get _weapon;
-if (isNil "_compatOptics") then {
-    private _compatItems = compatibleItems _weapon; // cached, should be fast		// cached, should be fast
-    _compatOptics = _compatItems arrayIntersect call {
-        if (_weaponType in ["Rifles", "MachineGuns"]) exitWith { A3A_rebelGear get "OpticsMid" };
-        if (_weaponType == "SniperRifles") exitWith { A3A_rebelGear get "OpticsLong" };
-        A3A_rebelGear get "OpticsClose";
-    };
-    if (_compatOptics isEqualTo []) then {
-        _compatOptics = _compatItems arrayIntersect call {
-            if (_weaponType in ["Rifles", "MachineGuns"]) exitWith { A3A_rebelGear get "OpticsClose" };
-            A3A_rebelGear get "OpticsMid";
-        };
-    };
-    A3A_rebelOpticsCache set [_weapon, _compatOptics];
-};
-if (_compatOptics isNotEqualTo []) then { _unit addPrimaryWeaponItem (selectRandom _compatOptics) };
+_weapon;

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -14,7 +14,8 @@ removeGoggles petros;
 private _vest = selectRandomWeighted (A3A_rebelGear get "ArmoredVests");
 if (_vest == "") then { _vest = selectRandomWeighted (A3A_rebelGear get "CivilianVests") };
 petros addVest _vest;
-[petros, "Rifles"] call A3A_fnc_randomRifle;
+private _weapon = ["Rifles"] call A3A_fnc_randomRifle;
+[petros, _weapon, "OpticsMid", 50] call A3A_fnc_addPrimaryAndMags;
 petros selectWeapon (primaryWeapon petros);
 
 if (petros == leader group petros) then {

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -27,6 +27,7 @@ call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from se
 // TODO: add types unitAA and unitAT(name?) when UI is ready
 private _unitType = if (_forceClass != "") then {_forceClass} else {_unit getVariable "unitType"};
 private _customLoadout = rebelLoadouts get _unitType;
+private _overrideLoadout = rebelLoadoutOverrides get _unitType;
 
 private _fnc_addSecondary = {
     params ["_unit"];
@@ -246,14 +247,7 @@ private _fnc_addNightEquip = {
 };
 
 if (!isNil "_customLoadout") then {
-    // * remove invalid loadout entries before applying the loadout to the unit
-    private _tempLoadout = _customLoadout;
-    if ("petros_knows_best" in flatten _tempLoadout) then {
-        {
-            if (_x isEqualTo "petros_knows_best") then {_tempLoadout set [_forEachIndex, ""]};
-        } forEach _tempLoadout;
-    };
-    _unit setUnitLoadout _tempLoadout;
+    _unit setUnitLoadout _customLoadout;
     
     private _addToLoadout = [
         "_unit call _fnc_addPrimary;",
@@ -267,12 +261,8 @@ if (!isNil "_customLoadout") then {
     ];
 
     {
-        if (_x select 0 == "petros_knows_best") then { call compile (_addToLoadout select _forEachIndex); };
-    } forEach (_customLoadout select [0,6]);
-
-    {
         if (_x == "petros_knows_best") then { call compile (_addToLoadout select _forEachIndex) };
-    } forEach (_customLoadout select [6,2]);
+    } forEach (_overrideLoadout select [0,8]);
 
     _unit call _fnc_addClassEquip;
     _unit call _fnc_addNightEquip;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -267,11 +267,11 @@ if (!isNil "_customLoadout") then {
     ];
 
     {
-        if (_x select 0 == "petros_knows_best") then { call compile preprocessFileLineNumbers (_addToLoadout select _forEachIndex); };
+        if (_x select 0 == "petros_knows_best") then { call compile (_addToLoadout select _forEachIndex); };
     } forEach (_customLoadout select [0,6]);
 
     {
-        if (_x == "petros_knows_best") then { call compile preprocessFileLineNumbers (_addToLoadout select _forEachIndex) };
+        if (_x == "petros_knows_best") then { call compile (_addToLoadout select _forEachIndex) };
     } forEach (_customLoadout select [6,2]);
 
     _unit call _fnc_addClassEquip;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -18,6 +18,7 @@ assigned items = [map, gps/uav term, radio, compass, watch, nvg]
 */
 
 #include "..\..\script_component.hpp"
+#include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 FIX_LINE_NUMBERS()
 
 params ["_unit", "_recruitType", ["_forceClass", ""]];
@@ -53,8 +54,12 @@ private _fnc_addSecondary = {
         private _weapon = selectRandomWeighted (_launcherPool get _typeTag);
 
         _unit addWeapon _weapon;
-        //private _magazine = (compatibleMagazines _weapon) arrayIntersect (jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select 0;
-        private _magazine = compatibleMagazines _weapon select 0;
+        private _allMagazines = if (minWeaps > 0) then {
+            flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 == -1}) select {typeName _x == "STRING"}
+        } else {
+            flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 >= 10}) select {typeName _x == "STRING"} // * No unlocks ITEM_MIN is 10
+        };
+        private _magazine = selectRandom ((compatibleMagazines _weapon) arrayIntersect _allMagazines);
         _unit addSecondaryWeaponItem _magazine;
 
         if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -51,15 +51,11 @@ private _fnc_addSecondary = {
             ["AA", _mLaunchersAA]
         ];
         
+        if (_launcherPool get _typeTag isEqualTo []) exitWith {};
         private _weapon = selectRandomWeighted (_launcherPool get _typeTag);
 
         _unit addWeapon _weapon;
-        private _allMagazines = if (minWeaps > 0) then {
-            flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 == -1}) select {typeName _x == "STRING"}
-        } else {
-            flatten ((jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL) select {_x select 1 >= 10}) select {typeName _x == "STRING"} // * No unlocks ITEM_MIN is 10
-        };
-        private _magazine = selectRandom ((compatibleMagazines _weapon) arrayIntersect _allMagazines);
+        private _magazine = selectRandom ((A3A_rebelGear get "Magazines") get _weapon);
         _unit addSecondaryWeaponItem _magazine;
 
         if ("Disposable" in (_weapon call A3A_fnc_equipmentClassToCategories)) exitWith {};

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -99,6 +99,8 @@ DECLARE_SERVER_VAR(A3A_unbuiltObjects, []);
 DECLARE_SERVER_VAR(randomizeRebelLoadoutUniforms, true);
 //Stores  custom AI rebel loadouts.
 DECLARE_SERVER_VAR(rebelLoadouts, createHashMap);
+//Stores  custom AI rebel loadout overrides.
+DECLARE_SERVER_VAR(rebelLoadoutOverrides, createHashMap);
 //Players who attend in parachute jumps
 DECLARE_SERVER_VAR(paradropAttendants, []);
 //Trader discount.

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_clearLoadout.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_clearLoadout.sqf
@@ -11,6 +11,7 @@ if (isNil "_loadout") exitWith {
 };
 
 rebelLoadouts deleteAt _loadoutKey;
+rebelLoadoutOverrides deleteAt _loadoutKey;
 publicVariable "rebelLoadouts";
 
 private _display = findDisplay 120000;

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -2820,11 +2820,7 @@ switch _mode do {
 
 		private _loadout = rebelLoadouts get currentRebelLoadout;
 
-		if (isNil "_loadout") then {
-			[player, 0, currentRebelLoadout] call A3A_fnc_equipRebel;
-		} else {
-			player setUnitLoadout _loadout;
-		};
+		[player, 0, currentRebelLoadout] call A3A_fnc_equipRebel;
 	};
 
 	case "Close": {

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1164,6 +1164,62 @@ switch _mode do {
 		}else{
 			lbclear _ctrlList;
 
+			// * Filter primary and secondary weapons available according to unit type / class
+			if (_index == IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON) then {
+				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+				_inventory = switch (_loadoutName) do {
+					case ("MACHINEGUNNER"): {
+						_inventory select { "MachineGuns" in (_x call A3A_fnc_equipmentClassToCategories)} ;
+					};
+					case ("STATICCREW");
+					case ("MEDIC"): {
+						_inventory select { "SMGs" in (_x call A3A_fnc_equipmentClassToCategories) };
+					};
+					case ("GRENADIER"): {
+						_inventory select { "GrenadeLaunchers" in (_x call A3A_fnc_equipmentClassToCategories) };
+					};
+					case ("SNIPER"): {
+						_inventory select { "SniperRifles" in (_x call A3A_fnc_equipmentClassToCategories) };
+					};
+					default {
+						_inventory select {
+							private _categories = _x call A3A_fnc_equipmentClassToCategories;
+							(["GrenadeLaunchers", "MachineGuns", "SniperRifles"] arrayIntersect _categories) isEqualTo [];
+						};
+					};
+				};
+			};
+
+			if (_index == IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON) then {
+				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+				_inventory = switch (_loadoutName) do {
+					case ("RIFLEMAN"): {
+						_inventory select {
+							private _categories = _x call A3A_fnc_equipmentClassToCategories;
+							"RocketLaunchers" in _categories && {"Disposable" in _categories}
+						};
+					};
+					case ("LAT"): {
+						_inventory select { "RocketLaunchers" in (_x call A3A_fnc_equipmentClassToCategories) };
+					};
+					case ("AT"): {
+						_inventory select {
+							private _categories = _x call A3A_fnc_equipmentClassToCategories;
+							"MissileLaunchers" in _categories && {"AT" in _categories}
+						};
+					};
+					case ("AA"): {
+						_inventory select {
+							private _categories = _x call A3A_fnc_equipmentClassToCategories;
+							"MissileLaunchers" in _categories && {"AA" in _categories}
+						};
+					};
+					default {
+						[];
+					};
+				};
+			};
+
 			// add empty item (deliberately choose nothing for this type) and any item ("randomly" (weighted) select an item)
 			if!(
 			_index in [

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1312,12 +1312,16 @@ switch _mode do {
 				_emptyItemString = ("           ") + _emptyItemString; //little longer for bigger icons
 				_anyItemString = ("           ") + _anyItemString; //little longer for bigger icons
 			};
-			_lbAddAny = _ctrlList lbAdd _anyItemString;
+
 			_lbAddEmpty = _ctrlList lbAdd _emptyItemString;
-			_anyItemData = str ["petros_knows_best",0,""];
 			_emptyItemData = str ["",0,""];
 			_ctrlList lbSetData [_lbAddEmpty, _emptyItemData];
-			_ctrlList lbSetData [_lbAddAny, _anyItemData];
+
+			if !(_index in [IDCS_RIGHT]) then {
+				_lbAddAny = _ctrlList lbAdd _anyItemString;	
+				_anyItemData = str ["petros_knows_best",0,""];
+				_ctrlList lbSetData [_lbAddAny, _anyItemData];
+			};
 		};
 		
 		// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -601,8 +601,8 @@ switch _mode do {
             private _displayName = _data select 2;
 
             //If it's the description string, then make sure it's first.
-            if (_item == "") then {
-              _amount = -100;
+            if (_item in ["", "petros_knows_best"]) then {
+              _amount = _amount -100;
             };
 
             _ctrlList lbSetValue [_i, _amount];
@@ -1164,7 +1164,7 @@ switch _mode do {
 		}else{
 			lbclear _ctrlList;
 
-			// add empty
+			// add empty item (deliberately choose nothing for this type) and any item ("randomly" (weighted) select an item)
 			if!(
 			_index in [
 				IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG,
@@ -1175,7 +1175,8 @@ switch _mode do {
 			])then{
 
 				//add empty
-				_emptyString =  ("            Qty:    Name:          <Empty>");
+				_anyItemString = ("       Any item (Petros Knows Best)       ");
+				_emptyItemString = ("            Qty:    Name:          <Empty>");
 				if(
 					_index in [
 						IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON,
@@ -1183,11 +1184,15 @@ switch _mode do {
 						IDC_RSCDISPLAYARSENAL_TAB_HANDGUN
 					]
 				)then{
-					_emptyString = ("           ") + _emptyString; //little longer for bigger icons
+					_emptyItemString = ("           ") + _emptyItemString; //little longer for bigger icons
+					_anyItemString = ("           ") + _anyItemString; //little longer for bigger icons
 				};
-				_lbAdd = _ctrlList lbadd _emptyString;
-				_data = str ["",0,""];
-				_ctrlList lbsetdata [_lbAdd,_data];
+				_lbAddAny = _ctrlList lbAdd _anyItemString;
+				_lbAddEmpty = _ctrlList lbAdd _emptyItemString;
+				_anyItemData = str ["petros_knows_best",0,""];
+				_emptyItemData = str ["",0,""];
+				_ctrlList lbSetData [_lbAddEmpty, _emptyItemData];
+				_ctrlList lbSetData [_lbAddAny, _anyItemData];
 			};
 		};
 
@@ -1237,7 +1242,7 @@ switch _mode do {
 		if (typeName _display == "STRING") exitWith {};
 		if(str _display isEqualTo "No display")exitWith{};
 
-		if(_item isEqualTo "")exitWith{};
+		if(_item in ["", "petros_knows_best"])exitWith{};
 
 		if(_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL)then{
 			if (ctrlEnabled (_display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG)))then{
@@ -1294,7 +1299,7 @@ switch _mode do {
 
 		if (typeName _display == "STRING") exitWith {};
 		if(str _display isEqualTo "No display")exitWith{};
-		if(_item isEqualTo "")exitWith{};
+		if(_item in ["", "petros_knows_best"])exitWith{};
 
 		if(_index == IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL)then{
 			if (ctrlEnabled (_display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG)))then{
@@ -1357,7 +1362,7 @@ switch _mode do {
 		private _display = _this select 0;
 		private _ctrlList = _this select 1;
 		private _index = _this select 2;
-		private _item = _this select 3;			if(_item isEqualTo "")exitWith{};
+		private _item = _this select 3;			if(_item in ["", "petros_knows_best"])exitWith{};
 		private _amount = _this select 4;
 
 		private _xCfg = switch _index do {
@@ -1434,7 +1439,7 @@ switch _mode do {
 					default {""};
 				};
 				_compatibleItems = compatibleItems _weapon;
-				if not (({_x == _item} count _compatibleItems > 0) || _item isequalto "")exitwith{
+				if not (({_x == _item} count _compatibleItems > 0) || _item in ["", "petros_knows_best"])exitwith{
 					_ctrlList lbSetColor [_lbAdd, [1,1,1,0.25]];
 				};
 				_xCfg call ADDMODICON;
@@ -1461,7 +1466,7 @@ switch _mode do {
 
 
 		//skip empty
-		if(_item isEqualTo "")exitWith{};
+		if(_item in ["", "petros_knows_best"])exitWith{};
 
 		//update name with counters and ammocounters (need to be done after sorting)
 		//TODO change to define
@@ -1513,7 +1518,7 @@ switch _mode do {
 			};
 			_compatibleItems = compatibleItems _weapon;
 
-			!({_x == _item} count _compatibleItems > 0 || _item isEqualTo "")
+			!({_x == _item} count _compatibleItems > 0 || _item in ["", "petros_knows_best"])
 		} else {
 			false
 		};
@@ -1704,6 +1709,7 @@ switch _mode do {
 		private _amount = _data select 1;
 		private _displayName = _data select 2;
 
+		private _overrideLoadout = rebelLoadoutOverrides getOrDefault [currentRebelLoadout, ["","","","","","","",""], true];
 		private _oldItem = "";
 
 		private _ctrlListPrimaryWeapon = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON);
@@ -1711,7 +1717,7 @@ switch _mode do {
 		private _ctrlListHandgun = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN);
 
 		// Prevent equipping item when there aren't any left
-		if (_amount == 0 and _item != "") exitWith{
+		if (_amount == 0 and {!(_item in ["", "petros_knows_best"])}) exitWith{
 			if(missionnamespace getvariable ["jna_reselect_item",true])then{//prefent loop when unavalable item was worn and a other unavalable item was selected
 				missionnamespace setvariable ["jna_reselect_item",false];
 				["ListSelectCurrent",[_display,_index]] call SCRT_fnc_arsenal_loadoutArsenal;
@@ -1721,7 +1727,7 @@ switch _mode do {
 
 		//check if weapon is unlocked
 		private _min = [_index, _item] call _minItemsMember;
-		if ((_amount <= _min) && {_amount != -1 AND {_item !="" && {!_type}}}) exitWith {
+		if ((_amount <= _min) && {_amount != -1 AND {!(_item in ["", "petros_knows_best"]) && {!_type}}}) exitWith {
 			['showMessage',[_display, (localize "STR_antistasi_dialogs_hq_button_rebel_set_loadout_unlocked_items")]] call SCRT_fnc_arsenal_loadoutArsenal;
 
 			//reset _cursel
@@ -1774,8 +1780,12 @@ switch _mode do {
 
 					[_index, _oldItem] call jn_fnc_arsenal_addItem;
 
-					if (_item != "") then{
+					if (_item == "") exitWith {};
+					if (_item == "petros_knows_best") then {
+						_overrideLoadout set [_index, _item];
+					} else {
 						switch _index do{
+							_overrideLoadout set [_index, ""];
 							case IDC_RSCDISPLAYARSENAL_TAB_UNIFORM:{
 								player forceaddUniform _item;
 							};
@@ -1853,7 +1863,11 @@ switch _mode do {
 				if (_oldItem != _item) then {
 					removeheadgear player;
 					[_index, _oldItem] call jn_fnc_arsenal_addItem;
-					if (_item != "") then{
+					if (_item == "") exitWith {};
+					if (_item == "petros_knows_best") then {
+						_overrideLoadout set [_index, _item];
+					} else {
+						_overrideLoadout set [_index, ""];
 						player addheadgear _item;
 						[_index, _item]call jn_fnc_arsenal_removeItem;
 					};
@@ -1866,7 +1880,11 @@ switch _mode do {
 				if (_oldItem != _item) then {
 					removeGoggles player;
 					[_index, _oldItem] call jn_fnc_arsenal_addItem;
-					if (_item != "") then{
+					if (_item == "") exitWith {};
+					if (_item == "petros_knows_best") then {
+						_overrideLoadout set [_index, _item];
+					} else {
+						_overrideLoadout set [_index, ""];
 						player addGoggles _item;
 						[_index, _item]call jn_fnc_arsenal_removeItem;
 					};
@@ -1938,7 +1956,11 @@ switch _mode do {
 					[_index, _oldItem] call jn_fnc_arsenal_addItem;
 
 					//add new weapon
-					if (_item != "") then {
+					if (_item == "") exitWith {};
+					if (_item == "petros_knows_best") then {
+						_overrideLoadout set [_index, _item];
+					} else {
+						_overrideLoadout set [_index, ""];
 						//give player new weapon
 						[player,_item,0] call bis_fnc_addweapon;
 						[_index, _item]call jn_fnc_arsenal_removeItem;
@@ -2091,7 +2113,7 @@ switch _mode do {
 
 				//prevent selecting grey items, needs to be this complicated because bis_fnc_compatibleItems returns some crap resolts like optic_aco instead of Optic_Aco
 				_compatibleItems = compatibleItems _weapon;
-				if not (({_x == _item} count _compatibleItems > 0) || _item isequalto "")exitwith{
+				if not (({_x == _item} count _compatibleItems > 0) || _item in ["", "petros_knows_best"])exitwith{
 					['TabSelectRight',[_display,_index]] call SCRT_fnc_arsenal_loadoutArsenal;
 				};
 
@@ -2617,7 +2639,7 @@ switch _mode do {
 			_ctrlTab = _display displayctrl(IDC_RSCDISPLAYARSENAL_TAB + _index);
 
 			//check if some item was selected
-			if(_item isEqualTo "")then{
+			if(_item in ["", "petros_knows_best"])then{
 				_ctrlTab ctrlSetTextColor [1,0.3,0.3,1];
 			}else{
 				_ctrlTab ctrlSetTextColor [1,1,1,1];

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1294,115 +1294,89 @@ switch _mode do {
 		_inventory = _this select 2;
 		_ctrlList = _display displayctrl (IDC_RSCDISPLAYARSENAL_LIST + _index);
 		_type = (ctrltype _ctrlList == 102);
-		if _type then{
-			lnbclear _ctrlList;
-
-			// * filter cargo items to what's unlocked
-			_inventory = switch (_index) do {
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW): {
-					_inventory select { (_x select 0) in unlockedMagazines}
-				};
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT): {
-					_inventory select { (_x select 0) in unlockedExplosives}
-				};
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC): {
-					_inventory select { (_x select 0) in unlockedItems}
-				};
-			};
-		}else{
-			lbclear _ctrlList;
-
-			// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked
-			_inventory = switch (_index) do {
-				// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > jna_minItemMember select _index
-				case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
-					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-					switch (_loadoutName) do {
-						case ("MACHINEGUNNER"): { 
-							_inventory select { (_x select 0) in (A3A_rebelGear get "MachineGuns") }
-						};
-						case ("STATICCREW");
-						case ("MEDIC"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "SMGs") }
-						};
-						case ("GRENADIER"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "GrenadeLaunchers") }
-						};
-						case ("SNIPER"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "SniperRifles") }
-						};
-						default {
-							_inventory select { (_x select 0) in ((A3A_rebelGear get "Rifles") + (A3A_rebelGear get "SMGs") + (A3A_rebelGear get "Shotguns")) }
-						};
-					};
-				};
-
-				case (IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON): {
-					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-					switch (_loadoutName) do {
-						case ("RIFLEMAN"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
-						};
-						case ("LAT"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") }
-						};
-						case ("AT"): {
-							_inventory select { (_x select 0) in ((A3A_rebelGear get "RocketLaunchers") + (A3A_rebelGear get "MissileLaunchersAT")) }
-						};
-						case ("AA"): {
-							_inventory select { (_x select 0) in (A3A_rebelGear get "MissileLaunchersAA") }
-						};
-						default { [] };
-					};
-				};
-
-				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG);
-				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2);
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
-				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL): {
-					_inventory select {
-						private _amountCfg = getNumber (configfile >> "CfgMagazines" >> _x select 0 >> "count");
-						(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ((jna_minItemMember select _index) * _amountCfg)}}
-					}
-				};
-				
-				default {
-					// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
-					_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} }
-				};
-			};
+		if _type then {
+			lnbClear _ctrlList;
+		} else {
+			lbClear _ctrlList;
 
 			// add empty item (deliberately choose nothing for this type) and any item ("randomly" (weighted) select an item)
-			if!(
-			_index in [
-				IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG,
-				IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL,
-				IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW,
-				IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT,
-				IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC
-			])then{
-
-				//add empty
-				_anyItemString = ("       Any item (Petros Knows Best)       ");
-				_emptyItemString = ("            Qty:    Name:          <Empty>");
-				if(
-					_index in [
-						IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON,
-						IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON,
-						IDC_RSCDISPLAYARSENAL_TAB_HANDGUN
-					]
-				)then{
-					_emptyItemString = ("           ") + _emptyItemString; //little longer for bigger icons
-					_anyItemString = ("           ") + _anyItemString; //little longer for bigger icons
+			_anyItemString = ("       Any item (Petros Knows Best)       ");
+			_emptyItemString = ("            Qty:    Name:          <Empty>");
+			if(
+				_index in [
+					IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON,
+					IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON,
+					IDC_RSCDISPLAYARSENAL_TAB_HANDGUN
+				]
+			)then{
+				_emptyItemString = ("           ") + _emptyItemString; //little longer for bigger icons
+				_anyItemString = ("           ") + _anyItemString; //little longer for bigger icons
+			};
+			_lbAddAny = _ctrlList lbAdd _anyItemString;
+			_lbAddEmpty = _ctrlList lbAdd _emptyItemString;
+			_anyItemData = str ["petros_knows_best",0,""];
+			_emptyItemData = str ["",0,""];
+			_ctrlList lbSetData [_lbAddEmpty, _emptyItemData];
+			_ctrlList lbSetData [_lbAddAny, _anyItemData];
+		};
+		
+		// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked
+		_inventory = switch (_index) do {
+			// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > jna_minItemMember select _index
+			case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
+				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+				switch (_loadoutName) do {
+					case ("MACHINEGUNNER"): { 
+						_inventory select { (_x select 0) in (A3A_rebelGear get "MachineGuns") }
+					};
+					case ("STATICCREW");
+					case ("MEDIC"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "SMGs") }
+					};
+					case ("GRENADIER"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "GrenadeLaunchers") }
+					};
+					case ("SNIPER"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "SniperRifles") }
+					};
+					default {
+						_inventory select { (_x select 0) in ((A3A_rebelGear get "Rifles") + (A3A_rebelGear get "SMGs") + (A3A_rebelGear get "Shotguns")) }
+					};
 				};
-				_lbAddAny = _ctrlList lbAdd _anyItemString;
-				_lbAddEmpty = _ctrlList lbAdd _emptyItemString;
-				_anyItemData = str ["petros_knows_best",0,""];
-				_emptyItemData = str ["",0,""];
-				_ctrlList lbSetData [_lbAddEmpty, _emptyItemData];
-				_ctrlList lbSetData [_lbAddAny, _anyItemData];
+			};
+
+			case (IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON): {
+				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+				switch (_loadoutName) do {
+					case ("RIFLEMAN"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
+					};
+					case ("LAT"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") }
+					};
+					case ("AT"): {
+						_inventory select { (_x select 0) in ((A3A_rebelGear get "RocketLaunchers") + (A3A_rebelGear get "MissileLaunchersAT")) }
+					};
+					case ("AA"): {
+						_inventory select { (_x select 0) in (A3A_rebelGear get "MissileLaunchersAA") }
+					};
+					default { [] };
+				};
+			};
+
+			case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG);
+			case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2);
+			case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
+			case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL): {
+				_inventory select {
+					private _amountCfg = getNumber (configfile >> "CfgMagazines" >> _x select 0 >> "count");
+					(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ((jna_minItemMember select _index) * _amountCfg)}}
+				}
+			};
+			
+			default {
+				// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
+				_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} }
 			};
 		};
 

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1360,6 +1360,16 @@ switch _mode do {
 					};
 				};
 
+				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG);
+				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2);
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL): {
+					_inventory select {
+						private _amountCfg = getNumber (configfile >> "CfgMagazines" >> _x select 0 >> "count");
+						(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (ITEM_MIN * _amountCfg)}}
+					}
+				};
+				
 				default {
 					// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
 					_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ITEM_MIN}} }

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -132,6 +132,8 @@ FIX_LINE_NUMBERS()
 #define INCOMPATIBLE_ITEM_COLOR [1,1,1,0.25]
 #define DEFAULT_COLOR [1,1,1,1]
 
+#define ITEM_MIN 10
+
 disableserialization;
 
 _arrayContains = {
@@ -1315,60 +1317,52 @@ switch _mode do {
 			lbclear _ctrlList;
 
 			// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked
-			switch (_index) do {
+			_inventory = switch (_index) do {
+				// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > ITEM_MIN
 				case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
 					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-					_inventory = switch (_loadoutName) do {
+					switch (_loadoutName) do {
 						case ("MACHINEGUNNER"): { 
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedMachineGuns") }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "MachineGuns") }
 						};
 						case ("STATICCREW");
 						case ("MEDIC"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSMGs") }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "SMGs") }
 						};
 						case ("GRENADIER"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedGrenadeLaunchers") }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "GrenadeLaunchers") }
 						};
 						case ("SNIPER"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSniperRifles") }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "SniperRifles") }
 						};
 						default {
-							private _excludedWeapons = (missionNamespace getVariable "unlockedMachineGuns") + (missionNamespace getVariable "unlockedGrenadeLaunchers") + (missionNamespace getVariable "unlockedSniperRifles");
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons") && {!((_x select 0) in _excludedWeapons)}}
+							_inventory select { (_x select 0) in ((A3A_rebelGear get "Rifles") + (A3A_rebelGear get "SMGs") + (A3A_rebelGear get "Shotguns")) }
 						};
 					};
 				};
 
 				case (IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON): {
 					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-					_inventory = switch (_loadoutName) do {
+					switch (_loadoutName) do {
 						case ("RIFLEMAN"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
 						};
 						case ("LAT"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "unlockedRocketLaunchers")} }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "RocketLaunchers") }
 						};
 						case ("AT"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") }
+							_inventory select { (_x select 0) in ((A3A_rebelGear get "RocketLaunchers") + (A3A_rebelGear get "MissileLaunchersAT")) }
 						};
 						case ("AA"): {
-							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAA") }
+							_inventory select { (_x select 0) in (A3A_rebelGear get "MissileLaunchersAA") }
 						};
 						default { [] };
 					};
 				};
 
-				case (IDC_RSCDISPLAYARSENAL_TAB_HANDGUN): {
-					_inventory = _inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons")}
-				};
-
-				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG);
-				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2): {
-					_inventory = _inventory select { (_x select 0) in (unlockedMagBullet + unlockedMagShotgun + unlockedMagShell + unlockedMagMissile + unlockedMagRocket) };
-				};
-
 				default {
-					_inventory = _inventory select { (_x select 0) in unlockedItems}
+					// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
+					_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ITEM_MIN}} }
 				};
 			};
 

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -132,8 +132,6 @@ FIX_LINE_NUMBERS()
 #define INCOMPATIBLE_ITEM_COLOR [1,1,1,0.25]
 #define DEFAULT_COLOR [1,1,1,1]
 
-#define ITEM_MIN 10
-
 disableserialization;
 
 _arrayContains = {
@@ -1318,7 +1316,7 @@ switch _mode do {
 
 			// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked
 			_inventory = switch (_index) do {
-				// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > ITEM_MIN
+				// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > jna_minItemMember select _index
 				case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
 					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
 					switch (_loadoutName) do {
@@ -1366,13 +1364,13 @@ switch _mode do {
 				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL): {
 					_inventory select {
 						private _amountCfg = getNumber (configfile >> "CfgMagazines" >> _x select 0 >> "count");
-						(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (ITEM_MIN * _amountCfg)}}
+						(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ((jna_minItemMember select _index) * _amountCfg)}}
 					}
 				};
 				
 				default {
 					// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
-					_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ITEM_MIN}} }
+					_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} }
 				};
 			};
 

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1303,24 +1303,22 @@ switch _mode do {
 			if (_index == IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON) then {
 				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
 				_inventory = switch (_loadoutName) do {
-					case ("MACHINEGUNNER"): {
-						_inventory select { "MachineGuns" in (_x call A3A_fnc_equipmentClassToCategories)} ;
+					case ("MACHINEGUNNER"): { 
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedMachineGuns") }
 					};
 					case ("STATICCREW");
 					case ("MEDIC"): {
-						_inventory select { "SMGs" in (_x call A3A_fnc_equipmentClassToCategories) };
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSMGs") }
 					};
 					case ("GRENADIER"): {
-						_inventory select { "GrenadeLaunchers" in (_x call A3A_fnc_equipmentClassToCategories) };
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedGrenadeLaunchers") }
 					};
 					case ("SNIPER"): {
-						_inventory select { "SniperRifles" in (_x call A3A_fnc_equipmentClassToCategories) };
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSniperRifles") }
 					};
 					default {
-						_inventory select {
-							private _categories = _x call A3A_fnc_equipmentClassToCategories;
-							(["GrenadeLaunchers", "MachineGuns", "SniperRifles"] arrayIntersect _categories) isEqualTo [];
-						};
+						private _excludedWeapons = (missionNamespace getVariable "unlockedMachineGuns") + (missionNamespace getVariable "unlockedGrenadeLaunchers") + (missionNamespace getVariable "unlockedSniperRifles");
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons") && {!((_x select 0) in _excludedWeapons)}}
 					};
 				};
 			};
@@ -1329,30 +1327,27 @@ switch _mode do {
 				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
 				_inventory = switch (_loadoutName) do {
 					case ("RIFLEMAN"): {
-						_inventory select {
-							private _categories = _x call A3A_fnc_equipmentClassToCategories;
-							"RocketLaunchers" in _categories && {"Disposable" in _categories}
-						};
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
 					};
 					case ("LAT"): {
-						_inventory select { "RocketLaunchers" in (_x call A3A_fnc_equipmentClassToCategories) };
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "unlockedRocketLaunchers")} }
 					};
 					case ("AT"): {
-						_inventory select {
-							private _categories = _x call A3A_fnc_equipmentClassToCategories;
-							"MissileLaunchers" in _categories && {"AT" in _categories}
-						};
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") }
 					};
 					case ("AA"): {
-						_inventory select {
-							private _categories = _x call A3A_fnc_equipmentClassToCategories;
-							"MissileLaunchers" in _categories && {"AA" in _categories}
-						};
+						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAA") }
 					};
-					default {
-						[];
-					};
+					default { [] };
 				};
+			};
+
+			if (_index == IDC_RSCDISPLAYARSENAL_TAB_HANDGUN) then {
+				_inventory = _inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons")}
+			};
+
+			if (_index in [IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG, IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2]) then {
+				_inventory = _inventory select { (_x select 0) in (unlockedMagBullet + unlockedMagShotgun + unlockedMagShell + unlockedMagMissile + unlockedMagRocket) };
 			};
 
 			// add empty item (deliberately choose nothing for this type) and any item ("randomly" (weighted) select an item)

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1296,58 +1296,80 @@ switch _mode do {
 		_type = (ctrltype _ctrlList == 102);
 		if _type then{
 			lnbclear _ctrlList;
+
+			// * filter cargo items to what's unlocked
+			_inventory = switch (_index) do {
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL);
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOTHROW): {
+					_inventory select { (_x select 0) in unlockedMagazines}
+				};
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOPUT): {
+					_inventory select { (_x select 0) in unlockedExplosives}
+				};
+				case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMISC): {
+					_inventory select { (_x select 0) in unlockedItems}
+				};
+			};
 		}else{
 			lbclear _ctrlList;
 
-			// * Filter primary and secondary weapons available according to unit type / class
-			if (_index == IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON) then {
-				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-				_inventory = switch (_loadoutName) do {
-					case ("MACHINEGUNNER"): { 
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedMachineGuns") }
-					};
-					case ("STATICCREW");
-					case ("MEDIC"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSMGs") }
-					};
-					case ("GRENADIER"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedGrenadeLaunchers") }
-					};
-					case ("SNIPER"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSniperRifles") }
-					};
-					default {
-						private _excludedWeapons = (missionNamespace getVariable "unlockedMachineGuns") + (missionNamespace getVariable "unlockedGrenadeLaunchers") + (missionNamespace getVariable "unlockedSniperRifles");
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons") && {!((_x select 0) in _excludedWeapons)}}
+			// * Filter primary and secondary weapons available according to unit type / class, all items to what's unlocked
+			switch (_index) do {
+				case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
+					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+					_inventory = switch (_loadoutName) do {
+						case ("MACHINEGUNNER"): { 
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedMachineGuns") }
+						};
+						case ("STATICCREW");
+						case ("MEDIC"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSMGs") }
+						};
+						case ("GRENADIER"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedGrenadeLaunchers") }
+						};
+						case ("SNIPER"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedSniperRifles") }
+						};
+						default {
+							private _excludedWeapons = (missionNamespace getVariable "unlockedMachineGuns") + (missionNamespace getVariable "unlockedGrenadeLaunchers") + (missionNamespace getVariable "unlockedSniperRifles");
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons") && {!((_x select 0) in _excludedWeapons)}}
+						};
 					};
 				};
-			};
 
-			if (_index == IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON) then {
-				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
-				_inventory = switch (_loadoutName) do {
-					case ("RIFLEMAN"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
+				case (IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON): {
+					private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
+					_inventory = switch (_loadoutName) do {
+						case ("RIFLEMAN"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "allDisposable")} }
+						};
+						case ("LAT"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "unlockedRocketLaunchers")} }
+						};
+						case ("AT"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") }
+						};
+						case ("AA"): {
+							_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAA") }
+						};
+						default { [] };
 					};
-					case ("LAT"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") && {(_x select 0) in (missionNamespace getVariable "unlockedRocketLaunchers")} }
-					};
-					case ("AT"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAT") }
-					};
-					case ("AA"): {
-						_inventory select { (_x select 0) in (missionNamespace getVariable "unlockedAA") }
-					};
-					default { [] };
 				};
-			};
 
-			if (_index == IDC_RSCDISPLAYARSENAL_TAB_HANDGUN) then {
-				_inventory = _inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons")}
-			};
+				case (IDC_RSCDISPLAYARSENAL_TAB_HANDGUN): {
+					_inventory = _inventory select { (_x select 0) in (missionNamespace getVariable "unlockedWeapons")}
+				};
 
-			if (_index in [IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG, IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2]) then {
-				_inventory = _inventory select { (_x select 0) in (unlockedMagBullet + unlockedMagShotgun + unlockedMagShell + unlockedMagMissile + unlockedMagRocket) };
+				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG);
+				case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2): {
+					_inventory = _inventory select { (_x select 0) in (unlockedMagBullet + unlockedMagShotgun + unlockedMagShell + unlockedMagMissile + unlockedMagRocket) };
+				};
+
+				default {
+					_inventory = _inventory select { (_x select 0) in unlockedItems}
+				};
 			};
 
 			// add empty item (deliberately choose nothing for this type) and any item ("randomly" (weighted) select an item)


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [x] Enhancement
4. [ ] Miscellaneous

## Ports:
https://github.com/official-antistasi-community/A3-Antistasi/pull/3392

### What have you changed and why?
This PR -

 - Changes AI loadout arsenal to an override system (see below)
 - Limits primary and secondary weapons in AI arsenal based on class type (e.g. only grenadiers can have GL)
 - Limits primary, secondary, and handguns available to only those with unlocked compatible magazines
 - Limits **all equipment** (weapons, uniforms, NVGs, mags, literally everything) available in the AI arsenal to what's unlocked
 - Ensures rebels are only equipped with unlocked magazines (no magazine farming)

---

Due to the nature of how the AI arsenal works, it's an all or nothing approach: if you want to change / statically set one thing for an AI class, the AI loadout has to set everything else as well. So e.g. if you want to ensure your AA Specialists use Stingers instead of Strelas, now every other part of their loadout (barring uniform / headgear) will always be exactly the one thing that was set in the loadout you chose the Stinger in.

This PR fixes that annoyance with an override system. Basically, the AI arsenal functions as normal, except that an option is added to all lists (except cargo) called "Petros Knows Best." If this option is chosen, AI will still use the normal functions within fn_equipRebel to equip item(s) from that category.

Example use case: Say I don't want my rebel riflemen to wear police vests, and I want them to always use M4s. So when editing the rifleman class, I choose a vest I like and select the M4. For all other categories, I select "Petros Knows Best." Now when I recruit AI rifleman, they'll have the vest and M4 I chose, and everything else will still be "randomized" using the functions in equipRebel.

PR also limits primary and secondary weapons available for the loadout based on the AI class (e.g. only grenadiers can have a grenade launcher, only AA can have an AA launcher, etc), and ensures rebels only get magazines that are in arsenal (and unlocked if playing with unlocks, or qty >= ITEM_MIN if no unlocks). No more farming rebel recruits for magazines. 

### Please specify which Issue this PR Resolves (If Applicable).
~~None AFAIK~~ Fixes - @UAC-MaxxLite desire for limiting weapons available by class, and my annoyance with all or nothing loadout approach.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

This is still very much a WIP. It works enough that you can give it a test and see if it makes sense and y'all think it works for this game.

Issues that need worked out:

**Major issues:**

 - [ ] "Petros Knows Best" is not a selection for cargo lists; however, if user selects "Petros Knows Best" for a cargo container (uniform, vest, backpack) user will not be able to add any cargo at all
 - [ ] "Petros Knows Best" is a possible selection, but is not implemented, for weapon magazines and attachments - misleading to user

**Minor issues:**

 - [ ] "Petros Knows Best" is not implemented for assigned items (map, gps/uav terminal, radio, compass, watch, nvg) or binoculars. I don't think this really matters.
 - [ ] When user selects "Petros Knows Best", leaves that tab, and then comes back to it, "Empty" is selected instead of "Petros Knows Best," which can be confusing. (For clarity, "Empty" selection still functions as normal).
- [ ] Probably some other stuff I'm not thinking of.

### How can the changes be tested?
Steps:

********************************************************
Notes:

#3392 is partially ported into this (fn_randomRifle, fn_addPrimaryAndMags, fn_equipRebel) to minimize divergence from upstream.

#433 is merged into this for compat.
