### PR TITLE
Improve FT restrictions for HC groups

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -81,15 +81,19 @@ if (_earlyEscape) exitWith {};
 
 private _areEnemiesNearby = false;
 
-if (!fastTravelEnemyCheck && {[getPosATL player] call A3A_fnc_enemyNearCheck}) exitWith {
-	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_enemiesnear_individual"] call SCRT_fnc_misc_deniedHint;
-};
-
-if (fastTravelEnemyCheck && {_units findIf {[getPosATL _x] call A3A_fnc_enemyNearCheck} != -1}) exitWith {
+if (_eshHC && {_units findIf {[getPosATL _x] call A3A_fnc_enemyNearCheck} != -1}) exitWith {
 	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_enemiesnear_group"] call SCRT_fnc_misc_deniedHint;
 };
 
-if (vehicle player != player && {driver vehicle player != player}) exitWith {
+if (!_esHC && {!fastTravelEnemyCheck && {[getPosATL player] call A3A_fnc_enemyNearCheck}}) exitWith {
+	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_enemiesnear_individual"] call SCRT_fnc_misc_deniedHint;
+};
+
+if (!_esHC && {fastTravelEnemyCheck && {_units findIf {[getPosATL _x] call A3A_fnc_enemyNearCheck} != -1}}) exitWith {
+	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_enemiesnear_group"] call SCRT_fnc_misc_deniedHint;
+};
+
+if (!_esHC && {vehicle player != player && {driver vehicle player != player}}) exitWith {
 	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_only_drivers"] call SCRT_fnc_misc_deniedHint;
 };
 

--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -81,7 +81,7 @@ if (_earlyEscape) exitWith {};
 
 private _areEnemiesNearby = false;
 
-if (_eshHC && {_units findIf {[getPosATL _x] call A3A_fnc_enemyNearCheck} != -1}) exitWith {
+if (_esHC && {_units findIf {[getPosATL _x] call A3A_fnc_enemyNearCheck} != -1}) exitWith {
 	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_enemiesnear_group"] call SCRT_fnc_misc_deniedHint;
 };
 


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR changes fast travel restrictions.

If attempting to FT a HC squad:

 - enemy check will only check for enemies for HC squad, not commander
 - allow FT even if commander is not driver of their vehicle (because their vehicle won't be FT'd)

If attempting to fast travel own squad:

 - no change to existing restrictions

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #431 and #452"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

~~I have not tested this yet. Will be testing today when back at main computer.~~

Update: works as intended after fixing typo

Hopefully this will not merge conflict with #450, but if so should be a very easy conflict to resolve.