### PR TITLE
Add missing 3CB and RHS vehicles cargo logistics nodes

### DIFF
--- a/A3A/addons/logistics/Nodes/3CBFactions.hpp
+++ b/A3A/addons/logistics/Nodes/3CBFactions.hpp
@@ -14,6 +14,10 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
         };
     };
 };
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_datsun_uk3cb_datsun_civ_closed_p3d : UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_datsun_uk3cb_datsun_civ_open_p3d
+{
+	canLoadWeapon = 0;
+};
 
 class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_datsun_uk3cb_datsun_open_p3d : TRIPLES(ADDON,Nodes,Base)
 {
@@ -47,6 +51,10 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehic
             seats[] = {3,4,6};
         };
     };
+};
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_hilux_uk3cb_hilux_civilian_closed_p3d : UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_hilux_uk3cb_hilux_p3d
+{
+	canLoadWeapon = 0;
 };
 
 class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_m939_uk3cb_m939_open_p3d : TRIPLES(ADDON,Nodes,Base)
@@ -782,6 +790,28 @@ class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_apc_UK3CB_Factions_Vehicles_
         {
             offset[] = {-0.10,-2.4,-0.58};
             seats[] = {};
+        };
+    };
+};
+
+class UK3CB_Factions_addons_UK3CB_Factions_Vehicles_wheeled_UK3CB_Factions_Vehicles_landrover_uk3cb_lr_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.15,-0.81};
+			seats[] = {2,3};
+        };
+        class Node2
+        {
+            offset[] = {0,-0.95,-0.81};
+			seats[] = {4,5};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.75,-0.81};
+			seats[] = {0,1,6};
         };
     };
 };

--- a/A3A/addons/logistics/Nodes/RHS.hpp
+++ b/A3A/addons/logistics/Nodes/RHS.hpp
@@ -811,10 +811,11 @@ class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.4,-0.93};
+            offset[] = {-0.07,-1.42,-0.93};
         };
     };
 };
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1043 : rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025 {};
 class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_mk19 : TRIPLES(ADDON,Nodes,Base)
 {
 	canLoadWeapon = 0;
@@ -822,10 +823,11 @@ class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_mk19 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.4,-1.01};
+            offset[] = {-0.07,-1.42,-1.01};
         };
     };
 };
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1043_mk19 : rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_mk19 {};
 class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_m2 : TRIPLES(ADDON,Nodes,Base)
 {
 	canLoadWeapon = 0;
@@ -833,10 +835,11 @@ class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_m2 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.4,-1.2};
+            offset[] = {-0.07,-1.42,-1.2};
         };
     };
 };
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1043_m2 : rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_m2 {};
 
 class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151 : TRIPLES(ADDON,Nodes,Base)
 {
@@ -845,7 +848,7 @@ class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.3,-0.77};
+            offset[] = {-0.04,-1.3,-0.77};
         };
     };
 };
@@ -856,7 +859,7 @@ class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v1 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.95,-0.77};
+            offset[] = {-0.04,-1.95,-0.77};
         };
     };
 };
@@ -869,10 +872,23 @@ class rhsusf_addons_rhsusf_m11xx_rhssaf_m1151_pkm_saf : TRIPLES(ADDON,Nodes,Base
     {
         class Node1
         {
-            offset[] = {0,-1.31,-0.68};
+            offset[] = {-0.04,-1.31,-0.68};
         };
     };
 };
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2crows : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.04,-2.1,-0.76};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_mk19crows : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2crows {};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_lras3_v1 : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2crows {};
 class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v2 : TRIPLES(ADDON,Nodes,Base)
 {
 	canLoadWeapon = 0;
@@ -880,7 +896,7 @@ class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v2 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-1.95,-0.77};
+            offset[] = {-0.04,-1.95,-0.77};
         };
     };
 };
@@ -894,14 +910,61 @@ class rhsusf_addons_rhsusf_m11xx_rhsusf_m1152 : TRIPLES(ADDON,Nodes,Base)
     {
         class Node1
         {
-            offset[] = {0,-0.5,-0.75};
+            offset[] = {-0.05,-0.5,-0.75};
         };
         class Node2
         {
-            offset[] = {0,-1.3,-0.75};
+            offset[] = {-0.05,-1.3,-0.75};
         };
     };
 };
+
+class rhsusf_addons_rhsusf_matv_m1240a1 : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.04,-2.1,-1.36};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_matv_m1240a1_m2 : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.04,-2.75,-1.36};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_matv_m1240a1_mk19 : rhsusf_addons_rhsusf_matv_m1240a1_m2 {};
+class rhsusf_addons_rhsusf_matv_m1240a1_m240 : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.04,-2.75,-1.31};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_matv_m1240a1_m2crows : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.04,-2.65,-1.36};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_matv_m1240a1_mk19crows : rhsusf_addons_rhsusf_matv_m1240a1_m2crows {};
 
 class rhsgref_addons_rhsgref_a2port_armor_brdm2_BRDM2_HQ_p3d : TRIPLES(ADDON,Nodes,Base)
 {
@@ -922,6 +985,7 @@ class rhsgref_addons_rhsgref_a2port_armor_brdm2_BRDM2_HQ_p3d : TRIPLES(ADDON,Nod
 
 class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_p3d : TRIPLES(ADDON,Nodes,Base)
 {
+    canLoadWeapon = 0;
     class Nodes
     {
         class Node1
@@ -931,4 +995,15 @@ class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_p3d : TRIPLES(ADDON,Nodes,Base)
         };
     };
 };
-class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_open_p3d : rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_p3d {};
+class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_open_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.06,-1.16,-0.46};
+            seats[] = {2,5};
+        };
+    };
+};

--- a/A3A/addons/logistics/Nodes/RHS.hpp
+++ b/A3A/addons/logistics/Nodes/RHS.hpp
@@ -791,6 +791,118 @@ class rhsusf_addons_rhsusf_hmmwv_rhsusf_m998_2dr : TRIPLES(ADDON,Nodes,Base)
     };
 };
 
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m998_4dr : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.37,-0.91};
+			seats[] = {3,4};
+        };
+    };
+};
+
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.4,-0.93};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_mk19 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.4,-1.01};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_hmmwv_rhsusf_m1025_m2 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.4,-1.2};
+        };
+    };
+};
+
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.3,-0.77};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v1 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.95,-0.77};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_mk19_v1 : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v1 {};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m240_v1 : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v1 {};
+class rhsusf_addons_rhsusf_m11xx_rhssaf_m1151_pkm_saf : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.31,-0.68};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v2 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.95,-0.77};
+        };
+    };
+};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_mk19_v2 : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v2 {};
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m240_v2 : rhsusf_addons_rhsusf_m11xx_rhsusf_m1151_m2_v2 {};
+
+class rhsusf_addons_rhsusf_m11xx_rhsusf_m1152 : TRIPLES(ADDON,Nodes,Base)
+{
+	canLoadWeapon = 0;
+    class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.5,-0.75};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.3,-0.75};
+        };
+    };
+};
+
 class rhsgref_addons_rhsgref_a2port_armor_brdm2_BRDM2_HQ_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     class Nodes
@@ -819,3 +931,4 @@ class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_p3d : TRIPLES(ADDON,Nodes,Base)
         };
     };
 };
+class rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_open_p3d : rhsafrf_addons_rhs_a2port_car_UAZ_UAZ_p3d {};


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

Adds missing cargo nodes for:

3CB:

- Datsun (covered)
- Hilux (covered)
- Land Rover (unarmed, open and covered)

RHS:

- M998 4 door
- M1025 (incl armed variants)
- M1043 (incl armed variants)
- M1151 (incl armed variants)
- M1240 (incl armed variants)
- UAZ (open)

### Please specify which Issue this PR Resolves (If Applicable).
https://discord.com/channels/817005365740044289/1218566036459229245/1330269414863409224

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
