### PR TITLE
Convoy spam fix

### DIFF
--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -68,13 +68,16 @@ Debug("Final target choice list:");
 } forEach _targets;
 
 // Cull anything worse than 10:1 value ratio, otherwise we'll launch some really stupid attacks occasionally
+private _arePunishmentsAllowed = ((enablePunishments isEqualTo 1) && (tierWar >= A3U_setting_tierWarPunishments));
+
 private _minWeight = selectMax _weights / 10;
 private _culledTargets = [];
 {
+    if (!_arePunishmentsAllowed && {(_x#0) in citiesX}) then {continue}; // Skip cities here rather than leaving it to the else statement later
+
     private _weight = _weights select _forEachIndex;
     if (_weight > _minWeight) then { _culledTargets append [_x, _weight] };
 } forEach _targets;
-
 
 // Now we just pick a target
 private _target = selectRandomWeighted _culledTargets;
@@ -94,19 +97,12 @@ if (sidesX getVariable _originMrk != _side) exitWith {
 
 
 if (_targetMrk in citiesX) exitWith {
-    private _tierWarPunishments = missionNamespace getVariable ["A3U_setting_tierWarPunishments",3];
-    if (_side == Invaders && {(tierWar >= _tierWarPunishments)} && {(enablePunishments isEqualTo 1)}) then {
+    if (_side == Invaders) then {
         // Punishment, unsimulated
         Info_2("Starting punishment mission from %1 to %2", _originMrk, _targetMrk);
         [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
         bigAttackInProgress = true; publicVariable "bigAttackInProgress";
         [_targetMrk, _originMrk] spawn A3A_fnc_invaderPunish;
-    } else {
-        // Supply convoy, unsimulated
-        // Do we allow these even if there's already a convoy? Probably not harmful.
-        Info_2("Sending supply convoy from %1 to %2", _originMrk, _targetMrk);
-        [-200, _side, "attack"] call A3A_fnc_addEnemyResources;
-        [[_targetMrk, _originMrk, "Supplies", "attack"],"A3A_fnc_convoy"] call A3A_fnc_scheduler;
     };
     true;
 };

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -3,6 +3,7 @@ FIX_LINE_NUMBERS()
 
 //Mission: Capture/destroy the convoy
 if (!isServer and hasInterface) exitWith {};
+if (missionNamespace getVariable ["A3A_convoyInProgress", false]) exitWith {};
 params ["_mrkDest", "_mrkOrigin", ["_convoyType", ""], ["_resPool", "legacy"], ["_startDelay", -1], ["_visible", false]];
 
 private _difficult = if (random 10 < tierWar) then {true} else {false};
@@ -18,6 +19,8 @@ private _markNames = [];
 private _POWS = [];
 private _reinforcementsX = [];
 
+// Prevent duplicate convoys
+missionNamespace setVariable ["A3A_convoyInProgress", true, true];
 
 // Setup start time
 
@@ -533,6 +536,8 @@ private _groups = [];
 { if (alive _x) then {_groups pushBackUnique (group _x)} } forEach _soldiers;
 { [_x] spawn A3A_fnc_groupDespawner } forEach _groups;
 { [_x] spawn A3A_fnc_VEHdespawner } forEach _vehiclesX;
+
+missionNamespace setVariable ["A3A_convoyInProgress", false, true];
 
 {deleteMarker _x} forEach _markers;
 // Hang around for a bit, and then send all escorts back to the source base


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Changed how target calculation works in chooseAttack, now cities are only added to the culled targets if punishments are available. This by extension should fix a potential issue where convoys are created every minute as a result of invaders not being able to launch a punishment due to things like war level

To be honest this is a hopeful fix, it's not something that can easily be tested

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

On a save with at least 2 cities flipped, see if supply convoy missions will be spammed in place of punishments (turn punishments off in the params)

********************************************************
Notes:
