### PR TITLE
Weighted vehicles and statics in faction templates

### DIFF
--- a/A3A/addons/core/functions/AI/fn_staticMGDrill.sqf
+++ b/A3A/addons/core/functions/AI/fn_staticMGDrill.sqf
@@ -9,7 +9,7 @@ private _mounted = false;
 private _veh = objNull;
 private _sideX = side _groupX;
 private _faction = Faction(_sideX);
-private _typeVehX = selectRandom (if !(_isMortar) then { _faction get "staticMGs" } else { _faction get "staticMortars" });
+private _typeVehX = selectRandomWeighted (if !(_isMortar) then { _faction get "staticMGs" } else { _faction get "staticMortars" });
 private _backpckG = backPack _gunner;
 private _backpckA = backpack _helperX;
 while {(alive _gunner)} do

--- a/A3A/addons/core/functions/Base/fn_getVehiclesAirSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesAirSupport.sqf
@@ -36,7 +36,7 @@ if (_faction get "vehiclesPlanesCAS" isNotEqualTo []) then {
     _vehWeights append ["CAS", _casWeight];
     _vehWeights append ["CASDIVE", _casDiveWeight];
 };
-[_faction get "vehiclesHelisAttack", _AHWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesHelisLightAttack", _lightAHWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesHelisAttack") select {_x isEqualType ""}, _AHWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesHelisLightAttack") select {_x isEqualType ""}, _lightAHWeight] call _fnc_addArrayToWeights;
 
 _vehWeights;

--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundSupport.sqf
@@ -28,22 +28,22 @@ private _tankWeight =       [ 0,  0,  0, 15, 20, 25, 30, 35, 40, 50] select _lev
 private _ltankWeight =      [ 0, 10, 15, 25, 30, 35, 30, 25, 20, 15] select _level;
 
 // filter out weak AA that shouldn't be tier-scaled (eg. Avenger, zu23)
-private _vehAA = (_faction get "vehiclesAA") select { A3A_vehicleResourceCosts get _x >= 100 };
+private _vehAA = (_faction get "vehiclesAA") select { _x isEqualType "" && {A3A_vehicleResourceCosts get _x >= 100} };
 if (_vehAA isEqualTo []) then { _tankWeight = _tankWeight + _aaWeight };
 
-[_faction get "vehiclesLightTanks", _ltankWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesTanks", _tankWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightTanks") select {_x isEqualType ""}, _ltankWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesTanks") select {_x isEqualType ""}, _tankWeight] call _fnc_addArrayToWeights;
 if (_tanksOnly) exitWith { _vehWeights };
 
 // only occupants use militia vehicles?
 if (_side == Occupants) then {
-    [_faction get "vehiclesMilitiaLightArmed", _milCarWeight] call _fnc_addArrayToWeights;
-    private _milApc = _faction get "vehiclesMilitiaAPCs";
+    [(_faction get "vehiclesMilitiaLightArmed") select {_x isEqualType ""}, _milCarWeight] call _fnc_addArrayToWeights;
+    private _milApc = (_faction get "vehiclesMilitiaAPCs") select {_x isEqualType ""};
     if (_milApc isNotEqualTo []) then {
         [_milApc, _milApcWeight] call _fnc_addArrayToWeights;
     };
 };
-[_faction get "vehiclesLightArmed", _carWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightArmed") select {_x isEqualType ""}, _carWeight] call _fnc_addArrayToWeights;
 [_vehAA, _aaWeight] call _fnc_addArrayToWeights;
 
 _vehWeights;

--- a/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehiclesGroundTransport.sqf
@@ -53,20 +53,20 @@ if (_faction get "vehiclesAPCs" isEqualTo []) then {
 
 // only occupants use militia vehicle types?
 if (_side == Occupants) then {
-    [_faction get "vehiclesPolice", _policeWeight] call _fnc_addArrayToWeights;
-    [_faction get "vehiclesMilitiaCars", _milCarWeight] call _fnc_addArrayToWeights;
-    [_faction get "vehiclesMilitiaTrucks", _milTruckWeight] call _fnc_addArrayToWeights;
-    private _milApc = _faction get "vehiclesMilitiaAPCs";
+    [(_faction get "vehiclesPolice") select {_x isEqualType ""}, _policeWeight] call _fnc_addArrayToWeights;
+    [(_faction get "vehiclesMilitiaCars") select {_x isEqualType ""}, _milCarWeight] call _fnc_addArrayToWeights;
+    [(_faction get "vehiclesMilitiaTrucks") select {_x isEqualType ""}, _milTruckWeight] call _fnc_addArrayToWeights;
+    private _milApc = (_faction get "vehiclesMilitiaAPCs") select {_x isEqualType ""};
     if (_milApc isNotEqualTo []) then {
         [_milApc, _milApcWeight] call _fnc_addArrayToWeights;
     };
 };
-[_faction get "vehiclesLightUnarmed", _carWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesLightArmedTroop", _armedCarWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesTrucks", _truckWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesLightAPCs", _lapcWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesAPCs", _apcWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesIFVs", _ifvWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesTanks", _tankWeight] call _fnc_addArrayToWeights;
-[_faction get "vehiclesLightTanks", _ltankWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightUnarmed") select {_x isEqualType ""}, _carWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightArmedTroop") select {_x isEqualType ""}, _armedCarWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesTrucks") select {_x isEqualType ""}, _truckWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightAPCs") select {_x isEqualType ""}, _lapcWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesAPCs") select {_x isEqualType ""}, _apcWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesIFVs") select {_x isEqualType ""}, _ifvWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesTanks") select {_x isEqualType ""}, _tankWeight] call _fnc_addArrayToWeights;
+[(_faction get "vehiclesLightTanks") select {_x isEqualType ""}, _ltankWeight] call _fnc_addArrayToWeights;
 _vehWeights;

--- a/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AAFroadPatrol.sqf
@@ -33,36 +33,36 @@ private _typePatrol = "LAND";
 
 switch (true) do {
 	case (_base in seaports): {
-		_typeCar = selectRandom (_faction get "vehiclesGunBoats");
+		_typeCar = selectRandomWeighted (_faction get "vehiclesGunBoats");
 		_typePatrol = "SEA";
 	};
 
 	case (_base in milbases): {
 		if (random 10 < tierWar + aggressionOccupants/10) then {
-			_typeCar = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks"));
+			_typeCar = selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks"));
 		} else {
-			_typeCar = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightAPCs") + (_faction get "vehiclesMilitiaAPCs"));
+			_typeCar = selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightAPCs") + (_faction get "vehiclesMilitiaAPCs"));
 		};
 	};
 
 	case (_base in airportsX && {!(_faction getOrDefault ["attributeLowAir", false])}): {
 		if (_sideX isEqualTo Invaders || {random 10 < tierWar + aggressionOccupants/10}) then {
-			_typeCar = selectRandom (_faction get "vehiclesHelisLight");
+			_typeCar = selectRandomWeighted (_faction get "vehiclesHelisLight");
 			if(count (_faction get "vehiclesAirPatrol") > 0) then 
 			{
-				_typeCar = selectRandom (_faction get "vehiclesAirPatrol");
+				_typeCar = selectRandomWeighted (_faction get "vehiclesAirPatrol");
 			};
 			_typePatrol = "AIR";
 		} else {
-			_typeCar = selectRandom ((_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars"));	
+			_typeCar = selectRandomWeighted ((_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars"));	
 		};
 	};
 
 	default {
 		if (_sideX isEqualTo Invaders || {random 10 < tierWar + aggressionOccupants/10}) then {
-			_typeCar = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"));
+			_typeCar = selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"));
 		} else {
-			_typeCar = selectRandom ((_faction get "vehiclesPolice") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesBasic"));
+			_typeCar = selectRandomWeighted ((_faction get "vehiclesPolice") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesBasic"));
 		};
 	};
 };

--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -36,8 +36,8 @@ private _radarType = _faction getOrDefault ["vehicleRadar", ""];
 private _samType = _faction getOrDefault ["vehicleSam", ""];
 
 // In case of array
-if (_radarType isEqualType [] && {_radarType isNotEqualTo []}) then {_radarType = selectRandom _radarType};
-if (_samType isEqualType [] && {_samType isNotEqualTo []}) then {_samType = selectRandom _samType};
+if (_radarType isEqualType [] && {_radarType isNotEqualTo []}) then {_radarType = selectRandomWeighted _radarType};
+if (_samType isEqualType [] && {_samType isNotEqualTo []}) then {_samType = selectRandomWeighted _samType};
 
 // In case of empty array
 if (_samType isEqualType [] && {_samType isEqualTo []}) then {_samType = ""};
@@ -108,7 +108,7 @@ for "_i" from 1 to _max do {
 
 	private _veh = nil;
 	isNil {
-		_veh = createVehicle [selectRandom (_faction get "vehiclesAA"), (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
+		_veh = createVehicle [selectRandomWeighted (_faction get "vehiclesAA"), (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 		_veh setDir (_spawnParameter select 1);
   	};
 
@@ -132,7 +132,7 @@ if (_frontierX && {random 100 < (20 + tierWar * 3)}) then {
 	if (_road distance2D _positionX > 800) exitWith {};
 
 	private _heavyVehPool =  (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesLightAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks");
-	private _type = selectRandom _heavyVehPool;
+	private _type = selectRandomWeighted _heavyVehPool;
 
 	private _heavyVehicle = [_type, (position _road), 15, 10] call A3A_fnc_safeVehicleSpawn;
 	if (isNull _heavyVehicle) exitWith {};
@@ -163,7 +163,7 @@ if (_frontierX) then {
 	if (count _roads != 0) then {
 		private _groupX = createGroup _sideX;
 		_groups pushBack _groupX;
-		private _typeVehX = selectRandom (_faction get "staticAT");
+		private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 
 		if (_faction getOrDefault ["noSandbag", false]) then {		
 			private _veh = _typeVehX createVehicle _positionX;
@@ -246,7 +246,7 @@ while {true} do {
 	if (_spawnParameter isEqualType false) exitWith {};
 
 	_spawnsUsed pushBack _spawnParameter#2;
-	_typeVehX = selectRandom (_faction get "staticMortars");
+	_typeVehX = selectRandomWeighted (_faction get "staticMortars");
 	_veh = _typeVehX createVehicle (_spawnParameter select 0);
 	_veh setDir (_spawnParameter select 1);
 	_unit = [_groupX, _typeUnit, _positionX, [], 0, "CAN_COLLIDE"] call A3A_fnc_createUnit;
@@ -303,7 +303,7 @@ if (!_busy) then {
 			if(count _vehPool > 0) then
 			{
 				_spawnsUsed pushBack _spawnParameter#2;
-				_typeVehX = selectRandom _vehPool;
+				_typeVehX = selectRandomWeighted _vehPool;
 				/* isNil { */
 					_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 					_veh setDir (_spawnParameter select 1);
@@ -333,7 +333,7 @@ if (!_busy) then {
                     + (_faction get "vehiclesPlanesLargeAA")
                     + (_faction get "vehiclesPlanesTransport");
 		    		+ (_faction getOrDefault ["vehiclesPlanesGunship", []]);
-				_typeVehX = selectRandom _airVehTypes;
+				_typeVehX = selectRandomWeighted _airVehTypes;
 				if (!isNil "_typeVehX") then {
 					_veh = createVehicle [_typeVehX, _pos, [],50, "NONE"];
 					_veh setDir (_ang);
@@ -387,7 +387,7 @@ if (!_busy) then
 			_spawnsUsed pushBack _spawnParameter#2;
 			private _veh = nil;
 			isNil {
-				_veh = createVehicle [selectRandom _vehTypesHeavy, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
+				_veh = createVehicle [selectRandomWeighted _vehTypesHeavy, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 				_veh setDir (_spawnParameter select 1);
 			};
 			_vehiclesX pushBack _veh;
@@ -409,7 +409,7 @@ private _vehTypesLight =
 _countX = 0;
 
 while {_countX < _nVeh && {_countX < 3}} do {
-	private _typeVehX = selectRandom _vehTypesLight;
+	private _typeVehX = selectRandomWeighted _vehTypesLight;
 	private _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 	if(_spawnParameter isEqualType []) then
 	{

--- a/A3A/addons/core/functions/CREATE/fn_createAIMilAdmin.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIMilAdmin.sqf
@@ -179,7 +179,7 @@ private _roadcon = roadsConnectedto (_road select 0);
 private _dirveh = if(count _roadcon > 0) then {[_road select 0, _roadcon select 0] call BIS_fnc_DirTo} else {random 360};
 private _roadPosition = getPos (_road select 0);
 
-private _vehClass = selectRandom _carPool;
+private _vehClass = selectRandomWeighted _carPool;
 private _spawnPos = (getPos (_road select 0)) findEmptyPosition [0, 10, _vehClass];
 if (isNil "_spawnPos") then {
 	_spawnPos = getPos (_road select 0);

--- a/A3A/addons/core/functions/CREATE/fn_createAIMilbase.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIMilbase.sqf
@@ -34,8 +34,8 @@ private _radarType = _faction getOrDefault ["vehicleRadar", ""];
 private _samType = _faction getOrDefault ["vehicleSam", ""];
 
 // In case of array
-if (_radarType isEqualType [] && {_radarType isNotEqualTo []}) then {_radarType = selectRandom _radarType};
-if (_samType isEqualType [] && {_samType isNotEqualTo []}) then {_samType = selectRandom _samType};
+if (_radarType isEqualType [] && {_radarType isNotEqualTo []}) then {_radarType = selectRandomWeighted _radarType};
+if (_samType isEqualType [] && {_samType isNotEqualTo []}) then {_samType = selectRandomWeighted _samType};
 
 // In case of empty array
 if (_samType isEqualType [] && {_samType isEqualTo []}) then {_samType = ""};
@@ -109,7 +109,7 @@ if (random 10 < (tierWar + difficultyCoef)) then {
 
 		private _veh = nil;
 		isNil {
-			_veh = createVehicle [selectRandom (_faction get "vehiclesAA"), (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
+			_veh = createVehicle [selectRandomWeighted (_faction get "vehiclesAA"), (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 			_veh setDir (_spawnParameter select 1);
 		};
 
@@ -132,7 +132,7 @@ if (random 10 < (tierWar + difficultyCoef)) then {
 
 if (random 100 < (40 + tierWar * 6)) then {
 	private _heavyVehPool =  (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks");
-	private _type = selectRandom _heavyVehPool;
+	private _type = selectRandomWeighted _heavyVehPool;
 
 	private _road = [_positionX] call A3A_fnc_findNearestGoodRoad;
 	if (_road distance2D _positionX > 800) exitWith {};
@@ -160,7 +160,7 @@ if (random 100 < (40 + tierWar * 6)) then {
 	_vehiclesX pushBack _heavyVehicle;		
 };
 
-private _boatType = selectRandom (_faction get "vehiclesGunBoats");
+private _boatType = selectRandomWeighted (_faction get "vehiclesGunBoats");
 private _mrkMar = seaSpawn select {getMarkerPos _x inArea _markerX};
 if (count _mrkMar > 0) then {
 	private _pos = (getMarkerPos (_mrkMar select 0)) findEmptyPosition [0,20,_typeVehX];
@@ -182,7 +182,7 @@ if (_frontierX) then {
 	if (count _roads != 0) then {
 		private _groupX = createGroup _sideX;
 		_groups pushBack _groupX;
-		private _typeVehX = selectRandom (_faction get "staticAT");
+		private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 
 		if (_faction getOrDefault ["noSandbag", false]) then {		
 			private _veh = _typeVehX createVehicle _positionX;
@@ -267,7 +267,7 @@ while {true} do {
 
 	_spawnsUsed pushBack _spawnParameter#2;
 
-	_typeVehX = selectRandom (_faction get "staticMortars");
+	_typeVehX = selectRandomWeighted (_faction get "staticMortars");
 	_veh = _typeVehX createVehicle (_spawnParameter select 0);
 	_veh setDir (_spawnParameter select 1);
 	_unit = [_groupX, _typeUnit, _positionX, [], 0, "CAN_COLLIDE"] call A3A_fnc_createUnit;
@@ -342,7 +342,7 @@ if (!_busy) then {
 			_spawnsUsed pushBack _spawnParameter#2;
 			private _veh = nil;
 			isNil {
-				_veh = createVehicle [selectRandom _vehTypesHeavy, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
+				_veh = createVehicle [selectRandomWeighted _vehTypesHeavy, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];
 				_veh setDir (_spawnParameter select 1);
 			};
 			_vehiclesX pushBack _veh;
@@ -364,7 +364,7 @@ private _vehTypesLight =
 _countX = 0;
 
 while {_countX < _nVeh && {_countX < 3}} do {
-	private _typeVehX = selectRandom _vehTypesLight;
+	private _typeVehX = selectRandomWeighted _vehTypesLight;
 	private _spawnParameter = [_markerX, "Vehicle"] call A3A_fnc_findSpawnPosition;
 	if(_spawnParameter isEqualType []) then
 	{

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -92,7 +92,7 @@ if (_patrol) then {
 
 if (_frontierX and {_markerX in outposts}) then {
 	_typeUnit = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
-	_typeVehX = selectRandom (_faction get "staticMortars");
+	_typeVehX = selectRandomWeighted (_faction get "staticMortars");
 	_spawnParameter = [_markerX, "Mortar"] call A3A_fnc_findSpawnPosition;
 	if (_spawnParameter isEqualType []) then {
 		_spawnsUsed pushBack _spawnParameter#2;
@@ -154,7 +154,7 @@ private _ammoBox = if (garrison getVariable [_markerX + "_lootCD", 0] == 0) then
 _roads = _positionX nearRoads _size;
 
 if (_markerX in seaports) then {
-	_typeVehX = selectRandom (_faction get "vehiclesGunBoats");
+	_typeVehX = selectRandomWeighted (_faction get "vehiclesGunBoats");
 	private _mrkMar = seaSpawn select {getMarkerPos _x inArea _markerX};
 	if(count _mrkMar > 0) then {
 		private _pos = (getMarkerPos (_mrkMar select 0)) findEmptyPosition [0,20,_typeVehX];
@@ -198,7 +198,7 @@ if (_markerX in seaports) then {
 		private _pos = [getPos _road, 7, _dirveh + 270] call BIS_fnc_relPos;
 
 		if (_faction getOrDefault ["noSandbag", false]) then {		
-			private _typeVehX = selectRandom (_faction get "staticAT");
+			private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 			private _veh = _typeVehX createVehicle _positionX;
 			_vehiclesX pushBack _veh;
 			_veh setPos _pos;
@@ -214,7 +214,7 @@ if (_markerX in seaports) then {
 			_vehiclesX pushBack _bunker;
 			_bunker setDir _dirveh;
 			_pos = getPosATL _bunker;
-			private _typeVehX = selectRandom (_faction get "staticAT");
+			private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 			private _veh = _typeVehX createVehicle _positionX;
 			_vehiclesX pushBack _veh;
 			_veh setPos _pos;
@@ -235,8 +235,8 @@ private _veh = nil;
 if (_spawnParameter isEqualType []) then {
 	_spawnsUsed pushBack _spawnParameter#2;
 	private _typeVehX = call {
-		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesRepairTrucks") };
-		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
+		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandomWeighted (_faction get "vehiclesRepairTrucks") };
+		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandomWeighted (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {
 			(_faction get "vehiclesTrucks") + 
 			(_faction get "vehiclesCargoTrucks") + 
@@ -249,9 +249,8 @@ if (_spawnParameter isEqualType []) then {
 			(_faction get "vehiclesMilitiaCars")+
 			(_faction get "vehiclesBasic") //we should use them somewhere at least
 		};
-		// _types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
 		if (count _types == 0) then { (_faction get "vehiclesCargoTrucks") } else { _types };
-		selectRandom _types;
+		selectRandomWeighted _types;
 	};
 	isNil {
 		_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "CAN_COLLIDE"];

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -42,7 +42,7 @@ if (_frontierX) then {
 		private _pos = [getPos _road, 7, _dirveh + 270] call BIS_Fnc_relPos;
 
 		if (_faction getOrDefault ["noSandbag", false]) then {		
-			private _typeVehX = selectRandom (_faction get "staticAT");
+			private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 			private _veh = _typeVehX createVehicle _positionX;
 			_vehiclesX pushBack _veh;
 			_veh setPos _pos;
@@ -58,7 +58,7 @@ if (_frontierX) then {
 			_vehiclesX pushBack _bunker;
 			_bunker setDir _dirveh;
 			_pos = getPosATL _bunker;
-			private _typeVehX = selectRandom (_faction get "staticAT");
+			private _typeVehX = selectRandomWeighted (_faction get "staticAT");
 			private _veh = _typeVehX createVehicle _positionX;
 			_vehiclesX pushBack _veh;
 			_veh setPos _pos;
@@ -136,16 +136,20 @@ private _veh = nil;
 if (_spawnParameter isEqualType []) then {
 	_spawnsUsed pushBack _spawnParameter#2;
 	private _typeVehX = call {
-		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesRepairTrucks") };
-		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandom (_faction get "vehiclesFuelTrucks") };
+		if (FactionGet(civ,"vehiclesCivRepair") isEqualTo [] and random 1 < 0.1) exitWith { selectRandomWeighted (_faction get "vehiclesRepairTrucks") };
+		if (FactionGet(civ,"vehiclesCivFuel") isEqualTo [] and random 1 < 0.1) exitWith { selectRandomWeighted (_faction get "vehiclesFuelTrucks") };
 		private _types = if (!_isFIA) then {
 			(_faction get "vehiclesTrucks") + (_faction get "vehiclesCargoTrucks")
 		} else {
 			_faction get "vehiclesMilitiaTrucks"
 		};
-		_types = _types select { _x in FactionGet(all,"vehiclesCargoTrucks") };
+		{
+			if (_x isEqualType "" && {!(_x in FactionGet(all,"vehiclesCargoTrucks")) ||
+				_x isEqualType 1 && {!(_types select (_forEachIndex - 1) in FactionGet(all, "vehiclesCargoTrucks"))}}
+			) then { _types deleteAt _forEachIndex };
+		} forEach _types;
 		if (count _types == 0) then { _types = (_faction get "vehiclesCargoTrucks") } else { _types }; // failsafe didn't work?
-		selectRandom _types;
+		selectRandomWeighted _types;
 	};
 	isNil {
 		_veh = createVehicle [_typeVehX, (_spawnParameter select 0), [], 0, "NONE"];

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -91,7 +91,7 @@ if (_isControl) then
 				_pos = getPosATL _bunker;
 			};
 			_vehiclesX pushBack _bunker;
-			_typeVehX = selectRandom (_faction get "staticMGs");
+			_typeVehX = selectRandomWeighted (_faction get "staticMGs");
 			_veh = _typeVehX createVehicle _positionX;
 			_vehiclesX pushBack _veh;
 			_veh setPosATL _pos;
@@ -109,7 +109,7 @@ if (_isControl) then
 				_bunker setDir _dirveh + 180;
 				_pos = _bunker modelToWorld [-0.200684,-0.91333,-0.421184];
 				_vehiclesX pushBack _bunker;
-				_typeVehX = selectRandom (_faction get "staticMGs");
+				_typeVehX = selectRandomWeighted (_faction get "staticMGs");
 				_veh = _typeVehX createVehicle _positionX;
 				_vehiclesX pushBack _veh;
 				_veh setPosATL _pos;
@@ -189,7 +189,7 @@ if (_isControl) then
 				_vehicleGet = "vehiclesMilitiaCars";
 			};
 		};
-		_typeVehX = selectRandom (_faction get _vehicleGet);
+		_typeVehX = selectRandomWeighted (_faction get _vehicleGet);
 		_veh = _typeVehX createVehicle getPos (_roads select 0);
 		_veh setDir _dirveh + 90;
 		[_veh, _sideX] call A3A_fnc_AIVEHinit;
@@ -223,7 +223,7 @@ else
 			Debug_1("Creating a Minefield at %1", _markerX);
 			private _mines = (_faction get "minefieldAPERS");
 			for "_i" from 1 to 45 do {
-				_mineX = createMine [ selectRandom _mines ,_positionX,[],_size];
+				_mineX = createMine [ selectRandomWeighted _mines ,_positionX,[],_size];
 				_sideX revealMine _mineX;
 			};
 		};
@@ -232,7 +232,7 @@ else
 		[_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
 		_groups pushBack _groupX;
 
-		_typeVehX = selectRandom (_faction get "uavsPortable");
+		_typeVehX = selectRandomWeighted (_faction get "uavsPortable");
 		if !(isNil "_typeVehX") then
 		{
 			sleep 1;

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceOrbital.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceOrbital.sqf
@@ -34,7 +34,7 @@ private _crewGroups = [];
 private _cargoGroups = [];
 
 private _faction = Faction(_side);
-private _transportPlanes = _faction get "vehiclesDropPod";
+private _transportPlanes = (_faction get "vehiclesDropPod") select {_x isEqualType ""};
 private _lhFactor = 0 max (1 - (tierWar+_tierMod) / 10);            // phase out light helis at higher war tiers
 
 private _transportPool = [];
@@ -56,7 +56,7 @@ for "_i" from 1 to _vehCount do {
     switch (true) do {   
         case (_isGuaranteedAirdrop || {_vehType == "VEHAIRDROP"}): {
             //TODO: remove this delicious copypasta
-            private _transportPlaneType = selectRandom _transportPlanes;
+            private _transportPlaneType = selectRandomWeighted _transportPlanes;
             private _vehData = [_transportPlaneType, _troopType, _resPool, [], _side, _base, _targPos, true] call A3A_fnc_createAttackVehicleOrbital;
             if !(_vehData isEqualType []) exitWith {};          // couldn't create for some reason. Not sure why for air vehicles.
 

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -145,7 +145,7 @@ if (({_x call A3A_fnc_canFight} count _soldiers < count _soldiers / 3) or (time 
     publicVariable "destroyedSites";
     private _mineTypes = A3A_faction_inv get "minefieldAPERS";
     for "_i" from 1 to 60 do {
-        private _mineX = createMine [selectRandom _mineTypes,_posDest,[],_size];
+        private _mineX = createMine [selectRandomWeighted _mineTypes,_posDest,[],_size];
         Invaders revealMine _mineX;
     };
     [_mrkDest] call A3A_fnc_destroyCity;

--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -42,7 +42,7 @@ private _count = 1 + round (random 3); //Change these numbers as you want, first
 while {_count > 0} do
 {
     if (_helicopterTypes isEqualTo []) exitWith {}; //no helis to pick from
-    _typeVehX = selectRandom _helicopterTypes;
+    _typeVehX = selectRandomWeighted _helicopterTypes;
     private _spawnParameter = [_markerX, "Heli"] call A3A_fnc_findSpawnPosition;
     if !(_spawnParameter isEqualType []) exitWith {};       // out of spawn places
     _spawnsUsed pushBack _spawnParameter#2;
@@ -89,7 +89,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         //Static MGs
         if 	((_typeB == "Land_Cargo_Patrol_V1_F") or (_typeB == "Land_Cargo_Patrol_V2_F") or (_typeB == "Land_Cargo_Patrol_V3_F") or (_typeB == "Land_Cargo_Patrol_V4_F")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 1);
             private _pos = _zpos getPos [1.5, _dir];			// zeroes Z value because BIS
@@ -98,7 +98,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		if 	((_typeB == "Land_Hlaska") or (_typeB == "Land_vn_hlaska")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building);
             private _zpos = AGLToASL (_building buildingPos 1);
             private _pos = _zpos getPos [0.5, _dir];
@@ -107,7 +107,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
         if 	((_typeB == "Land_fortified_nest_small_EP1") or (_typeB == "Land_BagBunker_Small_F") or (_typeB == "Land_BagBunker_01_small_green_F") or (_typeB == "Land_fortified_nest_small") or (_typeB == "Fort_Nest") or (_typeB == "Land_vn_bagbunker_01_small_green_f") or (_typeB == "Land_vn_bagbunker_small_f") or (_typeB == "Land_vn_o_shelter_05")or (_typeB == "Land_vn_bunker_small_01")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 1);
             private _pos = _zpos getPos [-1, _dir];
@@ -116,7 +116,7 @@ for "_i" from 0 to (count _buildings) - 1 do
 		};
  		if 	((_typeB == "Land_vn_o_tower_02")) exitWith
          {
-             private _type = selectRandom (_faction get "staticMGs");
+             private _type = selectRandomWeighted (_faction get "staticMGs");
              private _dir = (getDir _building) - 90;
              private _zpos = AGLToASL (_building buildingPos 1);
              private _pos = _zpos getPos [0.5, _dir];
@@ -125,7 +125,7 @@ for "_i" from 0 to (count _buildings) - 1 do
          };
  		if 	((_typeB == "Land_vn_hut_tower_01")) exitWith
          {
-             private _type = selectRandom (_faction get "staticMGs");
+             private _type = selectRandomWeighted (_faction get "staticMGs");
              private _dir = (getDir _building) - 180;
              private _zpos = AGLToASL (_building buildingPos 5);
              private _pos = _zpos getPos [1, _dir];
@@ -134,7 +134,7 @@ for "_i" from 0 to (count _buildings) - 1 do
          };
  		if 	((_typeB == "Land_vn_o_platform_05") or (_typeB == "Land_vn_o_platform_06")) exitWith
          {
-             private _type = selectRandom (_faction get "staticMGs");
+             private _type = selectRandomWeighted (_faction get "staticMGs");
              private _dir = (getDir _building) - 270;
              private _zpos = AGLToASL (_building buildingPos 5);
              private _pos = _zpos getPos [0.5, _dir];
@@ -143,7 +143,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		if 	((_typeB == "Land_vn_b_trench_bunker_04_01")) exitWith
          {
-             private _type = selectRandom (_faction get "staticMGs");
+             private _type = selectRandomWeighted (_faction get "staticMGs");
              private _dir = (getDir _building) + 90;
              private _zpos = AGLToASL (_building buildingPos 4);
              private _pos = _zpos getPos [-1.5, _dir];
@@ -153,7 +153,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
         if 	((_typeB == "Land_Cargo_Tower_V1_F") or (_typeB == "Land_Cargo_Tower_V1_No1_F") or (_typeB == "Land_Cargo_Tower_V1_No2_F") or (_typeB == "Land_Cargo_Tower_V1_No3_F") or (_typeB == "Land_Cargo_Tower_V1_No4_F") or (_typeB == "Land_Cargo_Tower_V1_No5_F") or (_typeB == "Land_Cargo_Tower_V1_No6_F") or (_typeB == "Land_Cargo_Tower_V1_No7_F") or (_typeB == "Land_Cargo_Tower_V2_F") or (_typeB == "Land_Cargo_Tower_V3_F") or (_typeB == "Land_Cargo_Tower_V4_F")) exitWith			// just the big towers which have 3 .50 cals on top
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             _dir = getDir _building;
             _zOffset = [0, 0, -0.3]; //fix spawn hight
             _Tdir = _dir + 90; //relative rotation to building
@@ -179,7 +179,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
         if     ((_typeB == "Land_SPE_Sandbag_Nest")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building);
             private _pos = _building modelToWorld [0.0065918,-0.489746,-0.417223];
             [_type, _pos, _dir] call _fnc_spawnStatic;
@@ -188,7 +188,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         //Static AAs
 		if 	((_typeB == "Land_Radar_01_HQ_F") or (_typeB == "Land_vn_radar_01_hq_f")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = getDir _building;
             private _zpos = AGLToASL (_building buildingPos 30);
             private _pos = getPosASL _building;
@@ -197,7 +197,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
         if 	((_typeB == "Land_Cargo_HQ_V1_F") or (_typeB == "Land_Cargo_HQ_V2_F") or (_typeB == "Land_Cargo_HQ_V3_F")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = getDir _building;
             private _zpos = AGLToASL (_building buildingPos 8);
             private _pos = getPosASL _building;
@@ -206,7 +206,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		if 	((_typeB == "Land_vn_cementworks_01_grey_f")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = getDir _building;
             private _zpos = AGLToASL (_building buildingPos 24);
             private _pos = getPosASL _building;
@@ -215,7 +215,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		if 	((_typeB == "Land_vn_cementworks_01_brick_f")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = getDir _building;
             private _zpos = AGLToASL (_building buildingPos 20);
             private _pos = getPosASL _building;
@@ -224,7 +224,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		if 	((_typeB == "Land_vn_a_office01")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = (getDir _building) + 180;
             private _zpos = AGLToASL (_building buildingPos 8);
 			private _pos = _zpos getPos [1.5, _dir];
@@ -233,7 +233,7 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
 		
         if (_typeB isEqualTo "land_gm_sandbags_02_bunker_high" or {_typeB isEqualTo "land_gm_woodbunker_01_bags"}) exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = getDir _building;
             private _zpos = AGLToASL (position _building);
             private _pos = _zpos getPos [0, _dir];
@@ -242,7 +242,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos
         };
         if (_typeB isEqualTo "Land_HBarrier_01_big_tower_green_F" or {_typeB isEqualTo "Land_HBarrierTower_F"}) exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (position _building);
             private _zOffset = [0, 0, 2.55];
@@ -253,7 +253,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "Land_HBarrier_01_tower_green_F"  or {_typeB isEqualTo "Land_BagBunker_Tower_F"}) exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (position _building);
             private _zOffset = [0, 0, 2.55];
@@ -264,7 +264,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "Land_Fort_Watchtower_EP1" or {_typeB isEqualTo "Land_Fort_Watchtower"}) exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (position _building);
             private _zOffset = [0, 0, 2.25];
@@ -275,7 +275,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB in ["Land_BagBunker_Large_F", "Land_fortified_nest_big_EP1", "Land_fortified_nest_big", "Land_BagBunker_01_large_green_F", "Land_vn_bunker_big_01"]) exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 4);
             private _pos = _zpos getPos [2, _dir];
@@ -284,7 +284,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "Land_Bunker_01_big_F") exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 2);
             private _pos = _zpos getPos [-1, _dir];
@@ -298,7 +298,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "Land_Bunker_01_small_F") exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 1);
             private _pos = _zpos getPos [-1, _dir];
@@ -307,7 +307,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "Land_Bunker_01_tall_F") exitWith {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 3);
             private _pos = _zpos getPos [-1.5, _dir];
@@ -316,7 +316,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             _static setPos _pos; 
         };
         if (_typeB isEqualTo "land_gm_euro_misc_viewplatform_01") exitWith {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (position _building);
             private _zOffset = [0, 0, 5.2];
@@ -328,91 +328,91 @@ for "_i" from 0 to (count _buildings) - 1 do
         };
         if  ((_typeB == "Land_WW2_Bunker_H679")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 90;
             private _pos = _building modelToWorld [-1.8,0,0.555];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_WW2_Bunker_Gun_R")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAT");
+            private _type = selectRandomWeighted (_faction get "staticAT");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0.2,0,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_WW2_Bunker_Gun_L")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAT");
+            private _type = selectRandomWeighted (_faction get "staticAT");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0,0,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_WW2_BET_Flak_Bettung")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = (getDir _building) - 45;
             private _pos = _building modelToWorld [-1.2,1,0.2];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_SPE_H667")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0,-0.1,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_SPE_H612")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [-0.3,-5,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_SPE_H630")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0.8,-2.5,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_SPE_H669")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAT");
+            private _type = selectRandomWeighted (_faction get "staticAT");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0,-3.2,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if  ((_typeB == "Land_SPE_H679")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAT");
+            private _type = selectRandomWeighted (_faction get "staticAT");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [-0.2,-2,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if     ((_typeB == "LAND_uns_weapon_pit")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0.5,0.1,0.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if     ((_typeB == "LAND_CSJ_gunpit")) exitWith
         {
-            private _type = selectRandom (_faction get "staticAA");
+            private _type = selectRandomWeighted (_faction get "staticAA");
             private _dir = (getDir _building) - 90;
             private _pos = _building modelToWorld [0,0,1.2];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if     ((_typeB == "csj_VCbunk01")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [0,0,-0.5];
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };
         if     ((_typeB == "Land_Vil_Tower")) exitWith
         {
-            private _type = selectRandom (_faction get "staticMGs");
+            private _type = selectRandomWeighted (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _pos = _building modelToWorld [-0.5,-0.7,1.3];
             [_type, _pos, _dir] call _fnc_spawnStatic;

--- a/A3A/addons/core/functions/CREATE/fn_minefieldAAF.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_minefieldAAF.sqf
@@ -59,7 +59,7 @@ Debug_1("Creating a Minefield at %1", _base);
 private _mines = (_faction get "minefieldAT") + (_faction get "minefieldAPERS");
 
 for "_i" from 1 to 30 do {
-	_mineX = createMine [ selectRandom _mines ,_pos,[],50];
+	_mineX = createMine [ selectRandomWeighted _mines ,_pos,[],50];
 	_sideX revealMine _mineX;
 };
 

--- a/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_patrolReinf.sqf
@@ -21,7 +21,7 @@ private _isLand = if (_lowAir) then { true } else {						// land markers guarant
 ServerInfo_5("Spawning PatrolReinf. Dest:%1 Orig:%2 Size:%3 Side:%4 Land:%5",_mrkDest,_mrkOrigin,_numTroops,_side,_isLand);
 
 private _vehicleType = if (_isLand) then {
-	selectRandom (_faction get "vehiclesTrucks");
+	selectRandomWeighted (_faction get "vehiclesTrucks");
 } else {
 	private _transportPlanes = _faction get "vehiclesPlanesTransport";
 	private _transportHelis = _faction get "vehiclesHelisTransport";

--- a/A3A/addons/core/functions/Garrison/fn_checkVehicleType.sqf
+++ b/A3A/addons/core/functions/Garrison/fn_checkVehicleType.sqf
@@ -14,8 +14,8 @@ params ["_vehicle", "_preference"];
 //define list of vehicles as lazy conditions
 #define lightVeh \
     {_vehicle in FactionGet(occ,"vehiclesLightArmed")} \
-    || {_vehicle in FactionGet(inv,"vehiclesLightUnarmed")} \
-    || {_vehicle in FactionGet(occ,"vehiclesLightArmed")} \
+    || {_vehicle in FactionGet(occ,"vehiclesLightUnarmed")} \
+    || {_vehicle in FactionGet(inv,"vehiclesLightArmed")} \
     || {_vehicle in FactionGet(inv,"vehiclesLightUnarmed")}
 
 #define apc \

--- a/A3A/addons/core/functions/Garrison/fn_selectReinfUnits.sqf
+++ b/A3A/addons/core/functions/Garrison/fn_selectReinfUnits.sqf
@@ -99,11 +99,11 @@ while {_currentUnitCount < (_maxUnitSend - 2) && {_maxCargoSpaceNeeded+_maxVehic
             {
                 if (_neededCargoSpace <= 4) then
                 {
-                    _currentSelected = selectRandom (_faction get "vehiclesHelisLight");
+                    _currentSelected = selectRandomWeighted (_faction get "vehiclesHelisLight");
                 }
                 else
                 {
-                    _currentSelected = selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport"));
+                    _currentSelected = selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport"));
                 };
                 Verbose_1("Selected %1 as an air transport vehicle", _currentSelected);
             }
@@ -112,19 +112,19 @@ while {_currentUnitCount < (_maxUnitSend - 2) && {_maxCargoSpaceNeeded+_maxVehic
                 if(_neededCargoSpace == 1) then
                 {
                     //Vehicle, crew and one person, selecting quad
-                    _currentSelected = selectRandom (_faction get "vehiclesBasic");
+                    _currentSelected = selectRandomWeighted (_faction get "vehiclesBasic");
                 }
                 else
                 {
                     if(_neededCargoSpace <= 5) then
                     {
                         //Select light unarmed vehicle (as the armed uses three crew)
-                        _currentSelected = selectRandom (_faction get "vehiclesLightUnarmed");
+                        _currentSelected = selectRandomWeighted (_faction get "vehiclesLightUnarmed");
                     }
                     else
                     {
                         //Select random truck or helicopter
-                        _currentSelected = selectRandom ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport"));
+                        _currentSelected = selectRandomWeighted ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport"));
                     };
                 };
                 Verbose_1("Selected %1 as an ground or air transport vehicle", _currentSelected);

--- a/A3A/addons/core/functions/Garrison/fn_selectVehicleType.sqf
+++ b/A3A/addons/core/functions/Garrison/fn_selectVehicleType.sqf
@@ -14,8 +14,8 @@ private _faction = Faction(_side);
 
 Verbose_2("SelectVehicleType: Selecting vehicle now, preferred is %1, side is %2", _preference, _side);
 
-if(_preference == "LAND_AIR") exitWith { selectRandom (_faction get "vehiclesAA") };
-if(_preference == "LAND_TANK") exitWith { selectRandom (_faction get "vehiclesTanks") };
+if(_preference == "LAND_AIR") exitWith { selectRandomWeighted (_faction get "vehiclesAA") };
+if(_preference == "LAND_TANK") exitWith { selectRandomWeighted (_faction get "vehiclesTanks") };
 
 private _possibleVehicles = [];
 if(_preference in ["EMPTY", "LAND_START", "HELI_PATROL", "AIR_DRONE"]) then {
@@ -66,4 +66,4 @@ if(count _possibleVehicles == 0) exitWith
 
 Verbose_1("SelectVehicleType: Preselection done, possible vehicles are %1", str _possibleVehicles);
 
-selectRandom _possibleVehicles;
+selectRandomWeighted _possibleVehicles;

--- a/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
@@ -71,8 +71,8 @@ Info_2("Origin: %1, Destination: %2", str _missionOrigin, str _destinationSite);
 
 // selecting classnames
 private _officerClass = _faction get "unitOfficial";
-private _escortVehicleClass = if(_difficult) then {selectRandom (_faction get "vehiclesAPCs")} else {selectRandom (_faction get "vehiclesTrucks")};
-private _officerVehicleClass = if(_difficult) then { selectRandom (_faction get "vehiclesLightArmed") } else { selectRandom (_faction get "vehiclesLightUnarmed") };
+private _escortVehicleClass = if(_difficult) then {selectRandomWeighted (_faction get "vehiclesAPCs")} else {selectRandomWeighted (_faction get "vehiclesTrucks")};
+private _officerVehicleClass = if(_difficult) then { selectRandomWeighted (_faction get "vehiclesLightArmed") } else { selectRandomWeighted (_faction get "vehiclesLightUnarmed") };
 private _infantrySquadArray = selectRandom ([_faction, "groupsTierSquads"] call SCRT_fnc_unit_flattenTier);
 
 if (isNil "_officerClass" || {isNil "_officerVehicleClass" || {isNil "_escortVehicleClass" || {isNil "_infantrySquadArray"}}}) exitWith {

--- a/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
@@ -76,9 +76,9 @@ if (_difficultX) then {
 
 	// Spawn attack helicopter
 	private _heliType = if (_faction getOrDefault ["vehiclesHelisAttack", []] isNotEqualTo []) then {
-		selectRandom (_faction getOrDefault ["vehiclesHelisAttack", []]);
+		selectRandomWeighted (_faction getOrDefault ["vehiclesHelisAttack", []]);
 	} else {
-		selectRandom (_faction getOrDefault ["vehiclesHelisLightAttack", []]);
+		selectRandomWeighted (_faction getOrDefault ["vehiclesHelisLightAttack", []]);
 	};
 	
 	private _heliPos = _posTask getPos [random [1000, 2000, 3000], random 360]; // replace this with an airbase or outpost, etc

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -107,7 +107,7 @@ if (count _roadCon > 0) then {
 };
 
 private _posVeh = [_posroad, 3, _dirveh + 90] call BIS_Fnc_relPos;
-private _vehType = selectRandom (FactionGet(reb,"vehiclesLightUnarmed"));
+private _vehType = selectRandomWeighted (FactionGet(reb,"vehiclesLightUnarmed"));
 private _veh = _vehType createVehicle _posVeh;
 _veh allowDamage false;
 _veh setDir _dirVeh;

--- a/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
@@ -49,7 +49,7 @@ switch (true) do
 	case (tierWar < 6): 
 	{
 		private _potentialArtillery = (_howitzersPool + _mortarsPool);
-		_artilleryClass = selectRandom (_potentialArtillery select {_x isNotEqualTo []});
+		_artilleryClass = selectRandomWeighted (_potentialArtillery select {_x isNotEqualTo []});
 		_artilleryShellClass = if (_artilleryClass in _howitzersPool) then 
         {
             _howitzerMagazine
@@ -60,7 +60,7 @@ switch (true) do
 	default
 	{
 		private _potentialArtillery = (_howitzersPool + _artilleryPool);
-		_artilleryClass = selectRandom (_potentialArtillery select {_x isNotEqualTo []});
+		_artilleryClass = selectRandomWeighted (_potentialArtillery select {_x isNotEqualTo []});
 		_artilleryShellClass = if (_artilleryClass in _howitzersPool) then 
         {
             _howitzerMagazine
@@ -70,7 +70,7 @@ switch (true) do
 	};
 };
 
-_mgClass = selectRandom (_faction get "staticMGs");
+_mgClass = selectRandomWeighted (_faction get "staticMGs");
 _mgCrewClass = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
 
 if (isNil "_artilleryClass" || {isNil "_artilleryShellClass" || {isNil "_mgClass" || {isNil "_mgCrewClass"}}}) exitWith {

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -46,7 +46,7 @@ while {true} do {
 
 // selecting Aircraft
 private _heliPool = (_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisTransport") + (_faction get "vehiclesHelisAttack") + (_faction get "vehiclesHelisLightAttack");
-private _typeVehH = selectRandom (_heliPool select {_x isKindOf "Helicopter"});
+private _typeVehH = selectRandomWeighted _heliPool;
 if (isNil "_typeVehH") exitWith {
     ["DES"] remoteExecCall ["A3A_fnc_missionRequest",2];
     Error("No aircrafts in arrays vehiclesHelisLight, vehiclesHelisTransport or vehiclesHelisAttack. Reselecting DES mission");
@@ -128,7 +128,7 @@ private _roadR = _roads select 0;
 sleep 1;
 
 //Spawning escort
-_typeVeh = selectRandom (_faction get "vehiclesLightUnarmed");
+_typeVeh = selectRandomWeighted (_faction get "vehiclesLightUnarmed");
 private _vehicleDataE = [position _roadE, 0,_typeVeh, _sideX] call A3A_fnc_spawnVehicle;
 private _vehE = _vehicleDataE select 0;
 _vehE limitSpeed 50;
@@ -156,7 +156,7 @@ _escortWP setWaypointBehaviour "SAFE";
 Debug_2("Placed Group: %1 in Lite Vehicle and set waypoint %2", _typeGroup, _posCrash);
 
 //creating repair vehicle
-_typeVeh = selectRandom (_faction get "vehiclesRepairTrucks");
+_typeVeh = selectRandomWeighted (_faction get "vehiclesRepairTrucks");
 private _vehicleDataR = [position _roadR, 0,_typeVeh, _sideX] call A3A_fnc_spawnVehicle;
 private _vehR = _vehicleDataR select 0;
 _vehR limitSpeed 50;
@@ -206,7 +206,7 @@ if !(_typeVehH in (_faction get "vehiclesHelisLight")) then {
     if (_isAttackHeli) then {
         //if attack helicopter
         //creating transport vehicle
-        _typeVeh = selectRandom (_faction get "vehiclesTrucks");
+        _typeVeh = selectRandomWeighted (_faction get "vehiclesTrucks");
         private _posVehHT = _posCrash findEmptyPosition [15, 30 ,_typeVeh];
         if (_posVehHT isEqualTo []) then {_posVehHT = _posCrash findEmptyPosition [15, 100 ,_typeVeh]}; //if it fails to find a pos expand and try again
         if (_posVehHT isEqualTo []) exitWith { _vehGuard = _heli};

--- a/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
@@ -16,7 +16,7 @@ private _limit = if (_difficultX) then {
 };
 _limit params ["_dateLimitNum", "_displayTime"];
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _typeVehX = selectRandom (_faction get "vehiclesAA");
+private _typeVehX = selectRandomWeighted (_faction get "vehiclesAA");
 
 private _taskId = "DES" + str A3A_taskCount;
 [

--- a/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
@@ -55,9 +55,9 @@ waitUntil {sleep 1; (call SCRT_fnc_misc_getRebelPlayers) findIf {_x inArea [_pos
 Info("Setting things in motion...");
 
 private _escortClass = if(_difficultX) then { 
-    selectRandom ((_faction get "vehiclesAPCs") + (_faction get "vehiclesLightAPCs"))
+    selectRandomWeighted ((_faction get "vehiclesAPCs") + (_faction get "vehiclesLightAPCs"))
 } else {
-    selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"))
+    selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesLightUnarmed"))
 };
 
 if (isNil "_escortClass") exitWith {
@@ -176,7 +176,7 @@ if(count _smokes > 0) then {
     private _height = random [500, 1000, 1300];
     private _direction = [_initialPlanePosition, _positionX] call BIS_fnc_DirTo;
 
-    _planeType = selectRandom (FactionGet(reb, "vehiclesPlane"));
+    _planeType = selectRandomWeighted (FactionGet(reb, "vehiclesPlane"));
     _planeData = [[_initialPlanePosition select 0, _initialPlanePosition select 1, _height], _direction, _planeType, teamPlayer] call A3A_fnc_spawnVehicle;
     _planeVeh = _planeData select 0;
     _planeVeh setPosATL [getPosATL _planeVeh select 0, getPosATL _planeVeh select 1, _height];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
@@ -17,7 +17,7 @@ private _limit = if (_difficultX) then {
 _limit params ["_dateLimitNum", "_displayTime"];
 
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _typeVehX = selectRandom (_faction get "vehiclesAmmoTrucks");
+private _typeVehX = selectRandomWeighted (_faction get "vehiclesAmmoTrucks");
 private _size = [_markerX] call A3A_fnc_sizeMarker;
 
 private _road = [_positionX] call A3A_fnc_findNearestGoodRoad;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
@@ -73,7 +73,7 @@ while {true} do {
 // selecting classnames
 private _reconVehicleDroppod = _faction getOrDefault ["vehiclesDropPod", []];
 
-private _reconVehicleClass = selectRandom ((_faction get "vehiclesPlanesTransport") + (_faction get "uavsAttack") + _reconVehicleDroppod); //  + _reconVehicleDroppod
+private _reconVehicleClass = selectRandomWeighted ((_faction get "vehiclesPlanesTransport") + (_faction get "uavsAttack") + _reconVehicleDroppod); //  + _reconVehicleDroppod
 private _pilotClass = _faction get "unitPilot";
 
 if (_reconVehicleClass in _reconVehicleDroppod) exitWith { 
@@ -89,13 +89,13 @@ if (_searchHeliClassLight isEqualTo [] && {_searchHeliClassLightAttack isEqualTo
     _searchHeliClass = [];
 } else {
     _searchHeliClass =  if (_difficult) then {
-        selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
+        selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
     } else {
-        selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
+        selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
     };
 };
 
-private _cargoTruckClass = selectRandom (_faction get "vehiclesTrucks");
+private _cargoTruckClass = selectRandomWeighted (_faction get "vehiclesTrucks");
 
 private _blackboxClass = "";
 

--- a/A3A/addons/core/functions/Missions/fn_LOG_Crashsite_Satellite.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Crashsite_Satellite.sqf
@@ -67,7 +67,7 @@ while {true} do { // This isn't great and would be better to figure out an alter
 };
 
 // selecting classnames
-private _reconVehicle = selectRandom (_faction get "vehiclesDropPod");
+private _reconVehicle = selectRandomWeighted (_faction get "vehiclesDropPod");
 private _reconVehicleDummyClass = _reconVehicle;
 if (_reconVehicle == "SpaceshipCapsule_01_F") then {
 	_reconVehicle = "SpaceshipCapsule_01_wreck_F";
@@ -76,12 +76,12 @@ if (_reconVehicle == "SpaceshipCapsule_01_F") then {
 private _pilotClass = _faction get "unitPilot";
 
 private _searchHeliClass =  if (_difficult) then {
-    selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
 } else {
-    selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
 };
 
-private _cargoTruckClass = selectRandom (_faction get "vehiclesTrucks");
+private _cargoTruckClass = selectRandomWeighted (_faction get "vehiclesTrucks");
 
 //selecting blackbox
 private _blackboxClass = "";

--- a/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
@@ -67,13 +67,13 @@ while {true} do {
 
 // selecting classnames
 private _pilotClass = _faction get "unitPilot";
-private _helicopterClass = selectRandom (_faction get "vehiclesHelisTransport");
+private _helicopterClass = selectRandomWeighted (_faction get "vehiclesHelisTransport");
 private _searchHeliClass =  if (_difficult) then {
-    selectRandom ((_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
 } else {
-    selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
 };
-private _cargoTruckClass = selectRandom (_faction get "vehiclesTrucks");
+private _cargoTruckClass = selectRandomWeighted (_faction get "vehiclesTrucks");
 private _boxClass = _faction get "ammobox";
 private _specOpsArray = if (_difficult) then {selectRandom (_faction get "groupSpecOpsRandom")} else {selectRandom ([_faction, "groupsTierSquads"] call SCRT_fnc_unit_flattenTier)};
 

--- a/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
@@ -81,7 +81,7 @@ Debug("Box spawned");
 
 //Create boat and initialise crew members
 Debug("Spawning patrol boat and crew");
-private _typeVeh = if (_difficultX) then { selectRandom (_faction get "vehiclesGunBoats") } else { selectRandom (_faction get "vehiclesTransportBoats") };
+private _typeVeh = if (_difficultX) then { selectRandomWeighted (_faction get "vehiclesGunBoats") } else { selectRandomWeighted (_faction get "vehiclesTransportBoats") };
 private _typeGroup = if _difficultX then {selectRandom ([_faction, "groupsTierSquads"] call SCRT_fnc_unit_flattenTier)} else {selectRandom ([_faction, "groupsTierMedium"] call SCRT_fnc_unit_flattenTier)};
 private _boatSpawnLocation = selectRandom [_mrk1Pos, _mrk2Pos, _mrk3Pos];
 
@@ -90,7 +90,7 @@ if (_typeSDV != "") then {
 	private _diverType = "";
 	private _diversGroup = createGroup _sideX;
 	private _diversGroup2 = createGroup _sideX;
-   _typeSDV = selectRandom (_faction get "vehiclesSDV");
+   _typeSDV = selectRandomWeighted (_faction get "vehiclesSDV");
    if (_typeSDV == "I_SDV_01_F") then {
 		_diverType = "I_diver_F";
    };

--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -34,7 +34,7 @@ if (spawner getVariable _markerX != 2) then {
 	private _road = [getPos _antennaDead] call A3A_fnc_findNearestGoodRoad;
 	private _pos = position _road;
 	_pos = _pos findEmptyPosition [1,60,"B_T_Truck_01_repair_F"];
-	private _veh = createVehicle [selectRandom (FactionGet(occ,"vehiclesRepairTrucks")), _pos, [], 0, "NONE"];
+	private _veh = createVehicle [selectRandomWeighted (FactionGet(occ,"vehiclesRepairTrucks")), _pos, [], 0, "NONE"];
 	_veh allowdamage false;
 	_veh setDir (getDir _road);
 	[_veh, Occupants] call A3A_fnc_AIVEHinit;

--- a/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
@@ -64,11 +64,11 @@ private _infantrySquadArray = [
 ] select _difficultX;
 private _vehiclePatrol = "";
 private _stolenVehicle = "";
-_vehiclePatrolType = selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesMilitiaTrucks"));
+_vehiclePatrolType = selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesMilitiaTrucks"));
 _stolenVehicleType = if (_difficultX) then {
-    selectRandom ((_faction get "vehiclesLightAPCs") +(_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks"));
+    selectRandomWeighted ((_faction get "vehiclesLightAPCs") +(_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks"));
 } else {
-    selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesMilitiaTrucks"));
+    selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesMilitiaTrucks"));
 }; 
 private _nearbyPos = [_spawnPos, 200, 300, 3, 0, 5, 0] call BIS_fnc_findSafePos;
 private _patrolGroup1 = [_nearbyPos, _sideX, _infantrySquadArray] call A3A_fnc_spawnGroup;

--- a/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
@@ -107,9 +107,9 @@ removeAllAssignedItems _informer;
 _informer playMoveNow "ApanPknlMstpSnonWnonDnon_G01";
 
 private _searchHeliClass =  if (_difficulty) then {
-    selectRandom ((_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLightAttack") + (_faction get "vehiclesHelisAttack"))
 } else {
-    selectRandom ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
+    selectRandomWeighted ((_faction get "vehiclesHelisLight") + (_faction get "vehiclesHelisLightAttack"))
 };
 private _searchHeliData = [[(_positionX select 0) + random 100, (_positionX select 1) + random 100, 300 + random 500], 0, _searchHeliClass, _side] call A3A_fnc_spawnVehicle;
 private _searchHeliVeh = _searchHeliData select 0;
@@ -218,9 +218,9 @@ for "_i" from 0 to _roadblockCount do {
     private _roadblockPosition = position (_roads select 0);   
 
     private _typeVehX = if(random 10 < (tierWar + (difficultyCoef / 2))) then {
-        selectRandom ((_faction get "vehiclesLightAPCs") + (_faction get "vehiclesLightArmed"))
+        selectRandomWeighted ((_faction get "vehiclesLightAPCs") + (_faction get "vehiclesLightArmed"))
     } else {
-        selectRandom (_faction get "vehiclesMilitiaLightArmed")
+        selectRandomWeighted (_faction get "vehiclesMilitiaLightArmed")
     };
 
     private _roadblockVehicleData = [_roadblockPosition, 0, _typeVehX, _side] call A3A_fnc_spawnVehicle;

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -112,7 +112,7 @@ if (_sideX == Invaders) then {
 		_dirVeh = getDir _road;
 		};
 	_posVeh = [_posroad, 3, _dirveh + 90] call BIS_Fnc_relPos;
-	_veh = (selectRandom (_faction get "vehiclesPolice")) createVehicle _posVeh;
+	_veh = (selectRandomWeighted (_faction get "vehiclesPolice")) createVehicle _posVeh;
 	_veh allowDamage false;
 	_veh setDir _dirVeh;
 	sleep 15;

--- a/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
@@ -158,9 +158,9 @@ for "_i" from 0 to _smugglerCount do {
     _x allowDamage true;
 } forEach _POWS;
 
-private _boatClass = selectRandom (_faction get "vehiclesGunBoats");
+private _boatClass = selectRandomWeighted (_faction get "vehiclesGunBoats");
 private _officerClass = _faction get "unitOfficial";
-private _truckClass = selectRandom (_faction get "vehiclesTrucks");
+private _truckClass = selectRandomWeighted (_faction get "vehiclesTrucks");
 
 private _infantrySquadArray = [
     selectRandom ([_faction, "groupsTierMedium"] call SCRT_fnc_unit_flattenTier),

--- a/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
@@ -129,7 +129,7 @@ if (dateToNumber date < _dateLimitNum && alive _traitor) then {
 	};
 
 	if (_isDifficult) then {
-		private _vehicleClass = selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+		private _vehicleClass = selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 
 		private _vehiclePosAndDir = [_positionX, _vehicleClass] call SCRT_fnc_common_findSafePositionForVehicle; 
 		private _patrolVehicleData = [(_vehiclePosAndDir select 0), 0, _vehicleClass, Rivals] call A3A_fnc_RivalsSpawnVehicle;

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
@@ -374,9 +374,9 @@ if (_isDifficult) then {
 //  Patrol vehicle 	                        //
 //////////////////////////////////////////////
 private _vehicleClass = if (_isDifficult) then {
-    selectRandom ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
+    selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
 } else {
-    selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+    selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 };
 
 private _vehiclePosAndDir = [_positionX, _vehicleClass] call SCRT_fnc_common_findSafePositionForVehicle; 
@@ -473,7 +473,7 @@ _lootContainer addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVe
 private _camoNet = createVehicle ["CamoNet_BLUFOR_F", _lootContainerPosition, [], 0 , "CAN_COLLIDE"];
 _camoNet setDir _direction;
 
-private _truckClass = selectRandom (A3A_faction_riv get "vehiclesRivalsTrucks");
+private _truckClass = selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsTrucks");
 private _vehiclePosAndDir = [_lootContainerPosition, _truckClass] call SCRT_fnc_common_findSafePositionForVehicle; 
 private _truck = createVehicle [_truckClass, (_vehiclePosAndDir select 0), [], 0 , "CAN_COLLIDE"];
 _truck setDir (_vehiclePosAndDir select 1);

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
@@ -181,7 +181,7 @@ if (dateToNumber date < _dateLimitNum) then {
     _lootContainer addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
     [_lootContainer] call A3A_Logistics_fnc_addLoadAction;
 
-    private _truckClass = selectRandom (A3A_faction_riv get "vehiclesRivalsTrucks");
+    private _truckClass = selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsTrucks");
     private _vehiclePosAndDir = [_lootContainerPosition, _truckClass, 50, true] call SCRT_fnc_common_findSafePositionForVehicle; 
     private _truck = createVehicle [_truckClass, (_vehiclePosAndDir select 0), [], 0 , "CAN_COLLIDE"];
     _truck setDir (_vehiclePosAndDir select 1);
@@ -191,7 +191,7 @@ if (dateToNumber date < _dateLimitNum) then {
 
     if (_isDifficult) then {
         _truckPosition = position _truck;
-        private _prizeClass = selectRandom ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks") + (A3A_faction_riv get "vehiclesRivalsHelis"));
+        private _prizeClass = selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks") + (A3A_faction_riv get "vehiclesRivalsHelis"));
         private _vehiclePosAndDir = [_truckPosition, _prizeClass, 50, true] call SCRT_fnc_common_findSafePositionForVehicle; 
         private _prizeVehicle = createVehicle [_prizeClass, (_vehiclePosAndDir select 0), [], 0 , "CAN_COLLIDE"];
         _prizeVehicle setDir (_vehiclePosAndDir select 1);
@@ -261,9 +261,9 @@ if (dateToNumber date < _dateLimitNum) then {
     //  Patrol vehicle 	                        //
     //////////////////////////////////////////////
     private _vehicleClass = if (_isDifficult) then {
-        selectRandom ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
+        selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
     } else {
-        selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+        selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
     };
 
     private _vehiclePosAndDir = [_hideoutPosition, _vehicleClass, 250, true] call SCRT_fnc_common_findSafePositionForVehicle; 

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
@@ -199,7 +199,7 @@ _lootContainerPosition = position _lootContainer;
 // Otherwise when destroyed, ammoboxes sink 100m underground and are never cleared up
 _lootContainer addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 [_lootContainer] call A3A_Logistics_fnc_addLoadAction;
-private _truckClass = selectRandom (A3A_faction_riv get "vehiclesRivalsTrucks");
+private _truckClass = selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsTrucks");
 private _vehiclePosAndDir = [_lootContainerPosition, _truckClass, 50, true] call SCRT_fnc_common_findSafePositionForVehicle; 
 private _truck = createVehicle [_truckClass, (_vehiclePosAndDir select 0), [], 0 , "CAN_COLLIDE"];
 _truck setDir (_vehiclePosAndDir select 1);
@@ -207,7 +207,7 @@ _truck setDir (_vehiclePosAndDir select 1);
 _vehicles append [_truck, _lootContainer];
 if (_isDifficult) then {
     _truckPosition = position _truck;
-    private _prizeClass = selectRandom ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks") + (A3A_faction_riv get "vehiclesRivalsHelis"));
+    private _prizeClass = selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks") + (A3A_faction_riv get "vehiclesRivalsHelis"));
     private _vehiclePosAndDir = [_truckPosition, _prizeClass, 50, true] call SCRT_fnc_common_findSafePositionForVehicle; 
     private _prizeVehicle = createVehicle [_prizeClass, (_vehiclePosAndDir select 0), [], 0 , "CAN_COLLIDE"];
     _prizeVehicle setDir (_vehiclePosAndDir select 1);
@@ -270,9 +270,9 @@ if (_isDifficult) then {
 //  Patrol vehicle 	                        //
 //////////////////////////////////////////////
 private _vehicleClass = if (_isDifficult) then {
-    selectRandom ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
+    selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
 } else {
-    selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+    selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 };
 private _vehiclePosAndDir = [_hideoutPosition, _vehicleClass, 250, true] call SCRT_fnc_common_findSafePositionForVehicle; 
 private _patrolVehicleData = [(_vehiclePosAndDir select 0), 0, _vehicleClass, Rivals] call A3A_fnc_RivalsSpawnVehicle;
@@ -286,21 +286,21 @@ _groups pushBack _patrolVehGroup;
 _vehicles pushBack _patrolVeh;
 [_patrolVehGroup, _hideoutPosition, 250] call bis_fnc_taskPatrol;
     
-private _vehicletransferClass = if (_isDifficult) then { selectRandom ((_faction get "vehiclesCargoTrucks") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
+private _vehicletransferClass = if (_isDifficult) then { selectRandomWeighted ((_faction get "vehiclesCargoTrucks") + (A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"));
     } else {
-        selectRandom ((_faction get "vehiclesCargoTrucks") + (A3A_faction_riv get "vehiclesRivalsLightArmed"));
+        selectRandomWeighted ((_faction get "vehiclesCargoTrucks") + (A3A_faction_riv get "vehiclesRivalsLightArmed"));
     }; ///check if vehicle is cargo truck or vehicle to transfer, if cargo truck create or move loot crate to truck.
 private _escortvehicle = if (_isDifficult) then {
-    selectRandom ((_faction get "vehiclesLightAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightArmed") + 
+    selectRandomWeighted ((_faction get "vehiclesLightAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightArmed") + 
     (_faction get "vehiclesTrucks"));
 } else {
-    selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + 
+    selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + 
     (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesMilitiaTrucks"));
 }; //check if vehicle is truck, if yes create a group and move in
 private _convoylead = if (_isDifficult) then {
-    selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks"));
+    selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks"));
 } else {
-    selectRandom ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + 
+    selectRandomWeighted ((_faction get "vehiclesLightArmed") + (_faction get "vehiclesTrucks") + (_faction get "vehiclesMilitiaLightArmed") + 
     (_faction get "vehiclesMilitiaCars") + (_faction get "vehiclesMilitiaTrucks") + (_faction get "vehiclesLightUnarmed"));
 };
     

--- a/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
@@ -50,7 +50,7 @@ private _roadPosition = getPos (_road select 0);
 
 private _crater = createVehicle ["Crater", _roadPosition, [], 0, "NONE"];
 
-private _vehicleClass = selectRandom ((A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsLightArmed"));
+private _vehicleClass = selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsCars") + (A3A_faction_riv get "vehiclesRivalsLightArmed"));
 private _crashedVehicle = createVehicle [_vehicleClass, [_roadPosition select 0, _roadPosition select 1, 0.2], [], 0, "CAN_COLLIDE"];
 _crashedVehicle setDir _dirveh;
 _crashedVehicle setDamage 0.7;
@@ -392,7 +392,7 @@ _roadcon = roadsConnectedto (selectRandom _road);
 _dirveh = if(count _roadcon > 0) then {[_road select 0, _roadcon select 0] call BIS_fnc_DirTo} else {random 360};
 _roadPosition = getPos (_road select 0);
 
-private _rivalVehData = [_roadPosition, 0, selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed"), Rivals] call A3A_fnc_RivalsSpawnVehicle;
+private _rivalVehData = [_roadPosition, 0, selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed"), Rivals] call A3A_fnc_RivalsSpawnVehicle;
 private _rivalVeh = _rivalVehData select 0;
 [_rivalVeh, Rivals] call A3A_fnc_AIVEHinit;
 private _rivalVehCrew = _rivalVehData select 1;

--- a/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
@@ -134,7 +134,7 @@ private _crewClasses = [
 	A3A_faction_reb get "unitEng"
 ];
 
-private _truckClass = selectRandom (A3A_faction_reb get "vehiclesTruck");
+private _truckClass = selectRandomWeighted (A3A_faction_reb get "vehiclesTruck");
 private _truck = createVehicle [_truckClass, [_startingRoadPosition select 0, _startingRoadPosition select 1, 0.9], [], 0, "CAN_COLLIDE"];
 _truck setDir _dirVeh;
 _truck setDamage (random [0.3,0.5,0.7]);
@@ -259,7 +259,7 @@ if (dateToNumber date < _dateLimitNum) then {
 	_others append [_canOpener, _barricade];
 
 	private _groupGunner = createGroup Rivals;
-	private _staticWeaponClass = selectRandom (_faction get "staticLowWeapons");
+	private _staticWeaponClass = selectRandomWeighted (_faction get "staticLowWeapons");
 	private _weaponPos = [_barricadePos, 7, _dirBarricade + 270] call BIS_Fnc_relPos;
 	private _weapon = createVehicle [_staticWeaponClass, _weaponPos, [], 0 , "NONE"];
 	_weapon setDir ([_weapon, _truck] call BIS_fnc_dirTo);
@@ -278,7 +278,7 @@ if (dateToNumber date < _dateLimitNum) then {
 		private _minesCount = round random [3,5,7];
 		private _mines = (_faction get "minefieldAPERS");
 		for "_i" from 1 to _minesCount do {
-			private _mineX = createMine [selectRandom _mines, _startingRoadPosition, [], 25];
+			private _mineX = createMine [selectRandomWeighted _mines, _startingRoadPosition, [], 25];
 			Rivals revealMine _mineX;
 			_vehicles pushBack _mineX;
 	#if __A3_DEBUG__

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -80,49 +80,49 @@ switch (toLowerANSI _convoyType) do
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_ammo",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_ammo";
         _taskIcon = "rearm";
-        _typeVehObj = selectRandom (_faction get "vehiclesAmmoTrucks");
+        _typeVehObj = selectRandomWeighted (_faction get "vehiclesAmmoTrucks");
     };
     case "fuel":
 	{
 		_textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_fuel",_nameOrigin,_displayTime,_nameDest];
 		_taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_fuel";
 		_taskIcon = "refuel";
-		_typeVehObj = selectRandom (_faction get "vehiclesFuelTrucks");
+		_typeVehObj = selectRandomWeighted (_faction get "vehiclesFuelTrucks");
 	};
     case "armor":
     {
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_armor",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_armor";
         _taskIcon = "destroy";
-        _typeVehObj = selectRandom (_faction get "vehiclesAA");
+        _typeVehObj = selectRandomWeighted (_faction get "vehiclesAA");
     };
     case "prisoners":
     {
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_prisoners",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_prisoners";
         _taskIcon = "run";
-        _typeVehObj = selectRandom (_faction get "vehiclesTrucks");
+        _typeVehObj = selectRandomWeighted (_faction get "vehiclesTrucks");
     };
     case "reinforcements":
     {
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_reinf",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_reinf";
         _taskIcon = "meet";
-        _typeVehObj = selectRandom (_faction get "vehiclesTrucks");
+        _typeVehObj = selectRandomWeighted (_faction get "vehiclesTrucks");
     };
     case "money":
     {
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_money",_nameOrigin,_displayTime,_nameDest];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_money";
         _taskIcon = "truck";
-        _typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
+        _typeVehObj = selectRandomWeighted (FactionGet(reb, "vehiclesCivSupply"));
     };
     case "supplies":
     {
         _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_supplies",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
         _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_supplies";
         _taskIcon = "truck";
-        _typeVehObj = selectRandom (FactionGet(reb, "vehiclesCivSupply"));
+        _typeVehObj = selectRandomWeighted (FactionGet(reb, "vehiclesCivSupply"));
     };
 };
 
@@ -265,7 +265,7 @@ for "_i" from 1 to _countX do
 
 // Lead vehicle
 sleep 2;
-private _typeVehX = selectRandom (if (_sideX == Occupants && random 4 < tierWar) then {_faction get "vehiclesPolice"} else {_faction get "vehiclesLightArmed"});
+private _typeVehX = selectRandomWeighted (if (_sideX == Occupants && random 4 < tierWar) then {_faction get "vehiclesPolice"} else {_faction get "vehiclesLightArmed"});
 private _LeadText = localize "STR_marker_convoy_lead_vehicle";
 private _vehLead = [_typeVehX, _LeadText] call _fnc_spawnConvoyVehicle;
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_ASF.sqf
@@ -25,7 +25,7 @@ private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
 private _faction = Faction(_side);
-private _vehType = selectRandom ((_faction get "vehiclesPlanesAA") + (_faction get "vehiclesPlanesLargeAA"));
+private _vehType = selectRandomWeighted ((_faction get "vehiclesPlanesAA") + (_faction get "vehiclesPlanesLargeAA"));
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 18*A3A_enemyResponseTime) };

--- a/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
@@ -25,7 +25,7 @@ private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
 private _faction = Faction(_side);
-private _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
+private _vehType = selectRandomWeighted ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (100 - _aggro + 18*A3A_enemyResponseTime) };

--- a/A3A/addons/core/functions/Supports/fn_SUP_CASDive.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CASDive.sqf
@@ -22,7 +22,7 @@ private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
 private _faction = Faction(_side);
-private _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
+private _vehType = selectRandomWeighted ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (450 - 15*tierWar - 1*_aggro) };

--- a/A3A/addons/core/functions/Supports/fn_SUP_UAV.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_UAV.sqf
@@ -24,7 +24,7 @@ params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos",
 private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
-private _planeType = selectRandom (Faction(_side) get "uavsAttack");
+private _planeType = selectRandomWeighted (Faction(_side) get "uavsAttack");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };

--- a/A3A/addons/core/functions/Supports/fn_SUP_UAVAttack.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_UAVAttack.sqf
@@ -24,7 +24,7 @@ params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos",
 private _airport = [_side, _targPos] call A3A_fnc_availableBasesAir;
 if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _supportName); -1; };
 
-private _planeType = selectRandom (Faction(_side) get "uavsAttack");
+private _planeType = selectRandomWeighted (Faction(_side) get "uavsAttack");
 
 private _aggro = if(_side == Occupants) then {aggressionOccupants} else {aggressionInvaders};
 if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };

--- a/A3A/addons/core/functions/Supports/fn_SUP_airstrike.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_airstrike.sqf
@@ -33,7 +33,7 @@ private _weightChemical = if (_side == Invaders) then {_weightCluster} else {0};
 private _bombType = selectRandomWeighted ["HE", _weightHE, "CLUSTER", _weightCluster, "NAPALM", _weightNapalm, "CHEMICAL", _weightChemical];
 
 private _faction = Faction(_side);
-private _planeType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
+private _planeType = selectRandomWeighted ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
 if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggroValue) };
 
 Debug_3("Airstrike will be carried out with aircraft type %1, bombType %2 and setup time %3", _planeType, _bombType, _delay);

--- a/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_artillery.sqf
@@ -21,7 +21,7 @@ FIX_LINE_NUMBERS()
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
 private _faction = Faction(_side);
-private _vehType = selectRandom (_faction get "vehiclesArtillery");
+private _vehType = selectRandomWeighted (_faction get "vehiclesArtillery");
 private _magPool = (_faction get "magazines") get _vehType;
 private _shellType = selectRandom _magPool;
 ([_vehType, _shellType] call A3A_fnc_getArtilleryRanges) params ["_minRange", "_maxRange"];

--- a/A3A/addons/core/functions/Supports/fn_SUP_howitzer.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_howitzer.sqf
@@ -22,7 +22,7 @@ FIX_LINE_NUMBERS()
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
 private _faction = Faction(_side);
-private _vehType = selectRandom (_faction get "staticHowitzers");
+private _vehType = selectRandomWeighted (_faction get "staticHowitzers");
 private _shellType = _faction get "howitzerMagazineHE";
 ([_vehType, _shellType] call A3A_fnc_getArtilleryRanges) params ["_minRange", "_maxRange"];
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_mortar.sqf
@@ -22,7 +22,7 @@ FIX_LINE_NUMBERS()
 params ["_supportName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_reveal", "_delay"];
 
 private _faction = Faction(_side);
-private _vehType = selectRandom (_faction get "staticMortars");
+private _vehType = selectRandomWeighted (_faction get "staticMortars");
 private _shellType = _faction get "mortarMagazineHE";
 ([_vehType, _shellType] call A3A_fnc_getArtilleryRanges) params ["_minRange", "_maxRange"];
 

--- a/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
@@ -92,44 +92,44 @@ Info("Identifying vehicle types");
 
 //Occ&Inv X vehicles
 //Antistasi Ultimate stuff
-setVar("vehiclesDropPod", OccAndInv("vehiclesDropPod"));
-setVar("vehiclesSDV", OccAndInv("vehiclesSDV"));
+setVar("vehiclesDropPod", OccAndInv("vehiclesDropPod") select {_x isEqualType ""});
+setVar("vehiclesSDV", OccAndInv("vehiclesSDV") select {_x isEqualType ""});
 ///
-setVar("vehiclesPolice", OccAndInv("vehiclesPolice"));
-setVar("vehiclesAttack", OccAndInv("vehiclesAttack"));
-setVar("vehiclesAmmoTrucks", OccAndInv("vehiclesAmmoTrucks"));
-setVar("vehiclesLightAPCs", OccAndInv("vehiclesLightAPCs") + OccAndInv("vehiclesMilitiaAPCs") + OccAndInv("vehiclesAirborne"));
-setVar("vehiclesMedical", OccAndInv("vehiclesMedical") + ((A3A_faction_civ get "vehiclesCivMedical") select {_x isEqualType ""}));
-setVar("vehiclesAPCs", OccAndInv("vehiclesAPCs") + Riv("vehiclesRivalsAPCs") + ("APC" call _fnc_extractMarketClasses));
-setVar("vehiclesIFVs", OccAndInv("vehiclesIFVs") );
-setVar("vehiclesUAVs", OccAndInv("uavsAttack")+ OccAndInv("uavsPortable") + Riv("vehiclesRivalsUavs") + ("UAV" call _fnc_extractMarketClasses));
-setVar("vehiclesAA", OccAndInv("vehiclesAA") + ("AA" call _fnc_extractMarketClasses) + Reb("vehiclesAA"));
-setVar("vehiclesArtillery", OccAndInv("vehiclesArtillery") + ("ARTILLERY" call _fnc_extractMarketClasses));
-setVar("vehiclesTanks", OccAndInv("vehiclesTanks") + Riv("vehiclesRivalsTanks") + ("TANK" call _fnc_extractMarketClasses));
-setVar("vehiclesTransportAir", OccAndInv("vehiclesHelisLight") + OccAndInv("vehiclesHelisTransport") + OccAndInv("vehiclesPlanesTransport"));
-setVar("vehiclesHelisLight", OccAndInv("vehiclesHelisLight") );
-setVar("vehiclesHelisLightAttack", OccAndInv("vehiclesHelisLightAttack") );
-setVar("vehiclesHelisAttack", OccAndInv("vehiclesHelisAttack") );
-setVar("vehiclesHelisTransport", OccAndInv("vehiclesHelisTransport") );
-setVar("vehiclesPlanesAA", OccAndInv("vehiclesPlanesAA") );
-setVar("vehiclesPlanesCAS", OccAndInv("vehiclesPlanesCAS") );
-setVar("vehiclesPlanesLargeAA", OccAndInv("vehiclesPlanesLargeAA") );
-setVar("vehiclesPlanesLargeCAS", OccAndInv("vehiclesPlanesLargeCAS") );
-setVar("vehiclesPlanesTransport", OccAndInv("vehiclesPlanesTransport"));
-setVar("vehiclesAirPatrol", OccAndInv("vehiclesAirPatrol"));
-setVar("vehiclesPlanesGunship", OccAndInv("vehiclesPlanesGunship"));
-setVar("staticMortars", OccAndInv("staticMortars") + Riv("staticMortars") + Reb("staticMortars") + ("STATICMORTAR" call _fnc_extractMarketClasses));
-setVar("staticAA", OccAndInv("staticAA") + Reb("staticAA") + ("STATICAA" call _fnc_extractMarketClasses));
-setVar("staticAT", OccAndInv("staticAT") + Reb("staticAT") + ("STATICAT" call _fnc_extractMarketClasses));
-setVar("staticMGs", OccAndInv("staticMGs") + Riv("staticLowWeapons") + Reb("staticMGs") + ("STATICMG" call _fnc_extractMarketClasses));
+setVar("vehiclesPolice", OccAndInv("vehiclesPolice") select {_x isEqualType ""});
+setVar("vehiclesAttack", OccAndInv("vehiclesAttack") select {_x isEqualType ""});
+setVar("vehiclesAmmoTrucks", OccAndInv("vehiclesAmmoTrucks") select {_x isEqualType ""});
+setVar("vehiclesLightAPCs", (OccAndInv("vehiclesLightAPCs") + OccAndInv("vehiclesMilitiaAPCs") + OccAndInv("vehiclesAirborne")) select {_x isEqualType ""});
+setVar("vehiclesMedical", (OccAndInv("vehiclesMedical") + (A3A_faction_civ get "vehiclesCivMedical")) select {_x isEqualType ""});
+setVar("vehiclesAPCs", (OccAndInv("vehiclesAPCs") + Riv("vehiclesRivalsAPCs") + ("APC" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("vehiclesIFVs", OccAndInv("vehiclesIFVs") select {_x isEqualType ""});
+setVar("vehiclesUAVs", (OccAndInv("uavsAttack")+ OccAndInv("uavsPortable") + Riv("vehiclesRivalsUavs") + ("UAV" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("vehiclesAA", (OccAndInv("vehiclesAA") + ("AA" call _fnc_extractMarketClasses) + Reb("vehiclesAA")) select {_x isEqualType ""});
+setVar("vehiclesArtillery", (OccAndInv("vehiclesArtillery") + ("ARTILLERY" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("vehiclesTanks", (OccAndInv("vehiclesTanks") + Riv("vehiclesRivalsTanks") + ("TANK" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("vehiclesTransportAir", (OccAndInv("vehiclesHelisLight") + OccAndInv("vehiclesHelisTransport") + OccAndInv("vehiclesPlanesTransport")) select {_x isEqualType ""});
+setVar("vehiclesHelisLight", OccAndInv("vehiclesHelisLight") select {_x isEqualType ""});
+setVar("vehiclesHelisLightAttack", OccAndInv("vehiclesHelisLightAttack") select {_x isEqualType ""});
+setVar("vehiclesHelisAttack", OccAndInv("vehiclesHelisAttack") select {_x isEqualType ""});
+setVar("vehiclesHelisTransport", OccAndInv("vehiclesHelisTransport") select {_x isEqualType ""});
+setVar("vehiclesPlanesAA", OccAndInv("vehiclesPlanesAA") select {_x isEqualType ""});
+setVar("vehiclesPlanesCAS", OccAndInv("vehiclesPlanesCAS") select {_x isEqualType ""});
+setVar("vehiclesPlanesLargeAA", OccAndInv("vehiclesPlanesLargeAA") select {_x isEqualType ""});
+setVar("vehiclesPlanesLargeCAS", OccAndInv("vehiclesPlanesLargeCAS") select {_x isEqualType ""});
+setVar("vehiclesPlanesTransport", OccAndInv("vehiclesPlanesTransport") select {_x isEqualType ""});
+setVar("vehiclesAirPatrol", OccAndInv("vehiclesAirPatrol") select {_x isEqualType ""});
+setVar("vehiclesPlanesGunship", OccAndInv("vehiclesPlanesGunship") select {_x isEqualType ""});
+setVar("staticMortars", (OccAndInv("staticMortars") + Riv("staticMortars") + Reb("staticMortars") + ("STATICMORTAR" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("staticAA", (OccAndInv("staticAA") + Reb("staticAA") + ("STATICAA" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("staticAT", (OccAndInv("staticAT") + Reb("staticAT") + ("STATICAT" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
+setVar("staticMGs", (OccAndInv("staticMGs") + Riv("staticLowWeapons") + Reb("staticMGs") + ("STATICMG" call _fnc_extractMarketClasses)) select {_x isEqualType ""});
 
 //Antistasi Plus stuff
-setVar("vehiclesAirborne", OccAndInv("vehiclesAirborne"));
-setVar("vehiclesLightTanks", OccAndInv("vehiclesLightTanks"));
+setVar("vehiclesAirborne", OccAndInv("vehiclesAirborne") select {_x isEqualType ""});
+setVar("vehiclesLightTanks", OccAndInv("vehiclesLightTanks") select {_x isEqualType ""});
 
-setVar("vehicleRadars", [Occ("vehicleRadar"), Inv("vehicleRadar")]);
-setVar("vehicleSams", [Occ("vehicleSam"), Inv("vehicleSam")]);
-setVar("staticHowitzers", OccAndInv("staticHowitzers"));
+setVar("vehicleRadars", [Occ("vehicleRadar"), Inv("vehicleRadar")] select {_x isEqualType ""});
+setVar("vehicleSams", [Occ("vehicleSam"), Inv("vehicleSam")] select {_x isEqualType ""});
+setVar("staticHowitzers", OccAndInv("staticHowitzers") select {_x isEqualType ""});
 
 [A3A_faction_inv, "animations"] call _fnc_setHashmap;
 [A3A_faction_occ, "animations"] call _fnc_setHashmap;
@@ -144,16 +144,16 @@ setVar("staticHowitzers", OccAndInv("staticHowitzers"));
 
 //Rivals
 private _vehRivalsArmor = Riv("vehiclesRivalsAPCs") + Riv("vehiclesRivalsTanks");
-setVar("vehiclesRivalsArmor", _vehRivalsArmor);
+setVar("vehiclesRivalsArmor", _vehRivalsArmor select {_x isEqualType ""});
 
 private _vehRivalsLight = Riv("vehiclesRivalsCars") + Riv("vehiclesRivalsLightArmed") + Riv("vehiclesRivalsTrucks");
-setVar("vehiclesRivalsLight", _vehRivalsLight);
+setVar("vehiclesRivalsLight", _vehRivalsLight select {_x isEqualType ""});
 
 private _vehRivalsStatics = Riv("staticMGs") + Riv("staticAT") + Riv("staticAA");
-setVar("vehiclesRivalsStatics", _vehRivalsStatics);
+setVar("vehiclesRivalsStatics", _vehRivalsStatics select {_x isEqualType ""});
 
 private _vehRivalsAir = Riv("vehiclesRivalsHelis");
-setVar("vehiclesRivalsAir", _vehRivalsAir);
+setVar("vehiclesRivalsAir", _vehRivalsAir select {_x isEqualType ""});
 
 private _vehRivals = Riv("vehiclesRivalsAPCs") 
 + Riv("vehiclesRivalsTanks") 
@@ -162,17 +162,17 @@ private _vehRivals = Riv("vehiclesRivalsAPCs")
 + Riv("vehiclesRivalsLightArmed") 
 + Riv("vehiclesRivalsUavs")
 + Riv("vehiclesRivalsHelis");
-setVar("vehiclesRivals", _vehRivals);
+setVar("vehiclesRivals", _vehRivals select {_x isEqualType ""});
 
 private _vehMilitia = OccAndInv("vehiclesMilitiaCars")
 + OccAndInv("vehiclesMilitiaTrucks")
 + OccAndInv("vehiclesMilitiaLightArmed")
 + OccAndInv("vehiclesMilitiaAPCs");
-setVar("vehiclesMilitia", _vehMilitia);
+setVar("vehiclesMilitia", _vehMilitia select {_x isEqualType ""});
 
 //boats
 private _vehBoats = OccAndInv("vehiclesTransportBoats") + OccAndInv("vehiclesGunBoats") + Reb("vehiclesBoat");
-setVar("vehiclesBoats", _vehBoats);
+setVar("vehiclesBoats", _vehBoats select {_x isEqualType ""});
 
 //Occ&Inv helicopters
 private _vehHelis =
@@ -181,7 +181,7 @@ OccAndInv("vehiclesHelisTransport")
 + OccAndInv("vehiclesHelisAttack")
 + OccAndInv("vehiclesHelisLight")
 + ("HELI" call _fnc_extractMarketClasses);
-setVar("vehiclesHelis", _vehHelis);
+setVar("vehiclesHelis", _vehHelis select {_x isEqualType ""});
 
 //fixed winged aircrafts
 private _vehFixedWing =
@@ -193,7 +193,7 @@ OccAndInv("vehiclesPlanesCAS")
 + Reb("vehiclesPlane")
 + Reb("vehiclesCivPlane")
 + ("PLANE" call _fnc_extractMarketClasses);
-setVar("vehiclesFixedWing", _vehFixedWing);
+setVar("vehiclesFixedWing", _vehFixedWing select {_x isEqualType ""});
 
 //trucks to carry infantry
 private _vehTrucks =
@@ -201,7 +201,7 @@ OccAndInv("vehiclesTrucks")
 + OccAndInv("vehiclesMilitiaTrucks")
 + Riv("vehiclesRivalsTrucks")
 + Reb("vehiclesTruck");
-setVar("vehiclesTrucks", _vehTrucks);
+setVar("vehiclesTrucks", _vehTrucks select {_x isEqualType ""});
 
 //Armed cars
 private _carsArmed =
@@ -210,7 +210,7 @@ OccAndInv("vehiclesLightArmed")
 + Reb("vehiclesLightArmed")
 + Riv("vehiclesRivalsLightArmed")
 + ("ARMEDCAR" call _fnc_extractMarketClasses);
-setVar("vehiclesLightArmed", _carsArmed);
+setVar("vehiclesLightArmed", _carsArmed select {_x isEqualType ""});
 
 //Unarmed cars
 private _carsUnarmed =
@@ -221,7 +221,7 @@ OccAndInv("vehiclesLightUnarmed")      // anything else?
 + ("UNARMEDCAR" call _fnc_extractMarketClasses)
 + Reb("vehiclesLightUnarmed");
 setVar("vehiclesLightUnarmed", _carsUnarmed);
-setVar("vehiclesLight", _carsArmed + _carsUnarmed);
+setVar("vehiclesLight", (_carsArmed + _carsUnarmed) select {_x isEqualType ""});
 
 //all Occ&Inv armor
 private _vehArmor =
@@ -233,7 +233,7 @@ getVar("vehiclesTanks")
 + getVar("vehiclesLightTanks")
 + getVar("vehiclesAirborne")
 + getVar("vehiclesIFVs");
-setVar("vehiclesArmor", _vehArmor);
+setVar("vehiclesArmor", _vehArmor select {_x isEqualType ""});
 
 //rebel vehicles
 private _vehReb = 
@@ -242,10 +242,10 @@ private _vehReb =
     + Reb("staticMGs") + Reb("staticAT") + Reb("staticAA") + Reb("staticMortars")
     + Reb("vehiclesHelis") + Reb("vehiclesPlane") + Reb("vehiclesMedical") + Reb("vehiclesAA")
     + (A3U_blackMarketStock apply {_x select 0});
-setVar("vehiclesReb", _vehReb);
+setVar("vehiclesReb", _vehReb select {_x isEqualType ""});
 
 //trucks that can cary logistics cargo
-private _vehCargoTrucks = (_vehTrucks + OccAndInv("vehiclesCargoTrucks")) select { [_x] call A3A_Logistics_fnc_getVehCapacity > 1 };
+private _vehCargoTrucks = (_vehTrucks + OccAndInv("vehiclesCargoTrucks")) select { _x isEqualType "" && {[_x] call A3A_Logistics_fnc_getVehCapacity > 1} };
 setVar("vehiclesCargoTrucks", _vehCargoTrucks);
 
 missionNamespace setVariable ["A3A_faction_all", A3A_faction_all, true];

--- a/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
@@ -22,7 +22,18 @@ private _dataStore = createHashMap;
 
 private _fnc_saveToTemplate = {
 	params ["_name", "_data"];
-
+	private _weightedArrays = [
+		"vehiclesSDV", "vehiclesBasic", "vehiclesLightUnarmed", "vehiclesLightArmed", "vehiclesTruck", "vehiclesTrucks", "vehiclesCargoTrucks", "vehiclesAmmoTrucks", "vehiclesRepairTrucks", "vehiclesFuelTrucks", "vehiclesMedical", "vehiclesLightAPCs", "vehiclesAPCs",
+		"vehiclesIFVs", "vehiclesTanks", "vehiclesAA", "vehiclesAirborne", "vehiclesLightTanks", "vehiclesBoat", "vehiclesTransportBoats", "vehiclesGunBoats", "vehiclesAmphibious", "vehiclesPlane", "vehiclesCivPlane", "vehiclesPlanesCAS", "vehiclesPlanesAA", "vehiclesPlanesTransport",
+		"vehiclesHelisLight", "vehiclesHelisTransport", "vehiclesHelisLightAttack", "vehiclesHelisAttack", "vehiclesAirPatrol", "vehiclesArtillery", "uavsAttack", "uavsPortable", "vehiclesMilitiaLightArmed", "vehiclesMilitiaTrucks", "vehiclesMilitiaCars", "vehiclesMilitiaAPCs", "vehiclesPolice",
+		"staticMGs", "staticAT", "staticAA", "staticMortars", "staticHowitzers", "vehicleRadar", "vehicleSAM", "minefieldAT", "minefieldAPERS",
+		"vehiclesCivCar", "vehiclesCivTruck", "vehiclesCivHeli", "vehiclesCivBoat",
+		"vehiclesRivalsLightArmed", "vehiclesRivalsTrucks", "vehiclesRivalsCars", "vehiclesRivalsAPCs", "vehiclesRivalsTanks", "vehiclesRivalsHelis", "vehiclesRivalsUavs", "staticLowWeapons"
+	];
+	if (_name in _weightedArrays) then { // * convert all data types to standard weighted list. Set weights to 1 if none given.
+		if (_data isEqualType "") then { _data = [_data] };
+		if (count _data > 0 && {isNil {_data select 1} || {(_data select 1) isEqualType ""}}) then { _data = flatten (_data apply {[_x, 1]}) };
+	};
 	_dataStore set [_name, _data];
 };
 

--- a/A3A/addons/core/functions/init/fn_initRivalsVehClassToCrew.sqf
+++ b/A3A/addons/core/functions/init/fn_initRivalsVehClassToCrew.sqf
@@ -35,20 +35,12 @@ private _allVehClassToCrew = [
 // Vehicles categories at the top have higher priority than bellow.
 // So if "Tank_F" is in both NATOLand and NATOTanks, NATOTanks should be ABOVE NATOLand, as NATOTanks is a specialised child.
     //[FactionGet(all,"vehiclesMilitia"), [FactionGet(riv,"unitRifle")]],
-    [FactionGet(all,"vehiclesRivalsArmor"),[FactionGet(riv,"unitCrew")]],
-    [FactionGet(all,"vehiclesRivalsLight"),[FactionGet(riv,"unitRifle")]],
-    [FactionGet(all,"vehiclesRivalsStatics"),[FactionGet(riv,"unitRifle")]],
-    [FactionGet(riv,"vehiclesRivalsUavs"), ["O_UAV_AI"]],
-    [FactionGet(all,"vehiclesRivalsAir"),[FactionGet(riv,"unitRifle")]],    ///why FactionGet(all and not riv? why c_man and not  FactionGet(civ,"unitMan")? why no FactionGet(inv ?
-    [FactionGet(all,"vehiclesRivals"),[FactionGet(riv,"unitRifle")]]/* ,
-
-    [FactionGet(all,"vehiclesFixedWing"),[FactionGet(riv,"unitCrew")]],
-    [FactionGet(all,"vehiclesArmor"), [FactionGet(riv,"unitCrew")]],          // <- vehiclesArmor has nested arrays; therefore, it needs to be flattened. (will change with arty template change)
-    [FactionGet(all,"vehiclesHelis"), [FactionGet(riv,"unitCrew")]],
-    [FactionGet(all,"vehicleRadars"), ["O_UAV_AI"]],
-    [FactionGet(all,"vehicleSams"), ["O_UAV_AI"]],
-    [FactionGet(all,"vehiclesUAVs"), ["O_UAV_AI"]],
-    [FactionGet(all, "vehiclesPolice"), [FactionGet(riv,"unitRifle")]]       // < vehiclesPolice is a single classname; therefore, it needs to be put into an array. */
+    [FactionGet(all,"vehiclesRivalsArmor") select {_x isEqualType ""},[FactionGet(riv,"unitCrew")]],
+    [FactionGet(all,"vehiclesRivalsLight") select {_x isEqualType ""},[FactionGet(riv,"unitRifle")]],
+    [FactionGet(all,"vehiclesRivalsStatics") select {_x isEqualType ""},[FactionGet(riv,"unitRifle")]],
+    [FactionGet(riv,"vehiclesRivalsUavs") select {_x isEqualType ""}, ["O_UAV_AI"]],
+    [FactionGet(all,"vehiclesRivalsAir") select {_x isEqualType ""},[FactionGet(riv,"unitRifle")]],    ///why FactionGet(all and not riv? why c_man and not  FactionGet(civ,"unitMan")? why no FactionGet(inv ?
+    [FactionGet(all,"vehiclesRivals") select {_x isEqualType ""},[FactionGet(riv,"unitRifle")]]
 ];
 // ⬆ STOP EDITING HERE 👋 THANK YOU, COME AGAIN ⬆
 

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -446,9 +446,9 @@ for "_i" from 0 to (count _civVehiclesWeighted - 2) step 2 do {
 	_civVehicles pushBack (_civVehiclesWeighted select _i);
 };
 
-_civVehicles append FactionGet(reb,"vehiclesCivCar");
-_civVehicles append FactionGet(reb,"vehiclesCivTruck");
-_civVehicles append FactionGet(reb,"vehiclesCivSupply");
+_civVehicles append (FactionGet(reb,"vehiclesCivCar") select {_x isEqualType ""});
+_civVehicles append (FactionGet(reb,"vehiclesCivTruck") select {_x isEqualType ""});
+_civVehicles append (FactionGet(reb,"vehiclesCivSupply") select {_x isEqualType ""});
 
 DECLARE_SERVER_VAR(arrayCivVeh, _civVehicles);
 DECLARE_SERVER_VAR(civVehiclesWeighted, _civVehiclesWeighted);
@@ -471,7 +471,7 @@ for "_i" from 0 to (count _civBoatData - 2) step 2 do {
 DECLARE_SERVER_VAR(civBoats, _civBoats);
 DECLARE_SERVER_VAR(civBoatsWeighted, _civBoatsWeighted);
 
-private _undercoverVehicles = (arrayCivVeh - ["C_Quadbike_01_F"]) + FactionGet(reb,"vehiclesCivBoat") + FactionGet(reb,"vehiclesCivHeli") + FactionGet(reb, "vehiclesCivPlane");
+private _undercoverVehicles = (arrayCivVeh - ["C_Quadbike_01_F"]) + FactionGet(reb,"vehiclesCivBoat") + FactionGet(reb,"vehiclesCivHeli") + FactionGet(reb, "vehiclesCivPlane") select {_x isEqualType ""};
 DECLARE_SERVER_VAR(undercoverVehicles, _undercoverVehicles);
 
 //////////////////////////////////////
@@ -520,7 +520,7 @@ ONLY_DECLARE_SERVER_VAR(A3A_utilityItemHM);
 //fast ropes are hard defined here, because of old fixed offsets.
 //fastrope needs to be rewritten and then we can get get ridd of this
 
-private _vehFastRope = (FactionGet(all,"vehiclesHelisTransport") + FactionGet(all,"vehiclesHelisLight") + FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesHelisLightAttack"));
+private _vehFastRope = (FactionGet(all,"vehiclesHelisTransport") + FactionGet(all,"vehiclesHelisLight") + FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesHelisLightAttack")) select {_x isEqualType ""};
 
 //private _vehFastRope = ["O_Heli_Light_02_unarmed_F","B_Heli_Transport_01_camo_F","RHS_UH60M_d","UK3CB_BAF_Merlin_HC3_18_GPMG_DDPM_RM","UK3CB_BAF_Merlin_HC3_18_GPMG_Tropical_RM","RHS_Mi8mt_vdv","RHS_Mi8mt_vv","RHS_Mi8mt_Cargo_vv"];
 DECLARE_SERVER_VAR(vehFastRope, _vehFastRope);
@@ -531,36 +531,36 @@ DECLARE_SERVER_VAR(A3A_RivalsVehClassToCrew,call A3A_fnc_initRivalsVehClassToCre
 // Default vehicle resource costs
 private _vehicleResourceCosts = createHashMap;
 
-{ _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars");
-{ _vehicleResourceCosts set [_x, 20] } forEach FactionGet(all, "vehiclesLightUnarmed") + FactionGet(all, "vehiclesTrucks");
-{ _vehicleResourceCosts set [_x, 50] } forEach FactionGet(all, "vehiclesLightArmed");
-{ _vehicleResourceCosts set [_x, 70] } forEach FactionGet(all, "vehiclesLightAPCs");
-{ _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesAPCs");
-{ _vehicleResourceCosts set [_x, 150] } forEach FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs");
-{ _vehicleResourceCosts set [_x, 170] } forEach FactionGet(all, "vehiclesLightTanks");
-{ _vehicleResourceCosts set [_x, 230] } forEach FactionGet(all, "vehiclesTanks");
+{ _vehicleResourceCosts set [_x, 20] } forEach ((FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 20] } forEach ((FactionGet(all, "vehiclesLightUnarmed") + FactionGet(all, "vehiclesTrucks")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 50] } forEach (FactionGet(all, "vehiclesLightArmed") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 70] } forEach (FactionGet(all, "vehiclesLightAPCs") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 100] } forEach (FactionGet(all, "vehiclesAPCs") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 150] } forEach ((FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 170] } forEach (FactionGet(all, "vehiclesLightTanks") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 230] } forEach (FactionGet(all, "vehiclesTanks") select {_x isEqualType ""});
 
-{ _vehicleResourceCosts set [_x, 70] } forEach FactionGet(all, "vehiclesHelisLight") + FactionGet(all, "vehiclesAirPatrol");
-{ _vehicleResourceCosts set [_x, 100] } forEach FactionGet(all, "vehiclesHelisTransport");
-{ _vehicleResourceCosts set [_x, 130] } forEach FactionGet(all, "vehiclesHelisLightAttack") + FactionGet(all, "vehiclesPlanesTransport");
-{ _vehicleResourceCosts set [_x, 150] } forEach FactionGet(all, "vehiclesDropPod") + FactionGet(all, "uavsAttack");
-{ _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesPlanesCAS") + FactionGet(all, "vehiclesPlanesAA");
-{ _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesHelisAttack");
-{ _vehicleResourceCosts set [_x, 275] } forEach FactionGet(all, "vehiclesPlanesGunship");
-{ _vehicleResourceCosts set [_x, 250] } forEach FactionGet(all, "vehiclesPlanesLargeCAS") + FactionGet(all, "vehiclesPlanesLargeAA");
+{ _vehicleResourceCosts set [_x, 70] } forEach ((FactionGet(all, "vehiclesHelisLight") + FactionGet(all, "vehiclesAirPatrol")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 100] } forEach (FactionGet(all, "vehiclesHelisTransport") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 130] } forEach ((FactionGet(all, "vehiclesHelisLightAttack") + FactionGet(all, "vehiclesPlanesTransport")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 150] } forEach ((FactionGet(all, "vehiclesDropPod") + FactionGet(all, "uavsAttack")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 250] } forEach ((FactionGet(all, "vehiclesPlanesCAS") + FactionGet(all, "vehiclesPlanesAA")) select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 250] } forEach (FactionGet(all, "vehiclesHelisAttack") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 275] } forEach (FactionGet(all, "vehiclesPlanesGunship") select {_x isEqualType ""});
+{ _vehicleResourceCosts set [_x, 250] } forEach ((FactionGet(all, "vehiclesPlanesLargeCAS") + FactionGet(all, "vehiclesPlanesLargeAA")) select {_x isEqualType ""});
 
 // Threat table
 private _groundVehicleThreat = createHashMap;
 
-{ _groundVehicleThreat set [_x, 40] } forEach FactionGet(all, "staticMGs");
-{ _groundVehicleThreat set [_x, 60] } forEach FactionGet(all, "vehiclesLightArmed");
-{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars");
-{ _groundVehicleThreat set [_x, 80] } forEach FactionGet(Reb, "vehiclesAA") + FactionGet(Reb, "vehiclesAT");
-{ _groundVehicleThreat set [_x, 90] } forEach FactionGet(all, "vehiclesLightAPCs");
-{ _groundVehicleThreat set [_x, 120] } forEach FactionGet(all, "vehiclesAPCs");
-{ _groundVehicleThreat set [_x, 180] } forEach FactionGet(all, "vehiclesLightTanks");
-{ _groundVehicleThreat set [_x, 200] } forEach FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs");
-{ _groundVehicleThreat set [_x, 300] } forEach FactionGet(all, "vehiclesTanks");
+{ _groundVehicleThreat set [_x, 40] } forEach (FactionGet(all, "staticMGs") select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 60] } forEach (FactionGet(all, "vehiclesLightArmed") select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 80] } forEach ((FactionGet(all, "staticAA") + FactionGet(all, "staticAT") + FactionGet(all, "staticMortars")) select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 80] } forEach ((FactionGet(Reb, "vehiclesAA") + FactionGet(Reb, "vehiclesAT")) select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 90] } forEach (FactionGet(all, "vehiclesLightAPCs") select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 120] } forEach (FactionGet(all, "vehiclesAPCs") select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 180] } forEach (FactionGet(all, "vehiclesLightTanks") select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 200] } forEach ((FactionGet(all, "vehiclesAA") + FactionGet(all, "vehiclesArtillery") + FactionGet(all, "vehiclesIFVs")) select {_x isEqualType ""});
+{ _groundVehicleThreat set [_x, 300] } forEach (FactionGet(all, "vehiclesTanks") select {_x isEqualType ""});
 
 
 // Rebel vehicle cost
@@ -575,20 +575,20 @@ _fnc_setPriceIfValid =
 	};
 };
 
-{ [_rebelVehicleCosts, _x, 100] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBasic");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat");
-{ [_rebelVehicleCosts, _x, 600] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivTruck") + FactionGet(reb, "vehiclesMedical");
-{ [_rebelVehicleCosts, _x, 300] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesTruck");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightUnarmed");
-{ [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightArmed");
-{ [_rebelVehicleCosts, _x, 500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMGs") + FactionGet(reb, "vehiclesBoat");
-{ [_rebelVehicleCosts, _x, 1000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT");
-{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAA");
-{ [_rebelVehicleCosts, _x, 2500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMortars");
-{ [_rebelVehicleCosts, _x, 1500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAA");
-{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAT");
-{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivHeli");
-{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane");
+{ [_rebelVehicleCosts, _x, 100] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesBasic") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach ((FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat")) select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 600] call _fnc_setPriceIfValid } forEach ((FactionGet(reb, "vehiclesCivTruck") + FactionGet(reb, "vehiclesMedical")) select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 300] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesTruck") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesLightUnarmed") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesLightArmed") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 500] call _fnc_setPriceIfValid } forEach ((FactionGet(reb, "staticMGs") + FactionGet(reb, "vehiclesBoat")) select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 1000] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "staticAT") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "staticAA") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 2500] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "staticMortars") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 1500] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesAA") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesAT") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach (FactionGet(reb, "vehiclesCivHeli") select {_x isEqualType ""});
+{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach ((FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane")) select {_x isEqualType ""});
 
 
 // Template overrides

--- a/A3A/addons/core/functions/init/fn_initVehClassToCrew.sqf
+++ b/A3A/addons/core/functions/init/fn_initVehClassToCrew.sqf
@@ -42,13 +42,13 @@ private _allVehClassToCrew = [
     [FactionGet(all,"vehiclesRivalsAir"),[FactionGet(occ,"unitPilot"), FactionGet(inv,"unitPilot"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]], //FactionGet(riv,"unitRifle"),    ///why FactionGet(all and not riv? why c_man and not  FactionGet(civ,"unitMan")? why no FactionGet(inv ?
     [FactionGet(all,"vehiclesRivals"),[FactionGet(occ,"unitRifle"), FactionGet(inv,"unitRifle"), FactionGet(reb,"unitRifle"), FactionGet(civ,"unitMan")]], //FactionGet(riv,"unitRifle"), */
 
-    [FactionGet(all,"vehiclesFixedWing"),[FactionGet(occ,"unitPilot"), FactionGet(inv,"unitPilot"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],
-    [FactionGet(all,"vehiclesArmor"), [FactionGet(occ,"unitCrew"), FactionGet(inv,"unitCrew"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],          // <- vehiclesArmor has nested arrays; therefore, it needs to be flattened. (will change with arty template change)
-    [FactionGet(all,"vehiclesHelis"), [FactionGet(occ,"unitPilot"), FactionGet(inv,"unitPilot"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],
-    [FactionGet(all,"vehicleRadars"), ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
-    [FactionGet(all,"vehicleSams"), ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
-    [FactionGet(all,"vehiclesUAVs"), ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
-    [FactionGet(all, "vehiclesPolice"), [FactionGet(occ,"unitPoliceGrunt"), FactionGet(inv,"unitPoliceGrunt"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]]       // < vehiclesPolice is a single classname; therefore, it needs to be put into an array.
+    [FactionGet(all,"vehiclesFixedWing") select {_x isEqualType ""},[FactionGet(occ,"unitPilot"), FactionGet(inv,"unitPilot"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],
+    [FactionGet(all,"vehiclesArmor") select {_x isEqualType ""}, [FactionGet(occ,"unitCrew"), FactionGet(inv,"unitCrew"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],          // <- vehiclesArmor has nested arrays; therefore, it needs to be flattened. (will change with arty template change)
+    [FactionGet(all,"vehiclesHelis") select {_x isEqualType ""}, [FactionGet(occ,"unitPilot"), FactionGet(inv,"unitPilot"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]],
+    [FactionGet(all,"vehicleRadars") select {_x isEqualType ""}, ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
+    [FactionGet(all,"vehicleSams") select {_x isEqualType ""}, ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
+    [FactionGet(all,"vehiclesUAVs") select {_x isEqualType ""}, ["B_UAV_AI", "O_UAV_AI", "I_UAV_AI", "C_UAV_AI"]],
+    [FactionGet(all, "vehiclesPolice") select {_x isEqualType ""}, [FactionGet(occ,"unitPoliceGrunt"), FactionGet(inv,"unitPoliceGrunt"), FactionGet(reb,"unitCrew"), FactionGet(civ,"unitMan")]]       // < vehiclesPolice is a single classname; therefore, it needs to be put into an array.
 
 ];
 // ⬆ STOP EDITING HERE 👋 THANK YOU, COME AGAIN ⬆

--- a/A3A/addons/scrt/Common/fn_common_paradropVehicle.sqf
+++ b/A3A/addons/scrt/Common/fn_common_paradropVehicle.sqf
@@ -108,7 +108,7 @@ if(_plane getVariable ["dropPosReached", false] && {!(_plane getVariable ["plane
 
     private _dir = getDir _plane;
     private _initialPos = (getPos _plane) vectorAdd [0, 0, -6.5];
-    private _apcClass =  selectRandom (_faction get "vehiclesAirborne");
+    private _apcClass =  selectRandomWeighted (_faction get "vehiclesAirborne");
 
     private _apcData = [_initialPos, _dir, _apcClass, _side] call A3A_fnc_spawnVehicle;
     private _apc = _apcData select 0;

--- a/A3A/addons/scrt/Encounter/fn_encounter_HeliSlingloadCargo.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_HeliSlingloadCargo.sqf
@@ -54,7 +54,7 @@ private _spawnPosition = selectRandom _potentialspawnPosition;
 
 private _actualspawnPosition = getMarkerPos _spawnPosition;
 
-private _HeliClass = selectRandom (_faction get "vehiclesHelisTransport");
+private _HeliClass = selectRandomWeighted (_faction get "vehiclesHelisTransport");
 private _ammoBoxType = _faction get "ammobox";
 
 if (_HeliClass == "") exitWith {
@@ -88,11 +88,9 @@ private _attempts = 15;
 
 if (_HeliClass == "O_Heli_Transport_04_F") then {
 	_HeliClass = "O_Heli_Transport_04_F";
-	/* _lootcrateType = selectRandom ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + 
-	(_faction get "vehiclesAA") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (selectRandom _csatPods)); */
 	while {_attempts != 0} do {
-		private _csatPods = ["Land_Pod_Heli_Transport_04_covered_F" , "Land_Pod_Heli_Transport_04_bench_F" , "Land_Pod_Heli_Transport_04_medevac_F" , "Land_Pod_Heli_Transport_04_repair_F", "Land_Pod_Heli_Transport_04_fuel_F" , "Land_Pod_Heli_Transport_04_ammo_F" , "Land_Pod_Heli_Transport_04_box_F"];
-		_lootcrateType = selectRandom ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + (_faction get "vehiclesAA") + (_faction get "vehiclesLightTanks") + 
+		private _csatPods = ["Land_Pod_Heli_Transport_04_covered_F", 1, "Land_Pod_Heli_Transport_04_bench_F", 1, "Land_Pod_Heli_Transport_04_medevac_F", 1, "Land_Pod_Heli_Transport_04_repair_F", 1, "Land_Pod_Heli_Transport_04_fuel_F", 1, "Land_Pod_Heli_Transport_04_ammo_F", 1, "Land_Pod_Heli_Transport_04_box_F", 1];
+		_lootcrateType = selectRandomWeighted ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + (_faction get "vehiclesAA") + (_faction get "vehiclesLightTanks") + 
 		(_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + _csatPods);
 		_lootCrate = _lootcrateType createVehicle _actualspawnPosition;
 		deleteVehicle _lootCrate;
@@ -149,12 +147,9 @@ if (_HeliClass == "O_Heli_Transport_04_F") then {
 		_lootCrate addEventHandler ["Killed", { [_this#0] spawn { sleep 10; deleteVehicle (_this#0) } }];
 	};
 } else {
-	//if (_HeliClass typeOf "Heli_Transport_03_base_F") then {
-	/* _lootcrateType = selectRandom ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + (_faction get "vehiclesAA") + 
-	(_faction get "vehiclesLightTanks") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + (selectRandom _regPods)); ///light armored vehicles + light tanks + pods */
 	while {_attempts != 0 } do {
-		private _regPods = ["B_Slingload_01_Cargo_F", "B_Slingload_01_Ammo_F", "B_Slingload_01_Medevac_F", "B_Slingload_01_Repair_F", "B_Slingload_01_Fuel_F"];
-		_lootcrateType = selectRandom ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + 
+		private _regPods = ["B_Slingload_01_Cargo_F", 1, "B_Slingload_01_Ammo_F", 1, "B_Slingload_01_Medevac_F", 1, "B_Slingload_01_Repair_F", 1, "B_Slingload_01_Fuel_F", 1];
+		_lootcrateType = selectRandomWeighted ((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + 
 		(_faction get "vehiclesAA") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesMilitiaAPCs") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs") + _regPods);
 		_lootCrate = _lootcrateType createVehicle _actualspawnPosition;
 		deleteVehicle _lootCrate;

--- a/A3A/addons/scrt/Encounter/fn_encounter_frontlineSkirmish.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_frontlineSkirmish.sqf
@@ -62,8 +62,8 @@ private _fnc_spawngroups = {
 		_wp setWaypointSpeed "NORMAL";
 		_wp setWaypointType "SAD";
 		_InfGroups pushBack _InfGroup;
-		private _vehicles = if (_difficult) then {selectRandom ((_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs"))
-					} else {selectRandom
+		private _vehicles = if (_difficult) then {selectRandomWeighted ((_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs"))
+					} else {selectRandomWeighted
 					((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesMilitiaAPCs") + 
 					(_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars"))
 		};///add a check for a crew or vehicle type, if met order getout because weak vehicle or unarmed.
@@ -76,7 +76,7 @@ private _fnc_spawngroups = {
 		_vehiclegroup setBehaviourStrong "AWARE";
 		units _vehiclegroup join _InfGroup;
 		if (_difficult) then {
-			_UAVtype = selectRandom (_faction get "uavsPortable");
+			_UAVtype = selectRandomWeighted (_faction get "uavsPortable");
 			_uav = createVehicle [_UAVtype, _skirmishpositionActuall, [], 0, "FLY"];
 			[_side, _uav] call A3A_fnc_createVehicleCrew;
 			_vehiclesArray pushBack _uav;
@@ -97,8 +97,8 @@ private _fnc_spawngroups = {
 		_wp setWaypointType "SAD";
 		_InfGroups2 pushBack _InfGroup2;
 
-		private _vehicles2 = if (_difficult2) then {selectRandom ((_faction2 get "vehiclesAirborne") + (_faction2 get "vehiclesLightTanks") + (_faction2 get "vehiclesTanks") + (_faction2 get "vehiclesAPCs") + (_faction2 get "vehiclesIFVs"))
-					} else {selectRandom
+		private _vehicles2 = if (_difficult2) then {selectRandomWeighted ((_faction2 get "vehiclesAirborne") + (_faction2 get "vehiclesLightTanks") + (_faction2 get "vehiclesTanks") + (_faction2 get "vehiclesAPCs") + (_faction2 get "vehiclesIFVs"))
+					} else {selectRandomWeighted
 					((_faction2 get "vehiclesLightUnarmed") + (_faction2 get "vehiclesLightArmed") + (_faction2 get "vehiclesAirborne") + (_faction2 get "vehiclesLightTanks") + (_faction2 get "vehiclesMilitiaAPCs") + 
 					(_faction2 get "vehiclesMilitiaLightArmed") + (_faction2 get "vehiclesMilitiaCars"))
 		};

--- a/A3A/addons/scrt/Encounter/fn_encounter_police.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_police.sqf
@@ -38,7 +38,7 @@ private _roadcon = roadsConnectedto (_road select 0);
 private _dirveh = if(count _roadcon > 0) then {[_road select 0, _roadcon select 0] call BIS_fnc_dirTo} else {random 360};
 private _roadPosition = getPos (_road select 0);
 
-private _policeVehicleClass = selectRandom (A3A_faction_occ get "vehiclesPolice");
+private _policeVehicleClass = selectRandomWeighted (A3A_faction_occ get "vehiclesPolice");
 
 private _policeVehicleData = [(getPos (_road select 0)), _dirveh, _policeVehicleClass, Occupants] call A3A_fnc_spawnVehicle;
 private _policeVehicle = _policeVehicleData select 0;

--- a/A3A/addons/scrt/Encounter/fn_encounter_postAmbush.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_postAmbush.sqf
@@ -45,9 +45,9 @@ private _faction = Faction(_side);
 
 private _isFia = if (random 10 > (tierWar + difficultyCoef)) then {true} else {false};
 private _vehicleClass = if (_isFia) then {
-    selectRandom ((_faction get "vehiclesMilitiaLightArmed") +  (_faction get "vehiclesMilitiaAPCs"));
+    selectRandomWeighted ((_faction get "vehiclesMilitiaLightArmed") +  (_faction get "vehiclesMilitiaAPCs"));
 } else {
-    selectRandom ((_faction get "vehiclesAPCs") +  (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesLightArmed"));
+    selectRandomWeighted ((_faction get "vehiclesAPCs") +  (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesLightArmed"));
 };
 
 if (_vehicleClass == "") exitWith {

--- a/A3A/addons/scrt/Encounter/fn_encounter_vehicleMove.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_vehicleMove.sqf
@@ -47,7 +47,7 @@ private _roadcon = roadsConnectedto (_road select 0);
 private _dirveh = if (count _roadcon > 0) then {[_road select 0, _roadcon select 0] call BIS_fnc_dirTo} else {random 360};
 private _roadPosition = getPos (_road select 0);
 
-private _truckClass = selectRandom ((_faction get "vehiclesAmmoTrucks") + (_faction get "vehiclesRepairTrucks") + (_faction get "vehiclesFuelTrucks") + (_faction get "vehiclesMedical"));
+private _truckClass = selectRandomWeighted ((_faction get "vehiclesAmmoTrucks") + (_faction get "vehiclesRepairTrucks") + (_faction get "vehiclesFuelTrucks") + (_faction get "vehiclesMedical"));
 
 if (_truckClass == "") exitWith {
     Error("No trucks, problems with template, aborting Vehicle Move Event.");

--- a/A3A/addons/scrt/Encounter/fn_encounter_vehiclePatrol.sqf
+++ b/A3A/addons/scrt/Encounter/fn_encounter_vehiclePatrol.sqf
@@ -45,9 +45,9 @@ private _faction = Faction(_side);
 
 private _isFia = if (random 10 > (tierWar + difficultyCoef)) then {true} else {false};
 private _vehicleClass = if (_isFia) then {
-    selectRandom ((_faction get "vehiclesMilitiaLightArmed") +  (_faction get "vehiclesMilitiaAPCs"));
+    selectRandomWeighted ((_faction get "vehiclesMilitiaLightArmed") +  (_faction get "vehiclesMilitiaAPCs"));
 } else {
-    selectRandom ((_faction get "vehiclesAPCs") +  (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesLightArmed"));
+    selectRandomWeighted ((_faction get "vehiclesAPCs") +  (_faction get "vehiclesIFVs") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesLightArmed"));
 };
 
 if (_vehicleClass == "") exitWith {

--- a/A3A/addons/scrt/Garrison/fn_garrison_rollOversizeVehicle.sqf
+++ b/A3A/addons/scrt/Garrison/fn_garrison_rollOversizeVehicle.sqf
@@ -20,7 +20,7 @@ if ((random 100) < _oversizeChance) then {
     } else {
         (_faction get "vehiclesAPCs") + (_faction get "vehiclesLightArmed") +  (_faction get "vehiclesIFVs")
     };
-    private _selectedVehicle = selectRandom _vehiclePool;
+    private _selectedVehicle = selectRandomWeighted _vehiclePool;
 
     if (!isNil "_selectedVehicle") then {
         private _road = nil;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAaDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAaDistance.sqf
@@ -8,7 +8,7 @@ if (!isServer and hasInterface) exitWith {};
 private _positionX = getMarkerPos _markerX;
 private _garrison = garrison getVariable [_markerX, []];
 
-private _aaClass = selectRandom (A3A_faction_reb get "staticAA");
+private _aaClass = selectRandomWeighted (A3A_faction_reb get "staticAA");
 
 private _props = [];
 

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAtDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAtDistance.sqf
@@ -8,7 +8,7 @@ if (!isServer and hasInterface) exitWith {};
 private _positionX = getMarkerPos _markerX;
 private _garrison = garrison getVariable [_markerX, []];
 
-private _atClass = selectRandom (A3A_faction_reb get "staticAT");
+private _atClass = selectRandomWeighted (A3A_faction_reb get "staticAT");
 
 private _props = [];
 

--- a/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
@@ -23,7 +23,7 @@ private _taskId = "outpostTask" + str A3A_taskCount;
 
 private _riflemanType = A3A_faction_reb get "unitRifle";
 private _squadType = A3A_faction_reb get "groupSquad";
-private _truckType = selectRandom (A3A_faction_reb get "vehiclesTruck");
+private _truckType = selectRandomWeighted (A3A_faction_reb get "vehiclesTruck");
 
 _formatX = [_riflemanType] + _squadType;
 

--- a/A3A/addons/scrt/Rivals/fn_rivals_chooseGroupToSpawn.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_chooseGroupToSpawn.sqf
@@ -39,7 +39,7 @@ private _groupAndVehicleToSpawn = switch (inactivityLevelRivals) do {
 		};
 
 		private _vehicle = if (random 100 < (((100 - 20 * inactivityLevelRivals) - 10) max 0)) then {
-			selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+			selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 		} else {
 			""
 		};
@@ -55,14 +55,14 @@ private _groupAndVehicleToSpawn = switch (inactivityLevelRivals) do {
 
 		private _vehicle = switch (true) do {
             case ((random 100) < 25): {
-				selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+				selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 			};
 			case ((random 100) < 15): {
 				private _apcs = A3A_faction_riv get "vehiclesRivalsAPCs";
 				if (_apcs isEqualTo []) then {
-					selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+					selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 				} else {
-					selectRandom _apcs;
+					selectRandomWeighted _apcs;
 				};
 			};
 			default {
@@ -76,14 +76,14 @@ private _groupAndVehicleToSpawn = switch (inactivityLevelRivals) do {
 		private _group = selectRandom (A3A_faction_riv get "groupsSquad");
 		private _vehicle = switch (true) do {
 			case ((random 100) < 35): {
-				selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+				selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 			};
             case ((random 100) < 25): {
 				private _apcs = A3A_faction_riv get "vehiclesRivalsAPCs";
 				if (_apcs isEqualTo []) then {
-					selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+					selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 				} else {
-					selectRandom _apcs;
+					selectRandomWeighted _apcs;
 				};
 			};
             case ((random 100) < 15): {
@@ -92,13 +92,13 @@ private _groupAndVehicleToSpawn = switch (inactivityLevelRivals) do {
 
 				switch (true) do {
 					case (_tanks isNotEqualTo []): {
-						selectRandom _tanks;
+						selectRandomWeighted _tanks;
 					};
 					case (_apcs isNotEqualTo []): {
-						selectRandom _apcs;
+						selectRandomWeighted _apcs;
 					};
 					default {
-						selectRandom (A3A_faction_riv get "vehiclesRivalsLightArmed");
+						selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsLightArmed");
 					};
 				};
 			};

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
@@ -53,8 +53,8 @@ private _fnc_spawngroups = {
 		_wp setWaypointType "SAD";
 		_InfGroups pushBack _InfGroup;
 
-		private _vehicles = if (_difficult) then {selectRandom ((_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs"))
-					} else {selectRandom
+		private _vehicles = if (_difficult) then {selectRandomWeighted ((_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesTanks") + (_faction get "vehiclesAPCs") + (_faction get "vehiclesIFVs"))
+					} else {selectRandomWeighted
 					((_faction get "vehiclesLightUnarmed") + (_faction get "vehiclesLightArmed") + (_faction get "vehiclesAirborne") + (_faction get "vehiclesLightTanks") + (_faction get "vehiclesMilitiaAPCs") + 
 					(_faction get "vehiclesMilitiaLightArmed") + (_faction get "vehiclesMilitiaCars"))
 		};///add a check for a crew or vehicle type, if met order getout because weak vehicle or unarmed.
@@ -66,7 +66,7 @@ private _fnc_spawngroups = {
 		_vehiclegroup setBehaviourStrong "AWARE";
 		units _vehiclegroup join _InfGroup;
 		if (_difficult) then {
-			_UAVtype = selectRandom (_faction get "uavsPortable");
+			_UAVtype = selectRandomWeighted (_faction get "uavsPortable");
 			_uav = createVehicle [_UAVtype, _skirmishpositionActuall, [], 0, "FLY"];
 			[_side, _uav] call A3A_fnc_createVehicleCrew;
 			_vehiclesArray pushBack _uav;
@@ -87,7 +87,7 @@ private _fnc_spawngroups = {
 		_wp setWaypointType "SAD";
 		_Rivalsgroups pushBack _Rivalsgroup;
 
-		private _vehicles2 = if (_difficult2) then {selectRandom ((A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"))} else {selectRandom ((A3A_faction_riv get "vehiclesRivalsCars") + 
+		private _vehicles2 = if (_difficult2) then {selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsAPCs") + (A3A_faction_riv get "vehiclesRivalsTanks"))} else {selectRandomWeighted ((A3A_faction_riv get "vehiclesRivalsCars") + 
 		(A3A_faction_riv get "vehiclesRivalsLightArmed") + (A3A_faction_riv get "vehiclesRivalsTrucks"))};
 		diag_log _vehicles2;
 		_vehicledata2 = [_skirmishpositionActuall2, 0,_vehicles2, _side2] call A3A_fnc_RivalsSpawnVehicle;

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_heliRaid.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_heliRaid.sqf
@@ -64,7 +64,7 @@ private _fnc_notifyPlayers = {
 
 	_spawnPosition pushBack ((_spawnPosition select 2) + _height);
 
-	private _heli = createVehicle [selectRandom (A3A_faction_riv get "vehiclesRivalsHelis"), _spawnPosition, [], 0, "FLY"];
+	private _heli = createVehicle [selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsHelis"), _spawnPosition, [], 0, "FLY"];
 	private _angle =  [_spawnPosition,_originPosition] call BIS_fnc_dirTo;
 	_heli setDir _angle;
 

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_rovingMortar.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_rovingMortar.sqf
@@ -90,7 +90,7 @@ if (count _sites > 0 && {_sites findIf {private _markerPos = getMarkerPos _x; _m
     };
 };
 
-private _mortar = [selectRandom (A3A_faction_riv get "staticMortars"), _spawnPosition, 5, 5, true] call A3A_fnc_safeVehicleSpawn;
+private _mortar = [selectRandomWeighted (A3A_faction_riv get "staticMortars"), _spawnPosition, 5, 5, true] call A3A_fnc_safeVehicleSpawn;
 [_mortar, Rivals] call A3A_fnc_AIVEHinit;
 _vehicles pushBack _mortar;
 
@@ -115,7 +115,7 @@ private _patrolPosition = [
 ] call BIS_fnc_findSafePos;
 
 private _carPos =  [_spawnPosition, (random [4,6,8]), (random 360)] call BIS_fnc_relPos;
-private _car = (selectRandom (A3A_faction_riv get "vehiclesRivalsCars")) createVehicle _spawnPosition;
+private _car = (selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsCars")) createVehicle _spawnPosition;
 private _dirCar = [_mortar, _car] call BIS_fnc_dirTo;
 _car setDir _dirCar + (random 90);
 [_car, Rivals] call A3A_fnc_AIVEHinit;

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_uavFlyby.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_uavFlyby.sqf
@@ -91,7 +91,7 @@ for "_i" from 0 to _uavQuantity - 1 do {
 
 	_spawnPosition pushBack ((_spawnPosition select 2) + _height);
 
-	private _uav = createVehicle [selectRandom (A3A_faction_riv get "vehiclesRivalsUavs"), _spawnPosition, [], 0, "FLY"];
+	private _uav = createVehicle [selectRandomWeighted (A3A_faction_riv get "vehiclesRivalsUavs"), _spawnPosition, [], 0, "FLY"];
 	private _angle =  [_spawnPosition,_originPosition] call BIS_fnc_dirTo;
 	_uav setDir _angle;
 

--- a/A3A/addons/scrt/Support/fn_support_lootHeli.sqf
+++ b/A3A/addons/scrt/Support/fn_support_lootHeli.sqf
@@ -14,7 +14,7 @@ private _intermediatePosition = [_positionDestination, 200, _angle] call BIS_fnc
 private _originPosition = [_positionOrigin, 1500, _angleOrigin] call BIS_fnc_relPos;
 private _finPosition = [_positionDestination, 1500, _angle] call BIS_fnc_relPos;
 
-private _heliType = selectRandom (A3A_faction_reb getOrDefault ["vehiclesCivHeli", []]);
+private _heliType = selectRandomWeighted (A3A_faction_reb getOrDefault ["vehiclesCivHeli", []]);
 private _heliData = [_originPosition, _angle, _heliType, teamPlayer] call A3A_fnc_spawnVehicle;
 private _heli = _heliData select 0;
 private _heliCrew = _heliData select 1;

--- a/A3A/addons/scrt/Support/fn_support_planePayloadedRun.sqf
+++ b/A3A/addons/scrt/Support/fn_support_planePayloadedRun.sqf
@@ -6,7 +6,7 @@ private _angleOrigin = _angle - 180;
 private _originPosition = [_positionOrigin, 2500, _angleOrigin] call BIS_fnc_relPos;
 private _finPosition = [_positionDestination, 2500, _angle] call BIS_fnc_relPos;
 
-private _planeData = [_originPosition, _angle, selectRandom (A3A_faction_reb get "vehiclesPlane"), teamPlayer] call A3A_fnc_spawnVehicle;
+private _planeData = [_originPosition, _angle, selectRandomWeighted (A3A_faction_reb get "vehiclesPlane"), teamPlayer] call A3A_fnc_spawnVehicle;
 private _plane = _planeData select 0;
 private _planeCrew = _planeData select 1;
 private _groupPlane = _planeData select 2;
@@ -34,7 +34,7 @@ switch (supportType) do {
 		_text = localize "STR_comms_mp_supply";
 	};
 	case ("VEH_AIRDROP"): {
-		_wp1 setWaypointStatements ["true", format ["if !(local this) exitWith {}; [this, '%1', '%2'] spawn SCRT_fnc_common_supplyDrop", selectRandom (A3A_faction_reb get "vehiclesBasic"), supportType]];
+		_wp1 setWaypointStatements ["true", format ["if !(local this) exitWith {}; [this, '%1', '%2'] spawn SCRT_fnc_common_supplyDrop", selectRandomWeighted (A3A_faction_reb get "vehiclesBasic"), supportType]];
 		_text = localize "STR_comms_mp_light_veh";
 	};
 	case ("NAPALM");

--- a/A3A/addons/scrt/Support/fn_support_planeReconRun.sqf
+++ b/A3A/addons/scrt/Support/fn_support_planeReconRun.sqf
@@ -6,7 +6,7 @@ private _angleOrigin = _angle - 180;
 private _originPosition = [_positionOrigin, 2500, _angleOrigin] call BIS_fnc_relPos;
 private _finPosition = [_positionDestination, 2500, _angle] call BIS_fnc_relPos;
 
-private _planeData = [_originPosition, _angle, selectRandom (A3A_faction_reb get "vehiclesPlane"), teamPlayer] call A3A_fnc_spawnVehicle;
+private _planeData = [_originPosition, _angle, selectRandomWeighted (A3A_faction_reb get "vehiclesPlane"), teamPlayer] call A3A_fnc_spawnVehicle;
 private _plane = _planeData select 0;
 private _planeCrew = _planeData select 1;
 private _groupPlane = _planeData select 2;

--- a/A3A/addons/scrt/UI/fn_ui_populateVehicleBox.sqf
+++ b/A3A/addons/scrt/UI/fn_ui_populateVehicleBox.sqf
@@ -14,9 +14,9 @@ switch (_category) do {
         private _civilianVehicles = 
 			(A3A_faction_reb get 'vehiclesCivCar') +
 			(A3A_faction_reb get 'vehiclesCivTruck') +
-			(A3A_faction_reb get 'vehiclesCivBoat') select {_x isNotEqualTo ""};
+			(A3A_faction_reb get 'vehiclesCivBoat') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 		
-		private _civAircrafts = (A3A_faction_reb get "vehiclesCivHeli") + (A3A_faction_reb get 'vehiclesCivPlane');
+		private _civAircrafts = ((A3A_faction_reb get "vehiclesCivHeli") + (A3A_faction_reb get 'vehiclesCivPlane')) select {_x isEqualType ""};
 		if (_civAircrafts isNotEqualTo [] && {{sidesX getVariable [_x,sideUnknown] isEqualTo teamPlayer} count airportsX > 0}) then {
 			_civilianVehicles append _civAircrafts;
 		};
@@ -25,26 +25,26 @@ switch (_category) do {
 		_vehicleClasses = _civilianVehicles;
     };
 	case "civcars": {
-        private _civilianVehicles = (A3A_faction_reb get 'vehiclesCivCar') select {_x isNotEqualTo ""};
+        private _civilianVehicles = (A3A_faction_reb get 'vehiclesCivCar') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 
 		_isCivilian = true;
 		_vehicleClasses = _civilianVehicles;
     };
 	case "civtrucks": {
-        private _civilianVehicles = (A3A_faction_reb get 'vehiclesCivTruck') select {_x isNotEqualTo ""};
+        private _civilianVehicles = (A3A_faction_reb get 'vehiclesCivTruck') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 
 		_isCivilian = true;
 		_vehicleClasses = _civilianVehicles;
     };
 	case "civboats": {
-        private _civilianVehicles =	(A3A_faction_reb get 'vehiclesCivBoat') select {_x isNotEqualTo ""};
+        private _civilianVehicles =	(A3A_faction_reb get 'vehiclesCivBoat') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 
 		_isCivilian = true;
 		_vehicleClasses = _civilianVehicles;
     };
 	case "civheli": {
         private _civilianVehicles = [];
-		private _civAircrafts = (A3A_faction_reb get "vehiclesCivHeli");
+		private _civAircrafts = (A3A_faction_reb get "vehiclesCivHeli") select {_x isEqualType "" && {_x isNotEqualTo ""}};
 		if (_civAircrafts isNotEqualTo [] && {{sidesX getVariable [_x,sideUnknown] isEqualTo teamPlayer} count airportsX > 0}) then {
 			_civilianVehicles append _civAircrafts;
 		};
@@ -55,7 +55,7 @@ switch (_category) do {
 	case "civplane": {
         private _civilianVehicles = [];
 		
-		private _civAircrafts = (A3A_faction_reb get 'vehiclesCivPlane');
+		private _civAircrafts = (A3A_faction_reb get 'vehiclesCivPlane') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 		if (_civAircrafts isNotEqualTo [] && {{sidesX getVariable [_x,sideUnknown] isEqualTo teamPlayer} count airportsX > 0}) then {
 			_civilianVehicles append _civAircrafts;
 		};
@@ -70,21 +70,21 @@ switch (_category) do {
 			(A3A_faction_reb get 'vehiclesLightUnarmed') +
 			(A3A_faction_reb get 'vehiclesBoat') + 
 			(A3A_faction_reb get 'vehiclesMedical')
-		select {_x isNotEqualTo []};
+		select {_x isEqualType ""};
 
 		if (tierWar > 2) then {
-			private _availableVehs = (A3A_faction_reb get 'vehiclesLightArmed') select {_x isNotEqualTo ""};
+			private _availableVehs = (A3A_faction_reb get 'vehiclesLightArmed') select {_x isEqualType "" && {_x isNotEqualTo ""}};
 			_militaryVehicles append _availableVehs;
 		};
 
 		if (tierWar > 3) then {
 			private _availableVehs = 
 				(A3A_faction_reb get 'vehiclesAT') + 
-				(A3A_faction_reb get 'vehiclesAA') select {_x isNotEqualTo []};
+				(A3A_faction_reb get 'vehiclesAA') select {_x isEqualType ""};
 			_militaryVehicles append _availableVehs;
 		};
 
-		private _milAircrafts = A3A_faction_reb get "vehiclesPlane";
+		private _milAircrafts = (A3A_faction_reb get "vehiclesPlane") select {_x isEqualType ""};
 		if (_milAircrafts isNotEqualTo [] && {{sidesX getVariable [_x,sideUnknown] isEqualTo teamPlayer} count airportsX > 0}) then {
 			_militaryVehicles append _milAircrafts;
 		};
@@ -92,29 +92,29 @@ switch (_category) do {
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militarybasic": {
-		private _militaryVehicles = (A3A_faction_reb get 'vehiclesBasic') select {_x isNotEqualTo []};
+		private _militaryVehicles = (A3A_faction_reb get 'vehiclesBasic') select {_x isEqualType ""};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militarytrucks": {
-		private _militaryVehicles = (A3A_faction_reb get 'vehiclesTruck') select {_x isNotEqualTo []};
+		private _militaryVehicles = (A3A_faction_reb get 'vehiclesTruck') select {_x isEqualType ""};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militarylightunarmed": {
-		private _militaryVehicles = (A3A_faction_reb get 'vehiclesLightUnarmed') select {_x isNotEqualTo []};
+		private _militaryVehicles = (A3A_faction_reb get 'vehiclesLightUnarmed') select {_x isEqualType ""};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militaryboats": {
-		private _militaryVehicles = (A3A_faction_reb get 'vehiclesBoat') select {_x isNotEqualTo []};
+		private _militaryVehicles = (A3A_faction_reb get 'vehiclesBoat') select {_x isEqualType ""};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militarymedical": {
-		private _militaryVehicles =	(A3A_faction_reb get 'vehiclesMedical')	select {_x isNotEqualTo []};
+		private _militaryVehicles =	(A3A_faction_reb get 'vehiclesMedical')	select {_x isEqualType ""};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militarylightarmed": {
 		private _militaryVehicles =[];
 		if (tierWar > 2) then {
-			private _availableVehs = (A3A_faction_reb get 'vehiclesLightArmed') select {_x isNotEqualTo ""};
+			private _availableVehs = (A3A_faction_reb get 'vehiclesLightArmed') select {_x isEqualType ""};
 			_militaryVehicles append _availableVehs;
 		};
 		_vehicleClasses = _militaryVehicles;
@@ -123,7 +123,7 @@ switch (_category) do {
 		private _militaryVehicles =[];
 		if (tierWar > 3) then {
 			private _availableVehs = 
-				(A3A_faction_reb get 'vehiclesAT') select {_x isNotEqualTo []};
+				(A3A_faction_reb get 'vehiclesAT') select {_x isEqualType ""};
 			_militaryVehicles append _availableVehs;
 		};
 		_vehicleClasses = _militaryVehicles;
@@ -132,14 +132,14 @@ switch (_category) do {
 		private _militaryVehicles =[];
 		if (tierWar > 3) then {
 			private _availableVehs = 
-				(A3A_faction_reb get 'vehiclesAA') select {_x isNotEqualTo []};
+				(A3A_faction_reb get 'vehiclesAA') select {_x isEqualType ""};
 			_militaryVehicles append _availableVehs;
 		};
 		_vehicleClasses = _militaryVehicles;
 	};
 	case "militaryplane": {
 		private _militaryVehicles =[];
-		private _milAircrafts = A3A_faction_reb get "vehiclesPlane";
+		private _milAircrafts = (A3A_faction_reb get "vehiclesPlane") select {_x isEqualType ""};
 		if (_milAircrafts isNotEqualTo [] && {{sidesX getVariable [_x,sideUnknown] isEqualTo teamPlayer} count airportsX > 0}) then {
 			_militaryVehicles append _milAircrafts;
 		};
@@ -149,21 +149,21 @@ switch (_category) do {
 		private _statics = [];
 		
 		if (tierWar > 2) then {
-			private _availableVehs = (A3A_faction_reb get 'staticMGs') select {_x isNotEqualTo []};
+			private _availableVehs = (A3A_faction_reb get 'staticMGs') select {_x isEqualType ""};
 			_statics append _availableVehs;
 		};
 
-		(A3A_faction_reb get 'staticMGs') select {_x isNotEqualTo []};
+		(A3A_faction_reb get 'staticMGs') select {_x isEqualType ""};
 
 		if (tierWar > 3) then {
 			private _availableVehs = 
 				(A3A_faction_reb get 'staticAT') +
-				(A3A_faction_reb get 'staticAA') select {_x isNotEqualTo []};
+				(A3A_faction_reb get 'staticAA') select {_x isEqualType ""};
 			_statics append _availableVehs;
 		};
 
 		if (tierWar > 4) then {
-			private _mortars = A3A_faction_reb get 'staticMortars';
+			private _mortars = (A3A_faction_reb get 'staticMortars') select {_x isEqualType ""};
 			if (_mortars isNotEqualTo []) then {
 				_statics append _mortars;
 			};
@@ -175,16 +175,16 @@ switch (_category) do {
 		private _statics = [];
 		
 		if (tierWar > 2) then {
-			private _availableVehs = (A3A_faction_reb get 'staticMGs') select {_x isNotEqualTo []};
+			private _availableVehs = (A3A_faction_reb get 'staticMGs') select {_x isEqualType ""};
 			_statics append _availableVehs;
 		};
-		(A3A_faction_reb get 'staticMGs') select {_x isNotEqualTo []};
+		(A3A_faction_reb get 'staticMGs') select {_x isEqualType ""};
 		_vehicleClasses = _statics;
 	};
 	case "staticAT": {
 		private _statics = [];
 		if (tierWar > 3) then {
-			private _availableVehs = (A3A_faction_reb get 'staticAT') select {_x isNotEqualTo []};
+			private _availableVehs = (A3A_faction_reb get 'staticAT') select {_x isEqualType ""};
 			_statics append _availableVehs;
 		};
 		_vehicleClasses = _statics;
@@ -192,7 +192,7 @@ switch (_category) do {
 	case "staticAA": {
 		private _statics = [];
 		if (tierWar > 3) then {
-			private _availableVehs = (A3A_faction_reb get 'staticAA') select {_x isNotEqualTo []};
+			private _availableVehs = (A3A_faction_reb get 'staticAA') select {_x isEqualType ""};
 			_statics append _availableVehs;
 		};
 		_vehicleClasses = _statics;
@@ -200,7 +200,7 @@ switch (_category) do {
 	case "staticMORTAR": {
 		private _statics = [];
 		if (tierWar > 4) then {
-			private _mortars = A3A_faction_reb get 'staticMortars';
+			private _mortars = (A3A_faction_reb get 'staticMortars') select {_x isEqualType ""};
 			if (_mortars isNotEqualTo []) then {
 				_statics append _mortars;
 			};

--- a/A3A/addons/scrt/UILayouts/menu.hpp
+++ b/A3A/addons/scrt/UILayouts/menu.hpp
@@ -866,7 +866,7 @@ class squadRecruit: SimpleMenuBigger
 			text = $STR_antistasi_dialogs_mg_team_title;
 			x = 0.257187 * safezoneW + safezoneX;
 			y = 0.584 * safezoneH + safezoneY;
-			action = "closeDialog 0;[selectRandom (A3A_faction_reb get 'staticMGs')] spawn A3A_fnc_addFIAsquadHC";
+			action = "closeDialog 0;[selectRandomWeighted (A3A_faction_reb get 'staticMGs')] spawn A3A_fnc_addFIAsquadHC";
 		};
 
 		class l5Button: SimpleButton
@@ -893,7 +893,7 @@ class squadRecruit: SimpleMenuBigger
 			text = $STR_antistasi_dialogs_at_car_title;
 			x = 0.477 * safezoneW + safezoneX;
 			y = 0.388 * safezoneH + safezoneY;
-			action = "closeDialog 0;[selectRandom (A3A_faction_reb get 'vehiclesAT')] spawn A3A_fnc_addFIAsquadHC";
+			action = "closeDialog 0;[selectRandomWeighted (A3A_faction_reb get 'vehiclesAT')] spawn A3A_fnc_addFIAsquadHC";
 		};
 
 		class r3Button: SimpleButton
@@ -902,7 +902,7 @@ class squadRecruit: SimpleMenuBigger
 			text = $STR_antistasi_dialogs_aa_car_title;
 			x = 0.477 * safezoneW + safezoneX;
 			y = 0.486 * safezoneH + safezoneY;
-			action = "closeDialog 0;[selectRandom (A3A_faction_reb get 'staticAA')] spawn A3A_fnc_addFIAsquadHC";
+			action = "closeDialog 0;[selectRandomWeighted (A3A_faction_reb get 'staticAA')] spawn A3A_fnc_addFIAsquadHC";
 		};
 
 		class r4Button: SimpleButton
@@ -911,7 +911,7 @@ class squadRecruit: SimpleMenuBigger
 			text = $STR_antistasi_dialogs_mortar_team_title;
 			x = 0.477 * safezoneW + safezoneX;
 			y = 0.584 * safezoneH + safezoneY;
-			action = "closeDialog 0;[selectRandom (A3A_faction_reb get 'staticMortars')] spawn A3A_fnc_addFIAsquadHC";
+			action = "closeDialog 0;[selectRandomWeighted (A3A_faction_reb get 'staticMortars')] spawn A3A_fnc_addFIAsquadHC";
 		};
 		class r5Button: SimpleButton
 		{
@@ -919,7 +919,7 @@ class squadRecruit: SimpleMenuBigger
 			text = $STR_antistasi_dialogs_mg_car_title;
 			x = 0.477 * safezoneW + safezoneX;
 			y = 0.682 * safezoneH + safezoneY;
-			action = "closeDialog 0;[selectRandom (A3A_faction_reb get 'vehiclesLightArmed')] spawn A3A_fnc_addFIAsquadHC";
+			action = "closeDialog 0;[selectRandomWeighted (A3A_faction_reb get 'vehiclesLightArmed')] spawn A3A_fnc_addFIAsquadHC";
 		};
 	};
 };


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR enables using weighted lists for vehicles, statics, and mines in faction templates (all military factions - occ, inv, reb, and riv).

If any given array is not weighted, it will be converted to a weighted list where all weights are 1 for compat with existing templates and so template creators don't have to weigh any arrays except those they want to; however, it should be noted that many functions combine multiple arrays together (e.g. vehiclesLightUnarmed + vehiclesTrucks + vehiclesCargoTrucks). Therefore, it would be best practice to weight all arrays sensibly. Furthermore, it may be a good idea in cases like that to normalize the weights.

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

If implemented, this probably needs at least a full campaign run, if not multiple, to suss out any errors.

********************************************************
### Notes:

So far I have tested:

 - [x] game loads with no errors
 - [x] towns, outposts, military bases, airports load and spawn vehicles with no errors

I have not explicitly tested any missions yet.

---

Supported arrays for weights:

```
"vehiclesSDV", "vehiclesBasic", "vehiclesLightUnarmed", "vehiclesLightArmed", "vehiclesTruck", "vehiclesTrucks", "vehiclesCargoTrucks", "vehiclesAmmoTrucks", "vehiclesRepairTrucks", "vehiclesFuelTrucks", "vehiclesMedical", "vehiclesLightAPCs", "vehiclesAPCs",
"vehiclesIFVs", "vehiclesTanks", "vehiclesAA", "vehiclesAirborne", "vehiclesLightTanks", "vehiclesBoat", "vehiclesTransportBoats", "vehiclesGunBoats", "vehiclesAmphibious", "vehiclesPlane", "vehiclesCivPlane", "vehiclesPlanesCAS", "vehiclesPlanesAA", "vehiclesPlanesTransport",
"vehiclesHelisLight", "vehiclesHelisTransport", "vehiclesHelisLightAttack", "vehiclesHelisAttack", "vehiclesAirPatrol", "vehiclesArtillery", "uavsAttack", "uavsPortable", "vehiclesMilitiaLightArmed", "vehiclesMilitiaTrucks", "vehiclesMilitiaCars", "vehiclesMilitiaAPCs", "vehiclesPolice",
"staticMGs", "staticAT", "staticAA", "staticMortars", "staticHowitzers", "vehicleRadar", "vehicleSAM", "minefieldAT", "minefieldAPERS",
"vehiclesCivCar", "vehiclesCivTruck", "vehiclesCivHeli", "vehiclesCivBoat",
"vehiclesRivalsLightArmed", "vehiclesRivalsTrucks", "vehiclesRivalsCars", "vehiclesRivalsAPCs", "vehiclesRivalsTanks", "vehiclesRivalsHelis", "vehiclesRivalsUavs", "staticLowWeapons"
```

---

**Example**:

https://github.com/jwoodruff40/A3-Antistasi-Ultimate/blob/altian-civil-war/A3A%2Faddons%2Fcore%2FTemplates%2FTemplates%2FCUP%2FCUP_AI_ACW_AAF%26TFAegis.sqf

Altian Civil War AAF has only Landrovers and Tigrs for vehiclesLightUnarmed / vehiclesLightArmed. The basic Altis lore timeline in most alternative Altis timeline scenarios is that they had previous Eastern Bloc ties and equipment, that is slowly being phased out with western equipment. So the natural choice would be Tigrs for militia / reserves and landrovers for higher tiers; however, Tigr is objectively a better vehicle, *and* there aren't as many variants (for variety) as landrovers. But with vehicle weights, all tiers can have both basic types of vehicle, just higher probability of Tigrs in militia and higher probability of landrovers in other tiers.

---

~~This also allows template creators to do some interesting stuff to work around template limitations. E.g. a vehicle array could look like this:~~

```
["CUP_B_Dingo_GER_Des", call {10 - tierWar}, "CUP_B_M1165_GMV_USA", call {tierWar}]
```
~~With each increase in war level, dingos would get less prevalent (lower weight) and M1165s would get more prevalent (higher weight).~~

~~Or alternatively,~~

```
["CUP_B_Dingo_GER_Des", call { [5,0] select (tierWar >= 8) }, "CUP_B_M1165_GMV_USA", call { [0,5] select (tierWar >= 8) }]
```
~~This would select dingos at war levels less than 8, and M1165s at war levels 8 or higher. IoW, this is a way to get "vehiclesEliteLightArmed" without changing the code everywhere.~~

~~Maybe this is hacky, but it works well.~~

Disregard above, my testing methodology was flawed. I mean, it does work, but only on restarting the server since the hashmap is populated on server load.