### PR TITLE
Prevent bad append to unlockedXYZ

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -133,7 +133,7 @@ else
         private _arsenalTab = _class call jn_fnc_arsenal_itemType;
         jna_dataList#_arsenalTab pushBack [_class, _count];         // direct add to avoid O(N^2) issue
 
-        if (_count == -1 || {_count >= minWeaps}) then {
+        if (_count == -1 || {(minWeaps != -1) && _count >= minWeaps}) then {
             private _categories = _class call A3A_fnc_equipmentClassToCategories;
             { (missionNamespace getVariable ("unlocked" + _x)) pushBack _class } forEach _categories;
             _categoriesToPublish insert [true, _categories, []];

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -133,9 +133,11 @@ else
         private _arsenalTab = _class call jn_fnc_arsenal_itemType;
         jna_dataList#_arsenalTab pushBack [_class, _count];         // direct add to avoid O(N^2) issue
 
-        private _categories = _class call A3A_fnc_equipmentClassToCategories;
-        { (missionNamespace getVariable ("unlocked" + _x)) pushBack _class } forEach _categories;
-        _categoriesToPublish insert [true, _categories, []];
+        if (_count == -1 || {_count >= minWeaps}) then {
+            private _categories = _class call A3A_fnc_equipmentClassToCategories;
+            { (missionNamespace getVariable ("unlocked" + _x)) pushBack _class } forEach _categories;
+            _categoriesToPublish insert [true, _categories, []];
+        };
     } foreach FactionGet(reb,"initialRebelEquipment");
 
     // Publish the unlocked categories (once each)


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Pretty simple one. Stop items from initial rebel equipment from being erroneously added to `unlockedXXX` arrays when not actually unlocked (qty == -1 || qty >= minWeaps).

### Please specify which Issue this PR Resolves (If Applicable).
None.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
