### PR TITLE
Fix #333 - Don't allow FT to trader until located

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -98,6 +98,10 @@ if (_positionTel isEqualTo []) exitWith {
 };
 
 private _base = [_markersX, _positionTel] call BIS_Fnc_nearestPosition;
+if (_base == traderMarker && (isTraderQuestAssigned || !isTraderQuestCompleted)) exitWith {
+	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_trader_locked"] call SCRT_fnc_misc_deniedHint;
+};
+
 private _rebelMarkers = if (!isNil "traderMarker") then {["Synd_HQ", traderMarker]} else {["Synd_HQ"]};
 private _isValidTargetLocation = (_base in (_rebelMarkers + airportsX + milbases));
 

--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -98,7 +98,8 @@ if (_positionTel isEqualTo []) exitWith {
 };
 
 private _base = [_markersX, _positionTel] call BIS_Fnc_nearestPosition;
-if (_base == traderMarker && (isTraderQuestAssigned || !isTraderQuestCompleted)) exitWith {
+
+if (_base == traderMarker && {isTraderQuestAssigned || !isTraderQuestCompleted}) exitWith {
 	[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_trader_locked"] call SCRT_fnc_misc_deniedHint;
 };
 

--- a/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
+++ b/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
@@ -102,7 +102,9 @@ waitUntil {
 traderPosition = _traderPosition;
 publicVariable "traderPosition";
 
-isTraderQuestCompleted = true; 
+isTraderQuestAssigned = false;
+isTraderQuestCompleted = true;
+publicVariable "isTraderQuestAssigned";
 publicVariable "isTraderQuestCompleted";
 
 deleteVehicle _trigger;

--- a/A3A/addons/core/functions/Save/fn_deleteSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_deleteSave.sqf
@@ -45,7 +45,7 @@ private _savedPlayers = _namespace getVariable ["savedPlayers" + _postfix, []];
 	"supportPoints",
     "constructionsX",
     "watchpostsFIA", "roadblocksFIA", "aapostsFIA", "atpostsFIA", "hmgpostsFIA",
-    "traderDiscount", "isTraderQuestCompleted", "traderPosition",
+    "traderDiscount", "isTraderQuestAssigned", "isTraderQuestCompleted", "traderPosition",
     "areOccupantsDefeated", "areInvadersDefeated",
     "destroyedMilAdmins",
     "rebelLoadouts", "randomizeRebelLoadoutUniforms",

--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -47,6 +47,7 @@ if (isServer) then {
 	["supportPoints"] call A3A_fnc_getStatVariable;
 	["areOccupantsDefeated"] call A3A_fnc_getStatVariable;
 	["areInvadersDefeated"] call A3A_fnc_getStatVariable;
+	["isTraderQuestAssigned"] call A3A_fnc_getStatVariable;
 	["isTraderQuestCompleted"] call A3A_fnc_getStatVariable;
 	["traderPosition"] call A3A_fnc_getStatVariable;
 	["traderDiscount"] call A3A_fnc_getStatVariable;

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -37,7 +37,7 @@ if (isNil "specialVarLoads") then {
         "supportPoints",
         "constructionsX",
         "watchpostsFIA", "roadblocksFIA", "aapostsFIA", "atpostsFIA", "hmgpostsFIA",
-        "traderDiscount", "isTraderQuestCompleted","traderPosition",
+        "traderDiscount", "isTraderQuestAssigned", "isTraderQuestCompleted","traderPosition",
         "areOccupantsDefeated", "areInvadersDefeated",
         "destroyedMilAdmins",
         "rebelLoadouts", "randomizeRebelLoadoutUniforms",
@@ -445,6 +445,11 @@ if (_varName in specialVarLoads) then {
             testingTimerIsActive = _varValue;
         };
 
+        case 'isTraderQuestAssigned': {
+            isTraderQuestAssigned = _varvalue;  
+            publicVariable "isTraderQuestAssigned";
+        };
+
         case 'isTraderQuestCompleted': {
             isTraderQuestCompleted = _varvalue;  
             publicVariable "isTraderQuestCompleted";
@@ -465,9 +470,7 @@ if (_varName in specialVarLoads) then {
 
         case 'traderPosition': {
 			if(count _varvalue > 0) then {
-                isTraderQuestAssigned = true;
-                publicVariable "isTraderQuestAssigned";
-				traderX = [_varvalue] call SCRT_fnc_trader_createTrader; 
+                traderX = [_varvalue] call SCRT_fnc_trader_createTrader; 
 				publicVariable "traderX";
 				[traderX] call SCRT_fnc_trader_setStockType;
 				[traderX] remoteExecCall ["SCRT_fnc_trader_addVehicleMarketAction", 0, true];

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -9550,7 +9550,7 @@
             </Key>
             </Key>
             <Key ID="STR_A3A_Missions_RES_Deserters_task_header">
-                <Original>Deserters Rescue</Original>
+                <Original>Rescue Deserters</Original>
                 <Russian>Спасите дезертиров</Russian>
             </Key>
             <Key ID="STR_A3A_Missions_RES_Deserters_task_desc">

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -12668,6 +12668,13 @@
                 <Korean>일부 플레이어가 차량에 탑승했으며 목적지가 본부나 공군 기지, 군사 기지, 집결 지점, 암거래상이 아니기 때문에 %1의 빠른 이동이 취소되었습니다.</Korean>
                 <French>%1 Le voyage rapide a été annulé parce qu'un joueur est monté à bord de son véhicule et que la destination n'est pas le QG ou une base aérienne, une base militaire, un point de ralliement ou un marchand d'armes.</French>
             </Key>
+            <Key ID="STR_A3A_Dialogs_fast_travel_trader_locked">
+                <Original>You can't Fast Travel to trader before visiting him once.</Original>
+                <Russian>Вы не можете совершить быстрое путешествие к торговцу, пока не посетите его хотя бы один раз.</Russian>
+                <Chinesesimp>在拜访交易者一次之前，你不能快速旅行到他那里</Chinesesimp>
+                <Korean>한 번 방문하기 전에는 상인에게 빠른 이동을 할 수 없습니다.</Korean>
+                <French>Vous ne pouvez pas voyager rapidement vers un commerçant avant de lui rendre visite une fois.</French>
+            </Key>
             <Key ID="STR_A3A_Dialogs_fast_travel_arrived_hc">
                 <Original>Group %1 arrived to destination.</Original>
                 <Russian>%1 отряд добрался до места назначения.</Russian>


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Builds on #333 / #450 to save (and load) `isTraderQuestAssigned` correctly. Now you can't fast travel to trader until trader quest is completed, and it doesn't break FT on server restart (in minimal testing).

### Please specify which Issue this PR Resolves (If Applicable).

This PR closes #[Discord](https://discord.com/channels/817005365740044289/1218566036459229245/1333150501776265418)

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

~~Currently in testing on AUC server IIRC~~

********************************************************
Notes:

This is just #450 rebased on latest unstable to clean up the commit history as there was a lot of completely unrelated stuff in there. I just made it worse trying to fix 450 lol.
