### PR TITLE
Fix: Missing param int > bool conversions during autoload

### DIFF
--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -80,6 +80,11 @@ private _savedParamsHM = createHashMapFromArray (A3A_saveData get "params");
 {
     if (getArray (_x/"texts") isEqualTo [""]) then { continue };                // spacer/title
     private _val = _savedParamsHM getOrDefault [configName _x, getNumber (_x/"default")];
+    if (getArray (_x/"values") isEqualTo [0,1]) then {
+        if (_val isEqualType 0) then { _val = _val != 0 };                      // number -> bool
+    } else {
+        if (_val isEqualType false) then { _val = [0, 1] select _val };         // bool -> number
+    };
     missionNamespace setVariable [configName _x, _val, true];                   // just publish them all, doesn't really hurt
 } forEach ("true" configClasses (configFile/"A3A"/"Params"));
 

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -230,7 +230,6 @@ switch (_mode) do
         private _params = (_paramsTable getVariable "allCtrls") apply {
             private _cfg = _x getVariable "config";
             private _val = _x lbValue lbCurSel _x;
-            if (getArray (_cfg/"values") isEqualTo [0,1]) then { _val = _val != 0 };          // number -> bool
             [configName _cfg, _val];
         };
         _params;


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Moved the `int` > `bool` code to initServer to ensure params are correctly converted when using autoLoadLastGame

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [x] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
