### PR TITLE
Fix createAttackForceOrbital call

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
@@ -113,8 +113,7 @@ if (_airBase != "") then            // uh, is that a thing
     private _troops = ["Normal", "SpecOps"] select ("specops" in _modifiers);
     ServerDebug_3("Attempting to spawn %1 air vehicles including %2 attack from %3", _airCount, _attackCount, _airbase);
     private _roll = round (random 100);
-    if (allowFuturisticSupports && _roll <= 25) then {
-
+    if (allowFuturisticUnfairSupports && _roll <= 25 && {(Faction(_side) get "vehiclesDropPod") isNotEqualTo []}) then {
         private _data = [_side, _airBase, _targPos, _resPool, _airCount, _attackCount, _tier, _troops] call A3A_fnc_createAttackForceOrbital;
         _resourcesSpent = _resourcesSpent + _data#0;
         _vehicles append _data#1;
@@ -124,7 +123,6 @@ if (_airBase != "") then            // uh, is that a thing
 
         ServerInfo_1("Spawn performed: Orbital vehicles %1", _data#1 apply {typeOf _x});
     } else {
-
         private _data = [_side, _airBase, _targPos, _resPool, _airCount, _attackCount, _tier, _troops] call A3A_fnc_createAttackForceAir;
         _resourcesSpent = _resourcesSpent + _data#0;
         _vehicles append _data#1;
@@ -134,11 +132,6 @@ if (_airBase != "") then            // uh, is that a thing
 
         ServerInfo_1("Spawn performed: Air vehicles %1", _data#1 apply {typeOf _x});
     };
-
-
-    [-(_data#0), _side, _resPool] remoteExec ["A3A_fnc_addEnemyResources", 2];
-
-    ServerInfo_1("Spawn performed: Air vehicles %1", _data#1 apply {typeOf _x});
 };
 
 [_resourcesSpent, _vehicles, _crewGroups, _cargoGroups];

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceOrbital.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceOrbital.sqf
@@ -35,7 +35,6 @@ private _cargoGroups = [];
 
 private _faction = Faction(_side);
 private _transportPlanes = _faction get "vehiclesDropPod";
-/* if (_transportPlanes isEqualType []) exitwith {}; */
 private _lhFactor = 0 max (1 - (tierWar+_tierMod) / 10);            // phase out light helis at higher war tiers
 
 private _transportPool = [];
@@ -51,6 +50,8 @@ private _isTransport = _vehAttackCount < _vehCount;            // normal case, f
 
 for "_i" from 1 to _vehCount do {
     private _vehType = selectRandomWeighted ([_supportPool, _transportPool] select _isTransport);
+
+    if (isNil "_vehType") then {continue};
 
     switch (true) do {   
         case (_isGuaranteedAirdrop || {_vehType == "VEHAIRDROP"}): {

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -44,12 +44,12 @@ private _initData = [
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
     ["QRFVEHAIRDROP", "TROOPS", 0.3, 0.1,   0,   0,  "", "vehiclesPlanesTransport"],
-    ["QRFORBITAL",        "TROOPS", 0.5, 0.1,   0,   0,  "f", "vehiclesDropPod"],     ///needs to be balanced
+    ["QRFORBITAL",        "TROOPS", 0.5, 0.1,   0,   0,  "fu", "vehiclesDropPod"],     ///needs to be balanced
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", ""],                            // balanced against airstrikes
     ["GUNSHIP",         "AREA", 0.2, 0.1, 0, 80, "", "vehiclesPlanesGunship"],                   //u      // uh. Does AREA work for this? Only lasts 5 minutes so maybe...
     ["SAM",           "TARGET", 1.0, 1.0,   0, 100, "u", ""],                            // balanced against ASF
     ["CRUISEMISSILE", "AREA", 0.3, 0.1, 150,   100, "u", ""],
-    ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "f", ""],
+    ["ORBITALSTRIKE",   "AREA", 0.2, 0.0, 300,   0, "fu", ""],
     ["UAV",           "TARGET", 0.4, 0.2,   0, 80,  "u", "uavsAttack"]
 ];
 


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Added extra checks before calling `createAttackForceOrbital` due to not all templates being supported by it, moved orbital supports to futuristic unfair

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
