### PR TITLE
Use faction-appropriate currency symbol

### DIFF
--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -93,7 +93,7 @@ if (_tab isEqualTo "vehicles") then
         private _button = _display ctrlCreate ["A3A_ShortcutButton", -1, _itemControlsGroup];
         _button ctrlSetPosition [0, 25 * GRID_H, 44 * GRID_W, 12 * GRID_H];
         _button ctrlSetText _displayName;
-        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, "€"];
+        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _button setVariable ["className", _className];
         _button setVariable ["model", _model];
         _button ctrlAddEventHandler ["ButtonClick", {
@@ -158,7 +158,7 @@ if (_tab isEqualTo "vehicles") then
         // Handles showing price
         private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
         _priceText ctrlSetPosition[23 * GRID_W, 21 * GRID_H, 20 * GRID_W, 3 * GRID_H];
-        _priceText ctrlSetText format ["%1 €",_price];
+        _priceText ctrlSetText format ["%1 %2",_price,A3A_faction_civ get "currencySymbol"];
         _priceText ctrlCommit 0;
 
         // Undercover icon

--- a/A3A/addons/gui/functions/GUI/fn_buyVehicleTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_buyVehicleTabs.sqf
@@ -90,7 +90,7 @@ if (_tab isEqualTo "vehicles") then
         private _button = _display ctrlCreate ["A3A_ShortcutButton", -1, _itemControlsGroup];
         _button ctrlSetPosition [0, 25 * GRID_H, 44 * GRID_W, 12 * GRID_H];
         _button ctrlSetText _displayName;
-        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, "€"];
+        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _button setVariable ["className", _className];
         _button setVariable ["model", _model];
         _button ctrlAddEventHandler ["ButtonClick", {
@@ -152,7 +152,7 @@ if (_tab isEqualTo "vehicles") then
 
         private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
         _priceText ctrlSetPosition[23 * GRID_W, 21 * GRID_H, 20 * GRID_W, 3 * GRID_H];
-        _priceText ctrlSetText format ["%1 €",_price];
+        _priceText ctrlSetText format ["%1 %2",_price, A3A_faction_civ get "currencySymbol"];
         _priceText ctrlCommit 0;
 
         // Undercover icon
@@ -352,7 +352,7 @@ if  (_tab in ["other"]) then
         private _button = _display ctrlCreate ["A3A_ShortcutButton", -1, _itemControlsGroup];
         _button ctrlSetPosition [0, 25 * GRID_H, 44 * GRID_W, 12 * GRID_H];
         _button ctrlSetText _displayName;
-        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_item_tooltip", _displayName, _price, "€"];
+        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_item_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _button setVariable ["className", _className];
         _button setVariable ["model", _model];
 
@@ -428,7 +428,7 @@ if  (_tab in ["other"]) then
 
         private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
         _priceText ctrlSetPosition[23 * GRID_W, 21 * GRID_H, 20 * GRID_W, 3 * GRID_H];
-        _priceText ctrlSetText format ["%1 €",_price];
+        _priceText ctrlSetText format ["%1 %2",_price, A3A_faction_civ get "currencySymbol"];
         _priceText ctrlCommit 0;
 
         private _itemPic = _display ctrlCreate ["A3A_PictureStroke", -1, _itemControlsGroup];

--- a/A3A/addons/gui/functions/GUI/fn_constructTab.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_constructTab.sqf
@@ -92,7 +92,7 @@ switch (_mode) do
             {
                 private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
                 _priceText ctrlSetPosition[23 * GRID_W, 18 * GRID_H, 20 * GRID_W, 3 * GRID_H];
-                _priceText ctrlSetText format ["%1 €",_price];
+                _priceText ctrlSetText format ["%1 %2",_price, A3A_faction_civ get "currencySymbol"];
                 _priceText ctrlCommit 0;
             };
             private _timeText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup]; // TODO UI-update: Add icon

--- a/A3A/addons/gui/functions/GUI/fn_donateTab.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_donateTab.sqf
@@ -50,7 +50,7 @@ switch (_mode) do
         private _target = cursorTarget;
 
         private _moneyText = _display displayCtrl A3A_IDC_DONATIONMONEYTEXT;
-        _moneyText ctrlSetText format ["%1 €", _money];
+        _moneyText ctrlSetText format ["%1 %2", _money, A3A_faction_civ get "currencySymbol"];
 
         private _playerList = _display displayCtrl A3A_IDC_DONATEPLAYERLIST;
         {

--- a/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_hqDialog.sqf
@@ -295,7 +295,7 @@ switch (_mode) do
 
         private _factionMoney = server getVariable ["resourcesFIA", 0];
         private _factionMoneyText = _display displayCtrl A3A_IDC_FACTIONMONEYTEXT;
-        _factionMoneyText ctrlSetText format ["%1 €", _factionMoney];
+        _factionMoneyText ctrlSetText format ["%1 %2", _factionMoney, A3A_faction_civ get "currencySymbol"];
 
         // Faction money slider update
         private _factionMoneySlider = _display displayCtrl A3A_IDC_FACTIONMONEYSLIDER;
@@ -454,14 +454,14 @@ switch (_mode) do
         _marksmanPriceText = _display displayCtrl A3A_IDC_MARKSMANPRICE;
         _atPriceText = _display displayCtrl A3A_IDC_ATPRICE;
 
-        _riflemanPriceText ctrlSetText str _riflemanPrice + "€";
-        _squadLeaderPriceText ctrlSetText str _squadLeaderPrice + "€";
-        _autoriflemanPriceText ctrlSetText str _autoriflemanPrice + "€";
-        _grenadierPriceText ctrlSetText str _grenadierPrice + "€";
-        _medicPriceText ctrlSetText str _medicPrice + "€";
-        _mortarPriceText ctrlSetText str _mortarPrice + "€";
-        _marksmanPriceText ctrlSetText str _marksmanPrice + "€";
-        _atPriceText ctrlSetText str _atPrice + "€";
+        _riflemanPriceText ctrlSetText str _riflemanPrice + A3A_faction_civ get "currencySymbol";
+        _squadLeaderPriceText ctrlSetText str _squadLeaderPrice + A3A_faction_civ get "currencySymbol";
+        _autoriflemanPriceText ctrlSetText str _autoriflemanPrice + A3A_faction_civ get "currencySymbol";
+        _grenadierPriceText ctrlSetText str _grenadierPrice + A3A_faction_civ get "currencySymbol";
+        _medicPriceText ctrlSetText str _medicPrice + A3A_faction_civ get "currencySymbol";
+        _mortarPriceText ctrlSetText str _mortarPrice + A3A_faction_civ get "currencySymbol";
+        _marksmanPriceText ctrlSetText str _marksmanPrice + A3A_faction_civ get "currencySymbol";
+        _atPriceText ctrlSetText str _atPrice + A3A_faction_civ get "currencySymbol";
 
         // Disable add buttons if faction is lacking the resources to recruit them (1HR + money)
         _hr = server getVariable ["hr", 0];

--- a/A3A/addons/gui/functions/GUI/fn_recruitDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_recruitDialog.sqf
@@ -72,14 +72,14 @@ switch (_mode) do
         private _bombSpecialistPrice = server getVariable FactionGet(reb,"unitExp");
 
         // Update price labels
-        _militiamanPriceText ctrlSetText ((str _militiamanPrice) + "€");
-        _autoriflemanPriceText ctrlSetText ((str _autoriflemanPrice) + "€");
-        _grenadierPriceText ctrlSetText ((str _grenadierPrice) + "€");
-        _antitankPriceText ctrlSetText ((str _antitankPrice) + "€");
-        _medicPriceText ctrlSetText ((str _medicPrice) + "€");
-        _marksmanPriceText ctrlSetText ((str _marksmanPrice) + "€");
-        _engineerPriceText ctrlSetText ((str _engineerPrice) + "€");
-        _bombSpecialistPriceText ctrlSetText ((str _bombSpecialistPrice) + "€");
+        _militiamanPriceText ctrlSetText ((str _militiamanPrice) + A3A_faction_civ get "currencySymbol");
+        _autoriflemanPriceText ctrlSetText ((str _autoriflemanPrice) + A3A_faction_civ get "currencySymbol");
+        _grenadierPriceText ctrlSetText ((str _grenadierPrice) + A3A_faction_civ get "currencySymbol");
+        _antitankPriceText ctrlSetText ((str _antitankPrice) + A3A_faction_civ get "currencySymbol");
+        _medicPriceText ctrlSetText ((str _medicPrice) + A3A_faction_civ get "currencySymbol");
+        _marksmanPriceText ctrlSetText ((str _marksmanPrice) + A3A_faction_civ get "currencySymbol");
+        _engineerPriceText ctrlSetText ((str _engineerPrice) + A3A_faction_civ get "currencySymbol");
+        _bombSpecialistPriceText ctrlSetText ((str _bombSpecialistPrice) + A3A_faction_civ get "currencySymbol");
 
         // Disable buttons and darken icon if not enough money or HR for the unit
         private _money = player getVariable "moneyX";

--- a/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_recruitSquadDialog.sqf
@@ -143,15 +143,15 @@ switch (_mode) do
         _aaTruckPrice params ["_aaTruckMoney", "_aaTruckHr"];
 
         // Update price labels
-        _infSquadPriceText ctrlSetText (format ["%1 € %2 HR", _infSquadMoney, _infSquadHr]);
-        // _engSquadPriceText ctrlSetText (format ["%1 €, %2 HR", _engSquadPrice, _engSquadHr]);
-        _infTeamPriceText ctrlSetText (format ["%1 € %2 HR", _infTeamMoney, _infTeamHr]);
-        _mgTeamPriceText ctrlSetText (format ["%1 € %2 HR", _mgTeamMoney, _mgTeamHr]);
-        _atTeamPriceText ctrlSetText (format ["%1 € %2 HR", _atTeamMoney, _atTeamHr]);
-        _mortarTeamPriceText ctrlSetText (format ["%1 € %2 HR", _mortarTeamMoney, _mortarTeamHr]);
-        _sniperTeamPriceText ctrlSetText (format ["%1 € %2 HR", _sniperTeamMoney, _sniperTeamHr]);
-        _atCarPriceText ctrlSetText (format ["%1 € %2 HR", _atCarMoney, _atCarHr]);
-        _aaTruckPriceText ctrlSetText (format ["%1 € %2 HR", _aaTruckMoney, _aaTruckHr]);
+        _infSquadPriceText ctrlSetText (format ["%1 %2 %3 HR", _infSquadMoney, A3A_faction_civ get "currencySymbol", _infSquadHr]);
+        // _engSquadPriceText ctrlSetText (format ["%1 %2, %3 HR", _engSquadPrice, A3A_faction_civ get "currencySymbol", _engSquadHr]);
+        _infTeamPriceText ctrlSetText (format ["%1 %2 %3 HR", _infTeamMoney, A3A_faction_civ get "currencySymbol", _infTeamHr]);
+        _mgTeamPriceText ctrlSetText (format ["%1 %2 %3 HR", _mgTeamMoney, A3A_faction_civ get "currencySymbol", _mgTeamHr]);
+        _atTeamPriceText ctrlSetText (format ["%1 %2 %3 HR", _atTeamMoney, A3A_faction_civ get "currencySymbol", _atTeamHr]);
+        _mortarTeamPriceText ctrlSetText (format ["%1 %2 %3 HR", _mortarTeamMoney, A3A_faction_civ get "currencySymbol", _mortarTeamHr]);
+        _sniperTeamPriceText ctrlSetText (format ["%1 %2 %3 HR", _sniperTeamMoney, A3A_faction_civ get "currencySymbol", _sniperTeamHr]);
+        _atCarPriceText ctrlSetText (format ["%1 %2 %3 HR", _atCarMoney, A3A_faction_civ get "currencySymbol", _atCarHr]);
+        _aaTruckPriceText ctrlSetText (format ["%1 %2 %3 HR", _aaTruckMoney, A3A_faction_civ get "currencySymbol", _aaTruckHr]);
 
         // Disable buttons and darken icon if not enough money or HR for the squad
         private _money = server getVariable "resourcesFIA";

--- a/A3A/addons/gui/functions/GUI/fn_setUpPlacerHints.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_setUpPlacerHints.sqf
@@ -59,7 +59,7 @@ switch (_mode) do
         };
         if (_keyType == "rebuild") exitWith {
             (_display displayCtrl IDC_PLACERHINT_T) ctrlShow true;
-            _textCtrl ctrlSetText format ["T: Rebuild for %1 €", _keyData];
+            _textCtrl ctrlSetText format ["T: Rebuild for %1 %2", _keyData, A3A_faction_civ get "currencySymbol"];
         };
         _textCtrl ctrlSetText "";
     };

--- a/A3A/addons/gui/functions/GUI/fn_teamLeaderRTSPlacerDialog.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_teamLeaderRTSPlacerDialog.sqf
@@ -33,7 +33,7 @@ switch (_mode) do
 		private _display = findDisplay A3A_IDD_TEAMLEADERDIALOG;
 		private _moneyCtrl = _display displayCtrl A3A_IDC_TEAMLEADERBUILDERMONEY;
 
-		_moneyCtrl ctrlSetText format ["%1 €", A3A_building_EHDB # AVAILABLE_MONEY];
+		_moneyCtrl ctrlSetText format ["%1 %2", A3A_building_EHDB # AVAILABLE_MONEY, A3A_faction_civ get "currencySymbol"];
 	};
 	case ("onLoad"):
     {
@@ -42,7 +42,7 @@ switch (_mode) do
 		private _buildControlsGroup = _parent controlsGroupCtrl A3A_IDC_TEAMLEADERBUILDINGGROUP;
 
 		private _moneyCtrl = _display displayCtrl A3A_IDC_TEAMLEADERBUILDERMONEY;
-		_moneyCtrl ctrlSetText format ["%1 €", A3A_building_EHDB # AVAILABLE_MONEY];
+		_moneyCtrl ctrlSetText format ["%1 %2", A3A_building_EHDB # AVAILABLE_MONEY, A3A_faction_civ get "currencySymbol"];
 
 		private _buildableObjects = A3A_buildableObjects;
 		
@@ -127,7 +127,7 @@ switch (_mode) do
 			if (_price isNotEqualTo 0) then {
 				private _priceText = _display ctrlCreate ["A3A_InfoTextRight", -1, _itemControlsGroup];
 				_priceText ctrlSetPosition[(_itemWidth - 21) * GRID_W, 20 * GRID_H, 20 * GRID_W, 3 * GRID_H];
-				_priceText ctrlSetText format ["%1 €",_price];
+				_priceText ctrlSetText format ["%1 %2",_price,A3A_faction_civ get "currencySymbol"];
 				_priceText ctrlCommit 0;
 			};
 


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR replaces the Euro symbol across all .sqf scripts with the appropriate symbol (from civ faction), if it's not inherited from the civ faction defaults.

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

There's still more cases where the Euro symbol is statically used, or generic "Money" is used instead, in the various .hpp headers. Most of these probably can't be changed.