### PR TITLE
Drone side alignment convenience fixes

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -81,14 +81,9 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 	};
 } else {
 	switch (true) do {
-		case (unitIsUAV _veh): {
-			if (crew _veh isNotEqualTo []) then {
-				private _uavGroup = createGroup teamPlayer;
-				crew _veh join _uavGroup;
-				_uavGroup deleteGroupWhenEmpty true;
-			} else {
-				[_side, _veh] call A3A_fnc_createVehicleCrew;
-			};
+		case (unitIsUAV _veh && {_side isEqualTo teamPlayer}): {
+			if (crew _veh isNotEqualTo []) then { deleteVehicleCrew _veh };
+			[_side, _veh] call A3A_fnc_createVehicleCrew;
 		};
 		case (_typeX in (FactionGet(all,"vehiclesFixedWing") + FactionGet(all,"vehiclesHelis"))): {
 			_veh addEventHandler ["GetIn", {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -81,6 +81,15 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 	};
 } else {
 	switch (true) do {
+		case (unitIsUAV _veh): {
+			if (crew _veh isNotEqualTo []) then {
+				private _uavGroup = createGroup teamPlayer;
+				crew _veh join _uavGroup;
+				_uavGroup deleteGroupWhenEmpty true;
+			} else {
+				[_side, _veh] call A3A_fnc_createVehicleCrew;
+			};
+		};
 		case (_typeX in (FactionGet(all,"vehiclesFixedWing") + FactionGet(all,"vehiclesHelis"))): {
 			_veh addEventHandler ["GetIn", {
 				if (_this select 1 != "driver") exitWith {};

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -121,6 +121,6 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
 
 HR_GRG_fnc_addVehicleUAVCompat = {
     private _veh = _this select 0;
-    if (crew _veh isNotEqualTo []) then { deleteVehicleCrew _veh };
+    if (unitIsUAV _veh && {crew _veh isNotEqualTo []}) then { deleteVehicleCrew _veh };
     _this call HR_GRG_fnc_addVehicle;
 };

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -118,3 +118,9 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
     }] call CBA_fnc_addSetting;
 
 };
+
+HR_GRG_fnc_addVehicleUAVCompat = {
+    private _veh = _this select 0;
+    if (crew _veh isNotEqualTo []) then { deleteVehicleCrew _veh };
+    _this call HR_GRG_fnc_addVehicle;
+};

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -121,6 +121,6 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
 
 HR_GRG_fnc_addVehicleUAVCompat = {
     private _veh = _this select 0;
-    if (unitIsUAV _veh && {crew _veh isNotEqualTo []}) then { deleteVehicleCrew _veh };
+    if (unitisUAV _veh && {crew _veh isNotEqualTo []}) then { [_this select 3, _this select 0] call A3A_fnc_moveOutCrew };
     _this call HR_GRG_fnc_addVehicle;
 };

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -121,6 +121,9 @@ if (isClass (configfile >> "CBA_Extended_EventHandlers")) then {
 
 HR_GRG_fnc_addVehicleUAVCompat = {
     private _veh = _this select 0;
-    if (unitisUAV _veh && {crew _veh isNotEqualTo []}) then { [_this select 3, _this select 0] call A3A_fnc_moveOutCrew };
+    if (unitisUAV _veh && {crew _veh isNotEqualTo []}) then {
+        private _moveOutCrewHandle = [_this select 3, _this select 0] spawn A3A_fnc_moveOutCrew;
+        waitUntil { sleep 0.1; scriptDone _moveOutCrewHandle };
+    };
     _this call HR_GRG_fnc_addVehicle;
 };

--- a/A3A/addons/scrt/UILayouts/menu.hpp
+++ b/A3A/addons/scrt/UILayouts/menu.hpp
@@ -355,7 +355,7 @@ class radioComm: SimpleMenuBigger
 			x = 0.257187 * safezoneW + safezoneX;
 			y = 0.486 * safezoneH + safezoneY;
 			tooltip = $STR_antistasi_dialogs_put_garage_tooltip;
-			action = "closeDialog 0; [cursorObject, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicleUAVCompat',2];";
+			action = "closeDialog 0; [cursorObject, clientOwner, call HR_GRG_dLock, player] remoteExec ['HR_GRG_fnc_addVehicleUAVCompat',2];";
 		};
 
 		class l4Button: SimpleButton

--- a/A3A/addons/scrt/UILayouts/menu.hpp
+++ b/A3A/addons/scrt/UILayouts/menu.hpp
@@ -355,7 +355,7 @@ class radioComm: SimpleMenuBigger
 			x = 0.257187 * safezoneW + safezoneX;
 			y = 0.486 * safezoneH + safezoneY;
 			tooltip = $STR_antistasi_dialogs_put_garage_tooltip;
-			action = "closeDialog 0; [cursorObject, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicle',2];";
+			action = "closeDialog 0; [cursorObject, clientOwner, call HR_GRG_dLock, player] remoteExecCall ['HR_GRG_fnc_addVehicleUAVCompat',2];";
 		};
 
 		class l4Button: SimpleButton


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

This PR:

 - Crews drones with rebel crew when purchasing from arms dealer, so they don't need to be hacked after purchase
 - Removes crew from drones automatically when attempting to garage them, so you don't have to 'Moveout Vehicle Crew' first

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #457 "

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

This doesn't touch the forbidden code 💀 