### PR TITLE
Fix petros identity/name

### DIFF
--- a/A3A/addons/core/functions/Base/fn_createPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_createPetros.sqf
@@ -15,8 +15,10 @@ if (isNil "_location") then {
 	};
 };
 
+private _petrosIdentity = createHashMapFromArray [["face", "GreekHead_A3_01"], ["speaker", "Male01GRE"], ["pitch", 1.1], ["firstName", "Petros"], ["lastName", ":)"]];
+
 private _oldPetros = petros;
-petros = [_groupPetros, FactionGet(reb,"unitPetros"), _location, [], 10, "NONE"] call A3A_fnc_createUnit;
+petros = [_groupPetros, FactionGet(reb,"unitPetros"), _location, [], 10, "NONE", _petrosIdentity] call A3A_fnc_createUnit;
 publicVariable "petros";
 deleteVehicle _oldPetros;		// Petros should now be leader unless there's a player in the group
 

--- a/A3A/addons/core/functions/Base/fn_initPetros.sqf
+++ b/A3A/addons/core/functions/Base/fn_initPetros.sqf
@@ -7,7 +7,9 @@ petros setSkill 1;
 petros setVariable ["respawning",false];
 petros allowDamage false;
 
-[petros, createHashMapFromArray [["face", "GreekHead_A3_01"], ["speaker", "Male01GRE"], ["pitch", 1.1], ["firstName", "Petros"], ["lastName", ""]]] call A3A_fnc_setIdentity;
+if (face petros != "GreekHead_A3_01") then {
+    [petros, createHashMapFromArray [["face", "GreekHead_A3_01"], ["speaker", "Male01GRE"], ["pitch", 1.1], ["firstName", "Petros"], ["lastName", ":)"]]] call A3A_fnc_setIdentity;
+};
 
 removeHeadgear petros;
 removeGoggles petros;
@@ -92,6 +94,7 @@ petros addMPEventHandler ["mpkilled",
         [] call A3A_fnc_createPetros;
     };
 }];
+
 [] spawn {sleep 120; petros allowDamage true;};
 
 Info("initPetros completed");

--- a/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
@@ -13,9 +13,31 @@ Arguments:
     <STRING> Optional: Name of unit
 */
 
+#include "..\..\script_component.hpp"
+
 params ["_unit", "_identity"];           // Don't care about the other params here
 
 if (isNull _unit) exitWith {};
+
+private _firstName = _identity getOrDefault ["firstName", ""];
+private _lastName = _identity getOrDefault ["lastName", ""];
+
+if ((isNil "_firstName" || {_firstName isEqualTo ""}) || (isNil "_lastName" || {_lastName isEqualTo ""})) then {
+    private _nameConfig = configfile >> "CfgWorlds" >> "GenericNames" >> "GreekMen";
+    private _firstNames = configProperties [_nameConfig >> "FirstNames"] apply { getText(_x) };
+    private _lastNames = configProperties [_nameConfig >> "LastNames"] apply { getText(_x) };
+
+    private _type = _unit getVariable "unitType";
+    private _identity = [Faction(side _unit), _type] call A3A_fnc_createRandomIdentity;
+
+    // Choose appropriate faction identity if possible, fallback to default names if unavailable
+    _firstName = ([_identity getOrDefault ["firstName", ""], selectRandom _firstNames] select {_x != ""}) # 0;
+    _lastName = ([_identity getOrDefault ["lastName", ""], selectRandom _lastNames] select {_x != ""}) # 0;
+};
+
+_identity set ["firstName", _firstName];
+_identity set ["lastName", _lastName];
+
 private _JIPID = "identity_" + netId _unit;
 [_JIPID, _unit, _identity] remoteExec ["A3A_fnc_setIdentityLocal", 0, _JIPID];
 // ([_JIPID] + _this) remoteExec ["A3A_fnc_setIdentityLocal", 0, _JIPID];

--- a/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentity.sqf
@@ -27,7 +27,7 @@ if ((isNil "_firstName" || {_firstName isEqualTo ""}) || (isNil "_lastName" || {
     private _firstNames = configProperties [_nameConfig >> "FirstNames"] apply { getText(_x) };
     private _lastNames = configProperties [_nameConfig >> "LastNames"] apply { getText(_x) };
 
-    private _type = _unit getVariable "unitType";
+    private _type = _unit getVariable ["unitType", ""]; // Why do some units *not* have this set? I will never know!
     private _identity = [Faction(side _unit), _type] call A3A_fnc_createRandomIdentity;
 
     // Choose appropriate faction identity if possible, fallback to default names if unavailable

--- a/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
+++ b/A3A/addons/core/functions/Utility/fn_setIdentityLocal.sqf
@@ -24,17 +24,8 @@ if !(isNil "_speaker") then { _unit setSpeaker _speaker };
 private _pitch = _identity get "pitch";
 if !(isNil "_pitch") then { _unit setPitch _pitch };
 
-private _firstName = _identity getOrDefault ["firstName", ""];
-private _lastName = _identity getOrDefault ["lastName", ""];
-
-if (isNil "_firstName" || {isNil "_lastName"}) then {
-    private _nameConfig = configfile >> "CfgWorlds" >> "GenericNames" >> "GreekMen";
-    private _firstNames = configProperties [_nameConfig >> "FirstNames"] apply { getText(_x) };
-    private _lastNames = configProperties [_nameConfig >> "LastNames"] apply { getText(_x) };
-
-    _firstName = selectRandom _firstNames;
-    _lastName = selectRandom _lastNames;
-};
+private _firstName = _identity get "firstName";
+private _lastName = _identity get "lastName";
 
 if (_firstName != "" || _lastName != "") then {
     private _fullName = [_firstName, _lastName] select { _x != "" } joinString " ";


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Added petros identity on creation rather than after

Moved redundancy code to `setIdentity` (locality issues with `setIdentityLocal`)

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

Ensure names and identities work on a dedicated server

### How can the changes be tested?
Steps:

********************************************************
Notes:
