### PR TITLE
Lootcrate ignore unlocked items improvements

### DIFF
--- a/A3A/addons/scrt/Loot/fn_loot_gatherLoot.sqf
+++ b/A3A/addons/scrt/Loot/fn_loot_gatherLoot.sqf
@@ -105,14 +105,14 @@ private _data = [];
     switch (true) do {
         case (_lootContainer isKindOf "Man"): {
 
-            _assignedItems = assignedItems _lootContainer;
-            _lootContainerMagazines = magazines _lootContainer;
-            _vest = vest _lootContainer;
-            _headgear = headgear _lootContainer;
-            _backpack = backpack _lootContainer;
-            _lootContainerWeapons = weapons _lootContainer;
+            private _assignedItems = assignedItems _lootContainer;
+            private _lootContainerMagazines = magazines _lootContainer;
+            private _vest = vest _lootContainer;
+            private _headgear = headgear _lootContainer;
+            private _backpack = backpack _lootContainer;
+            private _lootContainerWeapons = weaponsItems _lootContainer;
 
-            if ((lootCrateUnlockedItems isEqualTo true)) then {
+            if (lootCrateUnlockedItems isEqualTo true) then {
 
                 _data = [_assignedItems, _lootContainerMagazines, _lootContainerWeapons];
             
@@ -168,8 +168,8 @@ private _data = [];
             if (count _lootContainerWeapons > 0) then {
                 {
                     if ((lootCrateUnlockedItems isEqualTo true) && {_x in unlockedWeapons}) exitWith {_lootContainer removeWeaponGlobal _x};
-                    _vehicle addWeaponCargoGlobal [_x, 1];
-                    _lootContainer removeWeaponGlobal _x;
+                    _lootContainer addWeaponWithAttachmentsCargoGlobal [_x, 1];
+                    _lootContainer removeWeaponGlobal (_x#0);
                 } forEach _lootContainerWeapons;
             };
 

--- a/A3A/addons/ultimate/functions/Ammunition/fn_removeUnlockedItems.sqf
+++ b/A3A/addons/ultimate/functions/Ammunition/fn_removeUnlockedItems.sqf
@@ -29,11 +29,15 @@ private _unlocks = (unlockedHeadgear + unlockedVests + unlockedNVGs + unlockedOp
     private _array = _x;
 
     {
+        private _itemAttachments = [];
         private _item = _x;
         if (_item isEqualType []) then {
             // diag_log format["Test: %1", _item];
             _originalItem = _item;
             _item = _item select 0;
+            if (count _originalItem > 1) then {
+                _itemAttachments = [_originalItem#1, _originalItem#2, _originalItem#3, _originalItem#6];
+            };
         };
 
         {
@@ -51,8 +55,12 @@ private _unlocks = (unlockedHeadgear + unlockedVests + unlockedNVGs + unlockedOp
         {
             if (_originalItem in _indexed) exitWith {}; // element is already indexed, ignore
             if (_item in _x) then {
-                diag_log format["%1 is already unlocked", _item];
-                _indexed pushBack _originalItem;
+                private _hasAttachments = if (_itemAttachments findIf {_x != ""} != -1) then {true} else {false};
+
+                if (!_hasAttachments) then {
+                    diag_log format["%1 is already unlocked as a weapon", _item];
+                    _indexed pushBack _originalItem;
+                };
             
                 // _array = _array - [_originalItem];
                 // diag_log format["Removing %1 from array", _originalItem];


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Changed how lootcrate gathering works:

> Weapons taken from bodies should now have attachments when gathered
> Weapons that have attachments should be picked up by the loot crate even if the base weapon is already unlocked

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

Need to ensure that the gathering still works as intended, with the added benefit of looting attachments on weapons

### How can the changes be tested?
Steps:

Turn on ignore unlocked items, load into A3 FIA faction, put a CPW on the ground with no attachments and drop another with attachments. Gather with a lootcrate and ensure the base CPW is removed and the one with attachments is gathered

********************************************************
Notes:
