### PR TITLE
Add arsenal crate action to quickly equip a loadout

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -136,6 +136,7 @@ if(hasInterface)then{
                 case "I_G_Soldier_GL_F": { "Grenadier" };
                 case "I_G_Soldier_AR_F": { "MachineGunner" };
                 case "I_G_engineer_F":  { "Engineer" };
+                default { "Rifleman" };
             };
 
             [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -123,6 +123,31 @@ if(hasInterface)then{
         "alive _target && {_target distance _this < 5 && {vehicle player == player}}"
     ];
 
+    //add quick equip button
+    _object addAction [
+        (format ["<img image='%1' size='1.6' shadow=2/>", "\A3\ui_f\data\GUI\Rsc\RscDisplayArsenal\vest_ca.paa"] + format["<t size='1'> %1</t>", "Quick Equip Loadout"]),
+        { 
+            private _player = _this select 1;
+            private _prefix = "loadouts_reb_militia_";
+            private _loadout =  switch (typeOf _player) do {
+                case "I_G_medic_F":  { "Medic" }; 
+                case "I_G_Soldier_TL_F": { "SquadLeader" };
+                case "I_G_Soldier_F": { "Rifleman" };
+                case "I_G_Soldier_GL_F": { "Grenadier" };
+                case "I_G_Soldier_AR_F": { "MachineGunner" };
+                case "I_G_engineer_F":  { "Engineer" };
+            };
+
+            [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;
+        },
+        [],
+        6,
+        true,
+        false,
+        "",
+        "alive _target && {_target distance _this < 5} && {vehicle player == player}"
+    ];
+
     //add open event
     [missionNamespace, "arsenalOpened", {
         disableSerialization;

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -125,7 +125,7 @@ if(hasInterface)then{
 
     //add quick equip button
     _object addAction [
-        (format ["<img image='%1' size='1.6' shadow=2/>", "\A3\ui_f\data\GUI\Rsc\RscDisplayArsenal\vest_ca.paa"] + format["<t size='1'> %1</t>", "Quick Equip Loadout"]),
+        (format ["<img image='%1' size='1.6' shadow=2/>", "\A3\ui_f\data\GUI\Rsc\RscDisplayArsenal\vest_ca.paa"] + format["<t size='1'> %1</t>", (localize "STR_JNA_SCT_QUICK_EQUIP")]),
         { 
             private _player = _this select 1;
             private _prefix = "loadouts_reb_militia_";

--- a/A3A/addons/ultimate/Stringtable.xml
+++ b/A3A/addons/ultimate/Stringtable.xml
@@ -140,4 +140,13 @@
             <Original>%1 just sent a tank platoon.</Original>
         </Key>
     </Package>
+    <Package name="Arsenal">
+        <Key ID="STR_JNA_SCT_QUICK_EQUIP">
+            <Original>Quick Equip Loadout</Original>
+            <Russian>Быстрая экипировка</Russian>
+            <Korean>빠른 장비 로드아웃</Korean>
+            <Chinesesimp>快速装备</Chinesesimp>
+            <French>Équipement rapide</French>
+        </Key>
+    </Package>
 </Project>


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

This PR adds an additional action to the arsenal crate "Quick Equip Loadout".

The action equips the player, based on their role (TL, Rifleman, Grenadier, etc) with the same function that equips AI rebels.

This is just a small convenience function - use it to quickly grab a loadout instead of needing to create and / or select a saved loadout in the arsenal, or when time is of the essence (e.g. you just respawned and the HQ is under attack or enemies are on the way). Also useful for testing things like item weights in A3A_rebelGear.

### Please specify which Issue this PR Resolves (If Applicable).
None.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

Because this is based around fn_equipRebel, it suffers from the same problem / exploit mentioned in https://github.com/SilenceIsFatto/A3-Antistasi-Ultimate/pull/441#issuecomment-2619712675 when using this while unlocks are disabled. In short, with unlocks disabled but having a qty of some item > 25, a player could be equipped with that item, then place it right back in the arsenal to effectively duplicate it.

I don't think this PR is the venue to fix that problem. Will probably do it over there in #441 when I get around to finishing that one.