### PR TITLE
More reliable mag lookup in itemArrayWeight

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_itemArrayWeight.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_itemArrayWeight.sqf
@@ -26,8 +26,9 @@ private _config = _class call A3A_fnc_itemConfig;
 // Total "score" (array weight) of the item based on calculated properties
 private _arrayWeight = 1; // in case this function is called with an itemType without custom weighting setup or without an item type, just use default weight (but this shouldn't be called unless you're attempting to change this behavior)
 
-if ("Weapons" in _categories) then {
+if (_class in allWeapons) {
 	private _magcfg = getArray (_config >> "Magazines") # 0 call A3A_fnc_itemConfig;
+	if (isNil "_magcfg") then { _magcfg = (compatibleMagazines _class) # 0 call A3A_fnc_itemConfig};
 	private _ammocfg = getText (_magcfg >> "ammo") call A3A_fnc_itemConfig;
 	private _firemode = getArray (_config >> "modes") # 0; // primary firemode ("SINGLE", "FULLAUTO", etc)
 	private _modecfg = [_config >> _firemode, _config] select (_firemode == "this");

--- a/A3A/addons/core/functions/Ammunition/fn_itemArrayWeight.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_itemArrayWeight.sqf
@@ -26,7 +26,7 @@ private _config = _class call A3A_fnc_itemConfig;
 // Total "score" (array weight) of the item based on calculated properties
 private _arrayWeight = 1; // in case this function is called with an itemType without custom weighting setup or without an item type, just use default weight (but this shouldn't be called unless you're attempting to change this behavior)
 
-if (_class in allWeapons) {
+if (_class in allWeapons) then {
 	private _magcfg = getArray (_config >> "Magazines") # 0 call A3A_fnc_itemConfig;
 	if (isNil "_magcfg") then { _magcfg = (compatibleMagazines _class) # 0 call A3A_fnc_itemConfig};
 	private _ammocfg = getText (_magcfg >> "ammo") call A3A_fnc_itemConfig;


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR fixes an error case with generateRebelGear / itemArrayWeight:

Weapon classes with no magazines defined but that do have magwells defined.

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

Manually generate rebel gear hashmap or wait for it to generate. Check for no errors.
********************************************************
Notes:
