### PR TITLE
Fix bug attempting to add too many magazines to AI

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -21,7 +21,7 @@ params ["_unit", "_weaponType", ["_totalMagWeight", 50]];
 
 call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
 
-private _weightAvail = (maxLoad vest _unit + maxLoad uniform _unit) - (loadVest _unit + loadUniform _unit);
+private _weightAvail = (getContainerMaxLoad vest _unit + getContainerMaxLoad uniform _unit ) - (loadVest _unit + loadUniform _unit);
 _totalMagWeight = _totalMagWeight min _weightAvail;
 
 private _pool = A3A_rebelGear get _weaponType;

--- a/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomRifle.sqf
@@ -21,6 +21,9 @@ params ["_unit", "_weaponType", ["_totalMagWeight", 50]];
 
 call A3A_fnc_fetchRebelGear;        // Send current version of rebelGear from server if we're out of date
 
+private _weightAvail = (maxLoad vest _unit + maxLoad uniform _unit) - (loadVest _unit + loadUniform _unit);
+_totalMagWeight = _totalMagWeight min _weightAvail;
+
 private _pool = A3A_rebelGear get _weaponType;
 if (_pool isEqualTo []) then {
     _pool = A3A_rebelGear get "Rifles";

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -59,6 +59,9 @@ if (!isNil "_customLoadout") exitWith {
 private _fnc_addSecondaryAndMags = {
     params ["_unit", "_weapon", "_totalMagWeight"];
 
+    private _weightAvail = maxLoad _unit - load _unit;
+    _totalMagWeight = _totalMagWeight min _weightAvail;
+
     _unit addWeapon _weapon;
     private _magazine = compatibleMagazines _weapon select 0;
     _unit addSecondaryWeaponItem _magazine;
@@ -78,6 +81,9 @@ private _fnc_addSecondaryAndMags = {
 
 private _fnc_addCharges = {
     params ["_unit", "_totalWeight"];
+
+    private _weightAvail = maxLoad backpack _unit - loadBackpack _unit;
+    _totalWeight = _totalWeight min _weightAvail;
 
     private _charges = A3A_rebelGear get "ExplosiveCharges";
     if (_charges isEqualTo []) exitWith {};

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -82,7 +82,7 @@ private _fnc_addSecondaryAndMags = {
 private _fnc_addCharges = {
     params ["_unit", "_totalWeight"];
 
-    private _weightAvail = maxLoad backpack _unit - loadBackpack _unit;
+    private _weightAvail = getContainerMaxLoad backpack _unit - loadBackpack _unit;
     _totalWeight = _totalWeight min _weightAvail;
 
     private _charges = A3A_rebelGear get "ExplosiveCharges";


### PR DESCRIPTION
## What type of PR is this?
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR fixes a harmless but log-bloating bug when the rebel loadout / equipping attempt to add more magazines to AI's uniform / vest than can fit, with log messages like `Some of magazines weren't stored in soldier Vest or Uniform`.

Will look into making this work for the generated occ/Inv/riv loadouts as well

### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

Does not seem to *break* anything, but needs more testing to ensure that, and that it has a noticeable effect.

********************************************************
Notes:
