### PR TITLE
Fix bug with using not-unlocked mags in AI arsenal

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -1262,6 +1262,32 @@ switch _mode do {
 				}foreach assignedItems player;
 				_return1;
 			};
+			case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG;
+			case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMOPTIC;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMACC;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMMUZZLE;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMBIPOD: {
+				private _weapon = switch true do {
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON)): { primaryWeapon player };
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON)): { secondaryWeapon player };
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN)): { handgunWeapon player };
+				};
+				private _weaponItems = weaponsItems player select { _x select 0 isEqualTo _weapon } select 0;
+
+				_return1 = switch (_index) do {
+					case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG: { _weaponItems select 4 };
+					case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2: { _weaponItems select 5 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMOPTIC: { _weaponItems select 3 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMACC: { _weaponItems select 2 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMMUZZLE: { _weaponItems select 1 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMBIPOD: { _weaponItems select 6 };
+				};
+				if (_return1 isEqualType []) then { 
+					_return1 = if (count _return1 > 0) then { _return1 select 0 } else { "" };
+				};
+				_return1;
+			};
 		};
 		_return;
 	};

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -140,8 +140,9 @@ _arrayContains = {
 // Calculate the minimum number of an item needed before non-members can take it
 private _minItemsMember = {
 	params ["_index", "_item"];					// Arsenal tab index, item classname
+	if (_index in [IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG, IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2]) then { _index = IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG };
 	private _min = jna_minItemMember select _index;
-	if (_index in [IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG, IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2, IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL]) then {
+	if (_index in [IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG, IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL]) then {
 		_min = _min * getNumber (configfile >> "CfgMagazines" >> _item >> "count");
 	};
 	_min;
@@ -1257,6 +1258,32 @@ switch _mode do {
 				{
 					if(_index == _x call jn_fnc_arsenal_itemType)exitwith{_return1 = _x};
 				}foreach assignedItems player;
+				_return1;
+			};
+			case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG;
+			case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMOPTIC;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMACC;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMMUZZLE;
+			case IDC_RSCDISPLAYARSENAL_TAB_ITEMBIPOD: {
+				private _weapon = switch true do {
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON)): { primaryWeapon player };
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON)): { secondaryWeapon player };
+					case (ctrlEnabled (_display displayCtrl IDC_RSCDISPLAYARSENAL_LIST + IDC_RSCDISPLAYARSENAL_TAB_HANDGUN)): { handgunWeapon player };
+				};
+				private _weaponItems = weaponsItems player select { _x select 0 isEqualTo _weapon } select 0;
+
+				_return1 = switch (_index) do {
+					case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG: { _weaponItems select 4 };
+					case IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2: { _weaponItems select 5 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMOPTIC: { _weaponItems select 3 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMACC: { _weaponItems select 2 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMMUZZLE: { _weaponItems select 1 };
+					case IDC_RSCDISPLAYARSENAL_TAB_ITEMBIPOD: { _weaponItems select 6 };
+				};
+				if (_return1 isEqualType []) then { 
+					_return1 = if (count _return1 > 0) then { _return1 select 0 } else { "" };
+				};
 				_return1;
 			};
 		};


### PR DESCRIPTION
## What type of PR is this?
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR fixes bug where players can give AI not-unlocked mags in the AI arsenal / loadout builder.

Additionally, this PR stops the arsenal from visually selecting a not-unlocked weapon attachment (muzzle/acc/optic/bipod) even though it already didn't equip those items.

Whether an item is "unlocked" is still contingent on the calculation in minItemsMember as it always was, so these changes should also apply to the player arsenal for non-unlocked equipment for non-member players, if membership is enabled.

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #[Discord](https://discord.com/channels/817005365740044289/1342076821620920360)"

### Please verify the following.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

Yippee, I get to be No. 500 🎆 
