### PR TITLE
Improve build box with parameters, less saving restrictions

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -197,13 +197,6 @@ class Params
         texts[] = {$STR_params_afk_enabled, $STR_params_afk_disabled};
         default = 1;
     };
-    class recruitToPlayerSquad
-    {
-        title = $STR_params_recruitToPlayerSquad;
-        values[] = {1,0};
-        texts[] = {$STR_params_afk_enabled, $STR_params_afk_disabled};
-        default = 1;
-    }
     class enablePunishments
     {
         title = $STR_params_enablePunishments;
@@ -557,6 +550,13 @@ class Params
         values[] = {""};
         texts[] = {""};
         default = "";
+    };
+    class recruitToPlayerSquad
+    {
+        title = $STR_params_recruitToPlayerSquad;
+        values[] = {1,0};
+        texts[] = {$STR_params_afk_enabled, $STR_params_afk_disabled};
+        default = 1;
     };
     class enableSpectrumDevice
     {

--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -147,13 +147,6 @@ class Params
         texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_A3A_Params_selfReviveMethods_withstand};
         default = 0;
     };
-    class A3A_builderPermissions
-    {
-        title = "Player classes permitted to use the building placer";
-        values[] = {1, 2, 3};
-        texts[] = {"Team leaders", "Engineers", "Both"};
-        default = 3;
-    };
 
     class Spacer101
     {
@@ -168,13 +161,6 @@ class Params
         values[] = {""};
         texts[] = {""};
         default = "";
-    };
-    class totalVictory //deprecated Dont Use
-    {
-        title = $STR_A3AU_total_victory_deprecated;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_text,$STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
     };
     class victoryCondition
     {
@@ -337,13 +323,6 @@ class Params
         texts[] = {$STR_antistasi_dialogs_generic_button_no_text,$STR_antistasi_dialogs_generic_button_yes_text};
         default = 0;
     };
-    class enableSpectrumDevice
-    {
-        title = $STR_params_enableSpectrumDevice;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
-    };
 
     class Spacer60
     {
@@ -464,13 +443,6 @@ class Params
         texts[] = {"1","2","3","4","5","6"};
         default = 3;
     };
-    class unconsciousPossessAi
-    {
-        title = $STR_params_unconsciousAiPossess;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
-    };
     class areRandomEventsEnabled
     {
         attr[] = {"server"};
@@ -524,6 +496,94 @@ class Params
     class disableAutoSmokeCover
     {
         title = $STR_params_disableAutoSmokeCover;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
+    };
+
+    class SpacerBuilder
+    {
+        title = "";
+        values[] = {""};
+        texts[] = {""};
+        default = "";
+    };
+    class TitleBuilder
+    {
+        title = $STR_params_builder_header;
+        values[] = {""};
+        texts[] = {""};
+        default = "";
+    };
+    class A3A_builderPermissions
+    {
+        title = $STR_params_builderPermissions;
+        values[] = {1, 2, 3};
+        texts[] = {"Team leaders", "Engineers", "Both"};
+        default = 3;
+    };
+    class A3A_builderLimit
+    {
+        title = $STR_params_builderLimit;
+        values[] = {100, 200, 300, 400, 500, 600, 800, 900, 1000, 999999};
+        texts[] = {"100", "200", "300", "400", "500", "600", "800", "900", "1000", "Basically Infinite"};
+        default = 300;
+    };
+    class A3A_builderBuildTime
+    {
+        title = $STR_params_builderBuildTime;
+        values[] = {0, 4, 5, 6, 7, 8, 9, 10};
+        texts[] = {"DEBUG (Instant)", "0.4x", "0.5x", "0.6x", "0.7x", "0.8x", "0.9x", "1.0x"};
+        default = 5;
+    };
+    class A3A_builderAllowRoads
+    {
+        title = $STR_params_builderAllowRoads;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
+    };
+
+    class SpacerExperimental
+    {
+        title = "";
+        values[] = {""};
+        texts[] = {""};
+        default = "";
+    };
+    class TitleExperimental
+    {
+        title = $STR_params_experimental_header;
+        values[] = {""};
+        texts[] = {""};
+        default = "";
+    };
+    class enableSpectrumDevice
+    {
+        title = $STR_params_enableSpectrumDevice;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
+    };
+    class unconsciousPossessAi
+    {
+        title = $STR_params_unconsciousAiPossess;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
+    };
+    class allowFuturisticSupports
+    {
+        attr[] = {"server"};
+        title = $STR_params_allowFuturisticSupports;
+        values[] = {0,1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 0;
+    };
+    class allowFuturisticUnfairSupports
+    {
+        attr[] = {"server"};
+        title = $STR_params_allowFuturisticUnfairSupports;
         values[] = {0,1};
         texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
         default = 0;
@@ -614,22 +674,6 @@ class Params
     {
         attr[] = {"server"};
         title = $STR_params_allowUnfairSupports;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
-    };
-    class allowFuturisticSupports
-    {
-        attr[] = {"server"};
-        title = $STR_params_allowFuturisticSupports;
-        values[] = {0,1};
-        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
-        default = 0;
-    };
-    class allowFuturisticUnfairSupports
-    {
-        attr[] = {"server"};
-        title = $STR_params_allowFuturisticUnfairSupports;
         values[] = {0,1};
         texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
         default = 0;

--- a/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
@@ -15,8 +15,8 @@ private _fnc_distCheck = {
 
 // Cleanup constructed buildings
 private _rebMarkers = (airportsX + outposts + seaports + factories + resourcesX + milbases) select { sidesX getVariable _x == teamPlayer };
+_rebMarkers pushBack "Synd_HQ";
 // ^ Add extra plus related stuff
-_rebMarkers append outpostsFIA; _rebMarkers pushBack "Synd_HQ";
 
 A3A_buildingsToSave = A3A_buildingsToSave select {
 	// Keep if there are rebel spawners within 500m

--- a/A3A/addons/core/functions/Builder/fn_buildingPlacer.sqf
+++ b/A3A/addons/core/functions/Builder/fn_buildingPlacer.sqf
@@ -73,11 +73,16 @@ private _upKeyEH = _emptyDisplay displayAddEventHandler ["KeyUp", {
 
     // Place object
     if (_key isEqualTo DIK_SPACE) then {
+
+        if (count (A3A_buildingsToSave) >= A3A_builderLimit) exitWith {
+            ["Build Placer", format["There are too many builds. %1/%2", (count A3A_buildingsToSave), A3A_builderLimit]] call A3A_fnc_customHint;
+        };
+
         private _tempObject = (A3A_building_EHDB # BUILD_OBJECT_TEMP_OBJECT);
         if (isObjectHidden _tempObject) exitWith {};
-        if ((A3A_building_EHDB # BUILD_OBJECT_SELECTED_STRING) isEqualTo "Land_Can_V2_F") exitwith {};	// temp objects not built.
+        if ((A3A_building_EHDB # BUILD_OBJECT_SELECTED_STRING) isEqualTo "Land_Can_V2_F") exitWith {};	// temp objects not built.
 
-        if (_tempObject distance (A3A_building_EHDB # BUILD_RADIUS_OBJECT_CENTER) > (A3A_building_EHDB # BUILD_RADIUS)) exitwith {};
+        if (_tempObject distance (A3A_building_EHDB # BUILD_RADIUS_OBJECT_CENTER) > (A3A_building_EHDB # BUILD_RADIUS)) exitWith {};
         //if (isOnRoad getPosATL _tempObject) exitwith {};	// can't build on roads
         
         private _price = (A3A_building_EHDB # OBJECT_PRICE);

--- a/A3A/addons/core/functions/Builder/fn_placeBuilderObjects.sqf
+++ b/A3A/addons/core/functions/Builder/fn_placeBuilderObjects.sqf
@@ -71,7 +71,7 @@ private _constructionObjects = [
     A3A_unbuiltObjects pushBack _planks;
 
     // Should be the only actions on this object, so we can just JIP on the object
-    private _holdTime = 1.6 * sqrt _price;
+    private _holdTime = (A3A_builderBuildTime / 10) * sqrt _price;
     [_planks, _holdTime] remoteExecCall ["A3A_fnc_addBuildingActions", 0, _planks];
 
     // TODO: could trigger on unbuiltObjects change instead

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -210,16 +210,10 @@ _arrayEst = [];
 } forEach staticsToSave;
 
 private _rebMarkers = (airportsX + outposts + seaports + factories + resourcesX + milbases) select { sidesX getVariable _x == teamPlayer };
-// ^ Update to include plus related stuff
-_rebMarkers append outpostsFIA; _rebMarkers pushBack "Synd_HQ";
+_rebMarkers pushBack "Synd_HQ";
 {
-	// Ignore if outside mission distance (temporary)
-	if (!alive _x or (_x distance2d markerPos "Synd_HQ" > distanceMission)) then { continue };
-
-	// Ignore if not within a rebel marker
-	private _building = _x;
-	private _indexes = _rebMarkers inAreaArrayIndexes [getPosATL _x, 500, 500];
-	if (-1 == _indexes findIf { _building inArea _rebMarkers#_x } ) then { continue };
+	if (isOnRoad _x && {A3A_builderAllowRoads isEqualTo false}) then {continue};
+	if (surfaceIsWater getPosASL _x) then {continue};
 
 	_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
 } forEach A3A_buildingsToSave;

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -5271,8 +5271,8 @@
                 <French>PARAMÈTRES DE SOUTIEN</French>
             </Key>
             <Key ID="STR_params_enableSpectrumDevice">
-                <Original>Enable spectrum device hacking capability (conctact dlc required)</Original>
-                <Russian>Разрешить возможность взлома с помощью spectrum device (необходимо дополнение contact)</Russian>
+                <Original>[Experimental] Enable spectrum device hacking capability (Contact DLC)</Original>
+                <Russian>[Experimental] Разрешить возможность взлома с помощью spectrum device (Contact DLC)</Russian>
             </Key>
             <Key ID="STR_params_disableAutoSmokeCover">
                 <Original>Disable Auto Smoke Cover Script (Helps with performance)</Original>
@@ -5592,6 +5592,12 @@
                 <Chinesesimp>无限制</Chinesesimp>
                 <Korean>무제한</Korean>
                 <French>Illimité</French>
+            </Key>
+            <Key ID="STR_params_builder_header">
+                <Original>BUILDER BOX OPTIONS</Original>
+            </Key>
+            <Key ID="STR_params_experimental_header">
+                <Original>EXPERIMENTAL OPTIONS</Original>
             </Key>
             <Key ID="STR_params_balance_header">
                 <Original>BALANCE OPTIONS</Original>

--- a/A3A/addons/ultimate/Stringtable.xml
+++ b/A3A/addons/ultimate/Stringtable.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="A3AU-ultimate">
+    <Package name="A3-Antistasi-builderbox">
+        <Key ID="STR_params_builderPermissions">
+            <Original>Player classes permitted to use the building placer</Original>
+        </Key>
+        <Key ID="STR_params_builderLimit">
+            <Original>Build limit</Original>
+        </Key>
+        <Key ID="STR_params_builderAllowRoads">
+            <Original>Allow buildings to be saved on roads</Original>
+        </Key>
+        <Key ID="STR_params_builderBuildTime">
+            <Original>Build hold time multiplier</Original>
+        </Key>
+    </Package>
     <Package name="A3-Antistasi-Ultimate-functions">
         <Key ID="STR_A3AU_init_mods_warning_header">
             <Original>Warning</Original>


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

- Changed how build box saving works, now buildings should be saved anywhere (except on roads, unless the param is turned on);

- Changed how build box TTB (time to build) is calculated, now using the parameter `A3A_builderBuildTime`;

- Added a "Build limit" parameter for any potential save corruption concerns;

- Added a dedicated "BUILDER BOX OPTIONS" to the params section;

- Added a dedicated "Experimental" params tab to solve #447

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #447!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

Needs further testing to ensure there are no weird edge cases that may cause unwanted problems.

### How can the changes be tested?
Steps:

Use builder box as normal, observe the differences as stated above

********************************************************
Notes:
