### PR TITLE
Add ability to (instantly) garage vehicles at trader

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_addBlackMarketVeh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBlackMarketVeh.sqf
@@ -1,7 +1,8 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 params [
-	["_typeVehX", "", [""]]
+	["_typeVehX", "", [""]],
+	["_addToGarage", false]
 ];
 
 if (_typeVehX isEqualTo "") exitWith {[localize "STR_A3A_addFiaVeh_header", localize "STR_A3AP_error_empty_generic"] call A3A_fnc_customHint;};
@@ -55,4 +56,11 @@ private _fnc_check = {
 	[(player distance2d traderX > 50), localize "STR_veh_callback_arms_dealer_close"];
 };
 
-[_typeVehX, _fnc_placed, _fnc_check, [_cost], nil, nil, nil, _extraMessage] call HR_GRG_fnc_confirmPlacement;
+if (_addToGarage) then {
+	private _pos = [position player, 5, 25] call BIS_fnc_findSafePos;
+	private _vehicle = _typeVehX createVehicle _pos;
+	[_vehicle, _cost] call _fnc_placed;
+	[_vehicle, clientOwner, call HR_GRG_dLock, player] remoteExecCall ["HR_GRG_fnc_addVehicle",2];
+} else {
+	[_typeVehX, _fnc_placed, _fnc_check, [_cost], nil, nil, nil, _extraMessage] call HR_GRG_fnc_confirmPlacement;
+};

--- a/A3A/addons/core/functions/REINF/fn_addBlackMarketVeh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addBlackMarketVeh.sqf
@@ -36,6 +36,16 @@ private _extraMessage =	format [localize "STR_veh_callback_select_veh_generic", 
 private _fnc_placed = {
 	params ["_vehicle", "_cost"];
 	if (isNull _vehicle) exitWith {};
+
+	[_vehicle, _cost] call _fnc_buyVehicle;
+	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
+	[_vehicle, teamPlayer] call SCRT_fnc_misc_tryInitVehicle;
+
+	player reveal _vehicle;
+};
+private _fnc_buyVehicle = {
+	params ["_vehicle", "_cost"];
+
 	private _factionMoney = server getVariable "resourcesFIA";
 
 	if (player == theBoss && {_cost <= _factionMoney}) then {
@@ -43,24 +53,18 @@ private _fnc_placed = {
 	}
 	else {
 		[-1 * _cost] call A3A_fnc_resourcesPlayer;
-		_vehicle setVariable ["ownerX",getPlayerUID player,true];
+		if !(_vehicle isEqualType "") then { _vehicle setVariable ["ownerX",getPlayerUID player,true] };
 		playSound "A3AP_UiSuccess";
 	};
-
-	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
-	[_vehicle, teamPlayer] call SCRT_fnc_misc_tryInitVehicle;
-
-	player reveal _vehicle;
 };
 private _fnc_check = {
 	[(player distance2d traderX > 50), localize "STR_veh_callback_arms_dealer_close"];
 };
 
 if (_addToGarage) then {
-	private _pos = [position player, 5, 25] call BIS_fnc_findSafePos;
-	private _vehicle = _typeVehX createVehicle _pos;
-	[_vehicle, _cost] call _fnc_placed;
-	[_vehicle, clientOwner, call HR_GRG_dLock, player] remoteExecCall ["HR_GRG_fnc_addVehicle",2];
+	[_typeVehX, _cost] call _fnc_buyVehicle;
+	//[[_typeVehX], getPlayerUID player] remoteExecCall ["HR_GRG_fnc_addVehiclesByClass", 2]; // if we want to lock the vehicle when garaging
+	[[_typeVehX], ""] remoteExecCall ["HR_GRG_fnc_addVehiclesByClass", 2];
 } else {
 	[_typeVehX, _fnc_placed, _fnc_check, [_cost], nil, nil, nil, _extraMessage] call HR_GRG_fnc_confirmPlacement;
 };

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -485,7 +485,7 @@
                 <Original>Purchase</Original>
                 <French>Achat</French>
                 <Korean>사다</Korean>
-                <Russian>Покупать</Russian>
+                <Russian>Купить</Russian>
                 <Chinesesimp>购买</Chinesesimp>
                 <Czech>Nákup</Czech>
                 <Italian>Acquista</Italian>
@@ -507,7 +507,7 @@
                 <Original>Deliver</Original>
                 <French>Livrer</French>
                 <Korean>배달하다</Korean>
-                <Russian>Доставлять</Russian>
+                <Russian>Доставить</Russian>
                 <Chinesesimp>提供</Chinesesimp>
                 <Czech>Doručit</Czech>
                 <Italian>Consegnare</Italian>

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -481,6 +481,17 @@
                 <Korean>암시장 차량 재고는 현재 전쟁 레벨과 달성한 다양한 이정표에 따라 달라집니다.</Korean>
                 <French>Le stock de véhicules du marché noir dépend du niveau de guerre actuel et des différentes étapes franchies.</French>
             </Key>
+            <Key ID="STR_antistasi_dialogs_buy_vehicle_button">
+                <Original>Purchase</Original>
+                <French>Achat</French>
+                <Korean>사다</Korean>
+                <Russian>Покупать</Russian>
+                <Chinesesimp>购买</Chinesesimp>
+                <Czech>Nákup</Czech>
+                <Italian>Acquista</Italian>
+                <Spanish>Compra</Spanish>
+                <Polish>Kupno</Polish>
+            </Key>
             <Key ID="STR_antistasi_dialogs_buy_vehicle_button_tooltip">
                 <Original>Buy %1 for %2 %3</Original>
                 <French>Acheter %1 pour %2 %3</French>
@@ -491,6 +502,17 @@
                 <Italian>Compra %1 per %2 %3</Italian>
                 <Spanish>Comprar %1 por %2 %3</Spanish>
                 <Polish>Kup %1 za %2 %3</Polish>
+            </Key>
+            <Key ID="STR_antistasi_dialogs_buy_vehicle_deliver_button">
+                <Original>Deliver</Original>
+                <French>Livrer</French>
+                <Korean>배달하다</Korean>
+                <Russian>Доставлять</Russian>
+                <Chinesesimp>提供</Chinesesimp>
+                <Czech>Doručit</Czech>
+                <Italian>Consegnare</Italian>
+                <Spanish>Entregar</Spanish>
+                <Polish>Dostarczyć</Polish>
             </Key>
             <Key ID="STR_antistasi_dialogs_buy_vehicle_deliver_button_tooltip">
                 <Original>Deliver %1 to garage for %2 %3</Original>

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -492,6 +492,17 @@
                 <Spanish>Comprar %1 por %2 %3</Spanish>
                 <Polish>Kup %1 za %2 %3</Polish>
             </Key>
+            <Key ID="STR_antistasi_dialogs_buy_vehicle_deliver_button_tooltip">
+                <Original>Deliver %1 to garage for %2 %3</Original>
+                <French>Livrer %1 au garage pour %2 %3</French>
+                <Korean>%1을(를) %2에 차고로 배달%2 %3</Korean>
+                <Russian>Доставка %1 в гараж за %2 %3</Russian>
+                <Chinesesimp>将 %1 运送到 %2 %3 的车库</Chinesesimp>
+                <Czech>Doručte %1 do garáže za %2 %3</Czech>
+                <Italian>Consegna %1 all'officina per %2 %3</Italian>
+                <Spanish>Entrega %1 al garaje por %2 %3</Spanish>
+                <Polish>Dostarcz %1 do garażu za %2 %3</Polish>
+            </Key>
             <Key ID="STR_antistasi_dialogs_buy_vehicle_undercover_tooltip">
                 <Original>This vehicle can go undercover</Original>
                 <French>Ce véhicule peut passer incognito</French>

--- a/A3A/addons/gui/dialogues/controls.hpp
+++ b/A3A/addons/gui/dialogues/controls.hpp
@@ -412,6 +412,21 @@ class A3A_ShortcutButton : A3A_CtrlDefault
     };
 };
 
+class A3A_ShortcutButtonSmall : A3A_ShortcutButton
+{
+    size = GUI_TEXT_SIZE_SMALL;
+    sizeEx = GUI_TEXT_SIZE_SMALL;
+    sizeExSecondary = GUI_TEXT_SIZE_SMALL;
+
+    class TextPos
+    {
+        left = 2 * GRID_W;
+        right = 2 * GRID_W;
+        top = 1 * GRID_H;
+        bottom = 1 * GRID_H;
+    };
+};
+
 class A3A_ActiveText : A3A_CtrlDefault
 {
     type = CT_ACTIVETEXT;

--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -98,7 +98,7 @@ if (_tab isEqualTo "vehicles") then
 
         private _buttonTakeout = _display ctrlCreate ["A3A_ShortcutButtonSmall", -1, _itemControlsGroup];
         _buttonTakeout ctrlSetPosition [0, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
-        _buttonTakeout ctrlSetText "Takeout"; // TODO: Localize
+        _buttonTakeout ctrlSetText (localize "STR_antistasi_dialogs_buy_vehicle_button");
         _buttonTakeout ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _buttonTakeout setVariable ["className", _className];
         _buttonTakeout setVariable ["model", _model];
@@ -109,7 +109,7 @@ if (_tab isEqualTo "vehicles") then
 
         private _buttonDelivery = _display ctrlCreate ["A3A_ShortcutButtonSmall", -1, _itemControlsGroup];
         _buttonDelivery ctrlSetPosition [22 * GRID_W, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
-        _buttonDelivery ctrlSetText "Delivery"; // TODO: Localize
+        _buttonDelivery ctrlSetText (localize "STR_antistasi_dialogs_buy_vehicle_deliver_button");
         _buttonDelivery ctrlSetFontHeight GUI_TEXT_SIZE_SMALL;
         _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_deliver_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _buttonDelivery setVariable ["className", _className];

--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -99,7 +99,7 @@ if (_tab isEqualTo "vehicles") then
         private _buttonTakeout = _display ctrlCreate ["A3A_ShortcutButtonSmall", -1, _itemControlsGroup];
         _buttonTakeout ctrlSetPosition [0, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
         _buttonTakeout ctrlSetText "Takeout"; // TODO: Localize
-        _buttonTakeout ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_buttonTakeout_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
+        _buttonTakeout ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _buttonTakeout setVariable ["className", _className];
         _buttonTakeout setVariable ["model", _model];
         _buttonTakeout ctrlAddEventHandler ["ButtonClick", {
@@ -111,7 +111,7 @@ if (_tab isEqualTo "vehicles") then
         _buttonDelivery ctrlSetPosition [22 * GRID_W, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
         _buttonDelivery ctrlSetText "Delivery"; // TODO: Localize
         _buttonDelivery ctrlSetFontHeight GUI_TEXT_SIZE_SMALL;
-        _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_buttonDelivery_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
+        _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _buttonDelivery setVariable ["className", _className];
         _buttonDelivery setVariable ["model", _model];
         _buttonDelivery ctrlAddEventHandler ["ButtonClick", {

--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -111,7 +111,7 @@ if (_tab isEqualTo "vehicles") then
         _buttonDelivery ctrlSetPosition [22 * GRID_W, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
         _buttonDelivery ctrlSetText "Delivery"; // TODO: Localize
         _buttonDelivery ctrlSetFontHeight GUI_TEXT_SIZE_SMALL;
-        _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
+        _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_deliver_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
         _buttonDelivery setVariable ["className", _className];
         _buttonDelivery setVariable ["model", _model];
         _buttonDelivery ctrlAddEventHandler ["ButtonClick", {

--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -78,7 +78,7 @@ if (_tab isEqualTo "vehicles") then
         private _topPadding = if (count _buyableVehiclesList < 7) then {5 * GRID_H} else {1 * GRID_H};
 
         private _itemXpos = 7 * GRID_W + ((7 * GRID_W + 44 * GRID_W) * (_added mod 3)); /// space between first row(?) and left border
-        private _itemYpos = (floor (_added / 3)) * (44 * GRID_H) + _topPadding; ///spacer between vehicles
+        private _itemYpos = (floor (_added / 3)) * (38 * GRID_H) + _topPadding; ///spacer between vehicles
 
         private _itemControlsGroup = _display ctrlCreate ["A3A_ControlsGroupNoScrollbars", -1, _vehiclesControlsGroup];
         _itemControlsGroup ctrlSetPosition[_itemXpos, _itemYpos, 44 * GRID_W, 37 * GRID_H];
@@ -90,20 +90,38 @@ if (_tab isEqualTo "vehicles") then
         _previewPicture ctrlSetText _editorPreview;
         _previewPicture ctrlCommit 0;
 
-        private _button = _display ctrlCreate ["A3A_ShortcutButton", -1, _itemControlsGroup];
-        _button ctrlSetPosition [0, 25 * GRID_H, 44 * GRID_W, 12 * GRID_H];
-        _button ctrlSetText _displayName;
-        _button ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_button_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
-        _button setVariable ["className", _className];
-        _button setVariable ["model", _model];
-        _button ctrlAddEventHandler ["ButtonClick", {
-            closeDialog 2; [(_this # 0) getVariable "className"] spawn A3A_fnc_addBlackMarketVeh;
+        private _label = _display ctrlCreate ["A3A_SectionLabelLeft", -1, _itemControlsGroup];
+        _label ctrlSetPosition [0, 0, 44 * GRID_W, 6 * GRID_H];
+        _label ctrlSetText _displayName;
+        _label ctrlSetBackgroundColor [0,0,0,0.5];
+        _label ctrlCommit 0;
+
+        private _buttonTakeout = _display ctrlCreate ["A3A_ShortcutButtonSmall", -1, _itemControlsGroup];
+        _buttonTakeout ctrlSetPosition [0, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
+        _buttonTakeout ctrlSetText "Takeout"; // TODO: Localize
+        _buttonTakeout ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_buttonTakeout_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
+        _buttonTakeout setVariable ["className", _className];
+        _buttonTakeout setVariable ["model", _model];
+        _buttonTakeout ctrlAddEventHandler ["ButtonClick", {
+            closeDialog 2; [(_this # 0) getVariable "className", false] spawn A3A_fnc_addBlackMarketVeh;
         }];
-        _button ctrlCommit 0;
+        _buttonTakeout ctrlCommit 0;
+
+        private _buttonDelivery = _display ctrlCreate ["A3A_ShortcutButtonSmall", -1, _itemControlsGroup];
+        _buttonDelivery ctrlSetPosition [22 * GRID_W, 25 * GRID_H, 22 * GRID_W, 6 * GRID_H];
+        _buttonDelivery ctrlSetText "Delivery"; // TODO: Localize
+        _buttonDelivery ctrlSetFontHeight GUI_TEXT_SIZE_SMALL;
+        _buttonDelivery ctrlSetTooltip format [localize "STR_antistasi_dialogs_buy_vehicle_buttonDelivery_tooltip", _displayName, _price, A3A_faction_civ get "currencySymbol"];
+        _buttonDelivery setVariable ["className", _className];
+        _buttonDelivery setVariable ["model", _model];
+        _buttonDelivery ctrlAddEventHandler ["ButtonClick", {
+            closeDialog 2; [(_this # 0) getVariable "className", true] spawn A3A_fnc_addBlackMarketVeh;
+        }];
+        _buttonDelivery ctrlCommit 0;
 
         // Object Render
         if (!_hasVehiclePreview) then {
-            _button ctrlAddEventHandler ["MouseEnter", {
+            _buttonTakeout ctrlAddEventHandler ["MouseEnter", {
                 params ["_control"];
                 if (true || isNil "Dev_GUI_prevInjectEnter") then {
                     params ["_control"];
@@ -136,7 +154,7 @@ if (_tab isEqualTo "vehicles") then
                     _control call Dev_GUI_prevInjectEnter;
                 };
             }];
-            _button ctrlAddEventHandler ["MouseExit", {
+            _buttonTakeout ctrlAddEventHandler ["MouseExit", {
                 params ["_control"];
                 if (true || isNil "Dev_GUI_prevInjectExit") then {
                     params ["_control"];

--- a/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
+++ b/A3A/addons/gui/functions/GUI/fn_blackMarketTabs.sqf
@@ -115,7 +115,7 @@ if (_tab isEqualTo "vehicles") then
         _buttonDelivery setVariable ["className", _className];
         _buttonDelivery setVariable ["model", _model];
         _buttonDelivery ctrlAddEventHandler ["ButtonClick", {
-            closeDialog 2; [(_this # 0) getVariable "className", true] spawn A3A_fnc_addBlackMarketVeh;
+            [(_this # 0) getVariable "className", true] spawn A3A_fnc_addBlackMarketVeh;
         }];
         _buttonDelivery ctrlCommit 0;
 


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [x] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

This PR adds the ability to directly / instantly garage vehicles bought from the trader, instead of plopping them outside the tent, getting out of the buy menu, and manually garaging from Y menu. Should solve issues with vehicles that are destroyed when placing on land, and is more convenient for buying more than one vic.

Demo video at https://discord.com/channels/817005365740044289/1349758228946227292/1350914579818872953

Needs localization, and (IMO) garaging vehicles should cost extra. This is not currently implemented.

### Please specify which Issue this PR Resolves (If Applicable).
None.

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

Need to ensure works correctly with multiple players and on DS.

### How can the changes be tested?
Steps:

********************************************************
Notes:
