### PR TITLE
Use vehicle size for fast travel position search

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -190,7 +190,10 @@ if (_positionTel distance getMarkerPos _base < 50) then {
 						_radiusX = _radiusX + 10;
 					};
 					_road = _roads select 0;
-					private _pos = position _road findEmptyPosition [10,100,typeOf (vehicle _unit)];
+					private _pos = position _road findEmptyPosition [(sizeOf typeOf vehicle _unit) / 2, 100, typeOf (vehicle _unit)];
+					if (_pos isEqualTo []) exitWith {
+						[localize "STR_A3A_Dialogs_fast_travel_header", localize "STR_A3A_Dialogs_fast_travel_no_empty_position"] call SCRT_fnc_misc_deniedHint
+					};
 					vehicle _unit setPos _pos;
 				};
 				if ((vehicle _unit isKindOf "StaticWeapon") and (!isPlayer (leader _unit))) then {

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -13515,6 +13515,13 @@
                 <Korean>공격을 받거나 주변에 적이 포위한 지역으로는 빠른 이동을 할 수 없습니다.</Korean>
                 <French>Vous ne pouvez pas voyager rapidement vers une zone attaquée ou entourée d'ennemis.</French>
             </Key>
+            <Key ID="STR_A3A_Dialogs_fast_travel_no_empty_position">
+                <Original>Unable to find a position to place unit.</Original>
+                <Russian>Не удалось найти позицию для размещения юнита.</Russian>
+                <Chinesesimp>无法找到放置单元的位置。</Chinesesimp>
+                <Korean>장치를 배치할 위치를 찾을 수 없습니다.</Korean>
+                <French>Impossible de trouver une position pour placer l'unité.</French>
+            </Key>
             <Key ID="STR_A3A_Dialogs_fast_travel_moving_hc_group">
                 <Original>Moving group %1 to destination.</Original>
                 <Russian>Перемещаем %1 отряд в место назначения.</Russian>


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR uses the player's vehicle size instead of static 10m as min radius when searching for an empty position to FT the unit to. Fixes (or at least reduces the likelihood of) [issues like this](https://discord.com/channels/817005365740044289/1351291712663982152).

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

Tested locally and by OP in that discord thread.

********************************************************
Notes:

In testing, `(sizeOf typeOf vehicle _unit) / 2` is equivalent to `(0 boundingBoxReal (vehicle _unit)) select 2`