### PR TITLE
Normalize item weights in A3A_rebelGear

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -246,6 +246,15 @@ if (_opticsMidCount < ITEM_MAX*2) then {
 
 _rebelGear set ["OpticsAll", _opticClose + _opticMid + _opticLong];     // for launchers
 
+// normalize all item weights, within their own array
+{
+    private _array = _y; 
+    if !(_array isEqualType []) then {continue}; 
+    private _totalWeight = 0;  
+    { _totalWeight = _totalWeight + _x } forEach (_array select {_x isEqualType 1}); 
+    _rebelGear set [_x, _array apply {if (_x isEqualType 1) then {_x / _totalWeight} else {_x}}];
+} forEach _rebelGear;
+
 // Update everything while unscheduled so that version numbers match
 isNil {
     A3A_rebelGearVersion = time;


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [ ] Change
3. [ ] Enhancement
4. [x] Miscellaneous

### What have you changed and why?
Information:

Normalize the item weights in A3A_rebelGear for each category. Does not have a *current* benefit / use case, but in future can be beneficial if selecting an item from several types, since the different types are weighted in completely different ways.

E.g. something like `selectRandomWeighted ((A3A_rebelGear get "Carbines") + (A3A_rebelGear get "SMGs"));`

Also makes it easier at a glance to see the relative probabilities of each item in the list.

Arrays that looked like this:
```
[["test", ["test1",1,"test2",2,"test3",3]]]
```
will now look like this:
```
[["test",["test1",0.166667,"test2",0.333333,"test3",0.5]]]
```

### Please specify which Issue this PR Resolves (If Applicable).
N/A

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
