### PR TITLE
Support different vehicles in faction data hashmap for each tier / war level

### DIFF
--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -58,9 +58,9 @@ _vehiclesData set ["magazines", createHashMapFromArray [["CUP_B_M270_HE_USA", ["
 _vehiclesData set ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]];
 _vehiclesData set ["uavsPortable", ["B_UAV_01_F"]];
 
-_vehiclesData set ["vehiclesMilitiaLightArmed", ["CUP_B_nM1025_M2_USMC_DES"]];
+_vehiclesData set ["vehiclesMilitiaLightArmed", ["CUP_B_nM1025_M2_USA_DES", "CUP_B_nM1025_M2_DF_USA_DES", "CUP_B_nM1025_M240_USA_DES", "CUP_B_nM1025_M240_DF_USA_DES", "CUP_B_HMMWV_Crows_M2_USA", "CUP_B_HMMWV_Crows_MK19_USA", "CUP_B_nM1025_Mk19_USA_DES", "CUP_B_nM1025_Mk19_DF_USA_DES", "CUP_B_nM1036_TOW_USA_DES", "CUP_B_nM1036_TOW_DF_USA_DES"]];
 _vehiclesData set ["vehiclesMilitiaTrucks", ["CUP_B_MTVR_USMC"]];
-_vehiclesData set ["vehiclesMilitiaCars", ["CUP_B_nM1025_Unarmed_USMC_DES"]];
+_vehiclesData set ["vehiclesMilitiaCars", ["CUP_B_nM1025_Unarmed_USA_DES", "CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_M1152_USA", "CUP_B_nM1038_USA_DES", "CUP_B_nM1038_DF_USA_DES", "CUP_B_nM1038_4s_USA_DES", "CUP_B_nM1038_4s_DF_USA_DES"]];
 _vehiclesData set ["vehiclesMilitiaAPCs", ["CUP_B_M113A3_desert_USA"]];
 
 _vehiclesData set ["vehiclesPolice", ["B_GEN_Offroad_01_gen_F"]];

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -13,74 +13,86 @@
 //       Vehicles       //
 //////////////////////////
 
-["vehiclesDropPod", ["SpaceshipCapsule_01_F"]] call _fnc_saveToTemplate; 
+private _vehiclesData = call _fnc_createLoadoutData;
 
-["ammobox", "B_supplyCrate_F"] call _fnc_saveToTemplate;
-["surrenderCrate", "Box_IND_Wps_F"] call _fnc_saveToTemplate;
-["equipmentBox", "Box_NATO_Equip_F"] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesDropPod", ["SpaceshipCapsule_01_F"]]; 
 
-["vehiclesBasic", ["B_Quadbike_01_F"]] call _fnc_saveToTemplate;
-["vehiclesLightUnarmed", ["CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1025_Unarmed_USA_DES", "CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1038_DF_USA_DES", "CUP_B_nM1038_USA_DES", "CUP_B_nM1038_4s_DF_USA_DES", "CUP_B_nM1038_4s_USA_DES", "CUP_B_M1151_USA", "CUP_B_M1152_USA"]] call _fnc_saveToTemplate;
-["vehiclesLightArmed", ["CUP_B_HMMWV_Crows_M2_USA", "CUP_B_HMMWV_Crows_MK19_USA", "CUP_B_HMMWV_M2_GPK_USA", "CUP_B_nM1025_M2_USA_DES", "CUP_B_nM1025_M2_DF_USA_DES", "CUP_B_nM1025_M240_USA_DES", "CUP_B_nM1025_M240_DF_USA_DES", "CUP_B_nM1025_Mk19_USA_DES", "CUP_B_nM1025_Mk19_DF_USA_DES", "CUP_B_nM1025_SOV_M2_USA_DES", "CUP_B_nM1025_SOV_Mk19_USA_DES", "CUP_B_nM1036_TOW_USA_DES", "CUP_B_nM1036_TOW_DF_USA_DES", "CUP_B_M1151_M2_USA", "CUP_B_M1151_Deploy_USA", "CUP_B_M1151_Mk19_USA", "CUP_B_M1165_GMV_USA", "CUP_B_M1167_USA", "CUP_B_M1135_ATGMV_Desert"]] call _fnc_saveToTemplate;
-["vehiclesTrucks", ["CUP_B_MTVR_USA"]] call _fnc_saveToTemplate;
-["vehiclesCargoTrucks", ["B_Truck_01_flatbed_F"]] call _fnc_saveToTemplate;
-["vehiclesAmmoTrucks", ["CUP_B_MTVR_Ammo_USA", "CUP_B_nM1038_Ammo_USA_DES", "CUP_B_nM1038_Ammo_DF_USA_DES"]] call _fnc_saveToTemplate;
-["vehiclesRepairTrucks", ["CUP_B_nM1038_Repair_USA_DES", "CUP_B_nM1038_Repair_DF_USA_DES", "CUP_B_MTVR_Repair_USA"]] call _fnc_saveToTemplate;
-["vehiclesFuelTrucks", ["CUP_B_MTVR_Refuel_USA"]] call _fnc_saveToTemplate;
-["vehiclesMedical", ["CUP_B_nM997_DF_USA_DES", "CUP_B_nM997_USA_DES", "CUP_B_M1133_MEV_Desert"]] call _fnc_saveToTemplate;
-["vehiclesLightAPCs", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA", "CUP_B_RG31_Mk19_USA", "CUP_B_RG31E_M2_USA", "CUP_B_RG31_M2_USA", "CUP_B_RG31_M2_GC_USA"]] call _fnc_saveToTemplate;
-["vehiclesAPCs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]] call _fnc_saveToTemplate;     //   "CUP_B_M1129_MC_MK19_Desert"
-["vehiclesIFVs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]] call _fnc_saveToTemplate;
-["vehiclesTanks", ["CUP_B_M1A1SA_Desert_US_Army", "CUP_B_M1A1SA_Desert_TUSK_US_Army", "CUP_B_M1A2SEP_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_II_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_Desert_US_Army", "CUP_B_M1A2C_Desert_US_Army", "CUP_B_M1A2C_TUSK_II_Desert_US_Army", "CUP_B_M1A2C_TUSK_Desert_US_Army", "CUP_B_M1128_MGS_Desert"]] call _fnc_saveToTemplate;
-["vehiclesAA", ["CUP_B_M6LineBacker_USA_D", "CUP_B_nM1097_AVENGER_USA_DES", "CUP_B_M163_Vulcan_USA"]] call _fnc_saveToTemplate;
-["vehiclesAirborne", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA"]] call _fnc_saveToTemplate;
-["vehiclesLightTanks",  ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]] call _fnc_saveToTemplate;
+_vehiclesData set ["ammobox", "B_supplyCrate_F"];
+_vehiclesData set ["surrenderCrate", "Box_IND_Wps_F"];
+_vehiclesData set ["equipmentBox", "Box_NATO_Equip_F"];
 
-["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]] call _fnc_saveToTemplate;
-["vehiclesGunBoats", ["CUP_B_RHIB2Turret_USMC"]] call _fnc_saveToTemplate;
-["vehiclesAmphibious", []] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesBasic", ["B_Quadbike_01_F"]];
+_vehiclesData set ["vehiclesLightUnarmed", ["CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1025_Unarmed_USA_DES", "CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1038_DF_USA_DES", "CUP_B_nM1038_USA_DES", "CUP_B_nM1038_4s_DF_USA_DES", "CUP_B_nM1038_4s_USA_DES", "CUP_B_M1151_USA", "CUP_B_M1152_USA"]];
+_vehiclesData set ["vehiclesLightArmed", ["CUP_B_HMMWV_Crows_M2_USA", "CUP_B_HMMWV_Crows_MK19_USA", "CUP_B_HMMWV_M2_GPK_USA", "CUP_B_nM1025_M2_USA_DES", "CUP_B_nM1025_M2_DF_USA_DES", "CUP_B_nM1025_M240_USA_DES", "CUP_B_nM1025_M240_DF_USA_DES", "CUP_B_nM1025_Mk19_USA_DES", "CUP_B_nM1025_Mk19_DF_USA_DES", "CUP_B_nM1025_SOV_M2_USA_DES", "CUP_B_nM1025_SOV_Mk19_USA_DES", "CUP_B_nM1036_TOW_USA_DES", "CUP_B_nM1036_TOW_DF_USA_DES", "CUP_B_M1151_M2_USA", "CUP_B_M1151_Deploy_USA", "CUP_B_M1151_Mk19_USA", "CUP_B_M1165_GMV_USA", "CUP_B_M1167_USA", "CUP_B_M1135_ATGMV_Desert"]];
+_vehiclesData set ["vehiclesTrucks", ["CUP_B_MTVR_USA"]];
+_vehiclesData set ["vehiclesCargoTrucks", ["B_Truck_01_flatbed_F"]];
+_vehiclesData set ["vehiclesAmmoTrucks", ["CUP_B_MTVR_Ammo_USA", "CUP_B_nM1038_Ammo_USA_DES", "CUP_B_nM1038_Ammo_DF_USA_DES"]];
+_vehiclesData set ["vehiclesRepairTrucks", ["CUP_B_nM1038_Repair_USA_DES", "CUP_B_nM1038_Repair_DF_USA_DES", "CUP_B_MTVR_Repair_USA"]];
+_vehiclesData set ["vehiclesFuelTrucks", ["CUP_B_MTVR_Refuel_USA"]];
+_vehiclesData set ["vehiclesMedical", ["CUP_B_nM997_DF_USA_DES", "CUP_B_nM997_USA_DES", "CUP_B_M1133_MEV_Desert"]];
+_vehiclesData set ["vehiclesLightAPCs", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA", "CUP_B_RG31_Mk19_USA", "CUP_B_RG31E_M2_USA", "CUP_B_RG31_M2_USA", "CUP_B_RG31_M2_GC_USA"]];
+_vehiclesData set ["vehiclesAPCs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]];     //   "CUP_B_M1129_MC_MK19_Desert"
+_vehiclesData set ["vehiclesIFVs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_vehiclesData set ["vehiclesTanks", ["CUP_B_M1A1SA_Desert_US_Army", "CUP_B_M1A1SA_Desert_TUSK_US_Army", "CUP_B_M1A2SEP_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_II_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_Desert_US_Army", "CUP_B_M1A2C_Desert_US_Army", "CUP_B_M1A2C_TUSK_II_Desert_US_Army", "CUP_B_M1A2C_TUSK_Desert_US_Army", "CUP_B_M1128_MGS_Desert"]];
+_vehiclesData set ["vehiclesAA", ["CUP_B_M6LineBacker_USA_D", "CUP_B_nM1097_AVENGER_USA_DES", "CUP_B_M163_Vulcan_USA"]];
+_vehiclesData set ["vehiclesAirborne", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA"]];
+_vehiclesData set ["vehiclesLightTanks",  ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
 
-["vehiclesPlanesCAS", ["CUP_B_A10_DYN_USA"]] call _fnc_saveToTemplate;
-["vehiclesPlanesAA", ["CUP_B_AV8B_DYN_USMC"]] call _fnc_saveToTemplate;
-["vehiclesPlanesTransport", ["CUP_B_C130J_USMC", "CUP_B_MV22_USMC_RAMPGUN"]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]];
+_vehiclesData set ["vehiclesGunBoats", ["CUP_B_RHIB2Turret_USMC"]];
+_vehiclesData set ["vehiclesAmphibious", []];
 
-["vehiclesHelisLight", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA"]] call _fnc_saveToTemplate;
-["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_FFV_US", "CUP_B_UH60M_Unarmed_US", "CUP_B_UH60M_Unarmed_FFV_US"]] call _fnc_saveToTemplate;
-["vehiclesHelisLightAttack", ["CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]] call _fnc_saveToTemplate;
-["vehiclesHelisAttack", ["CUP_B_AH64D_DL_USA"]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesPlanesCAS", ["CUP_B_A10_DYN_USA"]];
+_vehiclesData set ["vehiclesPlanesAA", ["CUP_B_AV8B_DYN_USMC"]];
+_vehiclesData set ["vehiclesPlanesTransport", ["CUP_B_C130J_USMC", "CUP_B_MV22_USMC_RAMPGUN"]];
 
-["vehiclesAirPatrol", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA","CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesHelisLight", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA"]];
+_vehiclesData set ["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_FFV_US", "CUP_B_UH60M_Unarmed_US", "CUP_B_UH60M_Unarmed_FFV_US"]];
+_vehiclesData set ["vehiclesHelisLightAttack", ["CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]];
+_vehiclesData set ["vehiclesHelisAttack", ["CUP_B_AH64D_DL_USA"]];
 
-["vehiclesArtillery", ["CUP_B_M270_HE_USA"]] call _fnc_saveToTemplate;
-["magazines", createHashMapFromArray [["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]]]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesAirPatrol", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA","CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]];
 
-["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]] call _fnc_saveToTemplate;
-["uavsPortable", ["B_UAV_01_F"]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesArtillery", ["CUP_B_M270_HE_USA"]];
+_vehiclesData set ["magazines", createHashMapFromArray [["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]]]];
 
-["vehiclesMilitiaLightArmed", ["CUP_B_nM1025_M2_USMC_DES"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaTrucks", ["CUP_B_MTVR_USMC"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaCars", ["CUP_B_nM1025_Unarmed_USMC_DES"]] call _fnc_saveToTemplate;
-["vehiclesMilitiaAPCs", ["CUP_B_M113A3_desert_USA"]] call _fnc_saveToTemplate;
+_vehiclesData set ["uavsAttack", ["CUP_B_USMC_DYN_MQ9"]];
+_vehiclesData set ["uavsPortable", ["B_UAV_01_F"]];
 
-["vehiclesPolice", ["B_GEN_Offroad_01_gen_F"]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesMilitiaLightArmed", ["CUP_B_nM1025_M2_USMC_DES"]];
+_vehiclesData set ["vehiclesMilitiaTrucks", ["CUP_B_MTVR_USMC"]];
+_vehiclesData set ["vehiclesMilitiaCars", ["CUP_B_nM1025_Unarmed_USMC_DES"]];
+_vehiclesData set ["vehiclesMilitiaAPCs", ["CUP_B_M113A3_desert_USA"]];
 
-["staticMGs", ["CUP_B_M2StaticMG_US"]] call _fnc_saveToTemplate;
-["staticAT", ["CUP_B_TOW2_TriPod_US"]] call _fnc_saveToTemplate;
-["staticAA", ["CUP_B_CUP_Stinger_AA_pod_US"]] call _fnc_saveToTemplate;
-["staticMortars", ["CUP_B_M252_US"]] call _fnc_saveToTemplate;
-["staticHowitzers", [""]] call _fnc_saveToTemplate;
+_vehiclesData set ["vehiclesPolice", ["B_GEN_Offroad_01_gen_F"]];
 
-["vehicleRadar", "B_Radar_System_01_F"] call _fnc_saveToTemplate;
-["vehicleSam", "B_SAM_System_03_F"] call _fnc_saveToTemplate;
+_vehiclesData set ["staticMGs", ["CUP_B_M2StaticMG_US"]];
+_vehiclesData set ["staticAT", ["CUP_B_TOW2_TriPod_US"]];
+_vehiclesData set ["staticAA", ["CUP_B_CUP_Stinger_AA_pod_US"]];
+_vehiclesData set ["staticMortars", ["CUP_B_M252_US"]];
+_vehiclesData set ["staticHowitzers", [""]];
 
-["howitzerMagazineHE", ""] call _fnc_saveToTemplate;
+_vehiclesData set ["vehicleRadar", "B_Radar_System_01_F"];
+_vehiclesData set ["vehiclesam", "B_SAM_System_03_F"];
 
-["mortarMagazineHE", "8Rnd_82mm_Mo_shells"] call _fnc_saveToTemplate;
-["mortarMagazineSmoke", "8Rnd_82mm_Mo_Smoke_white"] call _fnc_saveToTemplate;
-["mortarMagazineFlare", "8Rnd_82mm_Mo_Flare_white"] call _fnc_saveToTemplate;
+_vehiclesData set ["howitzerMagazineHE", ""];
 
-["minefieldAT", ["CUP_Mine"]] call _fnc_saveToTemplate;
-["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
+_vehiclesData set ["mortarMagazineHE", "8Rnd_82mm_Mo_shells"];
+_vehiclesData set ["mortarMagazineSmoke", "8Rnd_82mm_Mo_Smoke_white"];
+_vehiclesData set ["mortarMagazineFlare", "8Rnd_82mm_Mo_Flare_white"];
+
+_vehiclesData set ["minefieldAT", ["CUP_Mine"]];
+_vehiclesData set ["minefieldAPERS", ["APERSMine"]];
+
+private _eliteVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+private _militaryVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+private _militiaVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+
+["vehiclesData", [
+    _militiaVehiclesData,
+    _militaryVehiclesData,
+    _eliteVehiclesData
+]] call _fnc_saveVehiclesToTemplate;
 
 #include "CUP_Vehicle_Attributes.sqf"
 

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_AI_US_Army_Arid.sqf
@@ -22,21 +22,21 @@ _vehiclesData set ["surrenderCrate", "Box_IND_Wps_F"];
 _vehiclesData set ["equipmentBox", "Box_NATO_Equip_F"];
 
 _vehiclesData set ["vehiclesBasic", ["B_Quadbike_01_F"]];
-_vehiclesData set ["vehiclesLightUnarmed", ["CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1025_Unarmed_USA_DES", "CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_nM1038_DF_USA_DES", "CUP_B_nM1038_USA_DES", "CUP_B_nM1038_4s_DF_USA_DES", "CUP_B_nM1038_4s_USA_DES", "CUP_B_M1151_USA", "CUP_B_M1152_USA"]];
-_vehiclesData set ["vehiclesLightArmed", ["CUP_B_HMMWV_Crows_M2_USA", "CUP_B_HMMWV_Crows_MK19_USA", "CUP_B_HMMWV_M2_GPK_USA", "CUP_B_nM1025_M2_USA_DES", "CUP_B_nM1025_M2_DF_USA_DES", "CUP_B_nM1025_M240_USA_DES", "CUP_B_nM1025_M240_DF_USA_DES", "CUP_B_nM1025_Mk19_USA_DES", "CUP_B_nM1025_Mk19_DF_USA_DES", "CUP_B_nM1025_SOV_M2_USA_DES", "CUP_B_nM1025_SOV_Mk19_USA_DES", "CUP_B_nM1036_TOW_USA_DES", "CUP_B_nM1036_TOW_DF_USA_DES", "CUP_B_M1151_M2_USA", "CUP_B_M1151_Deploy_USA", "CUP_B_M1151_Mk19_USA", "CUP_B_M1165_GMV_USA", "CUP_B_M1167_USA", "CUP_B_M1135_ATGMV_Desert"]];
+_vehiclesData set ["vehiclesLightUnarmed", []];
+_vehiclesData set ["vehiclesLightArmed", []];
 _vehiclesData set ["vehiclesTrucks", ["CUP_B_MTVR_USA"]];
 _vehiclesData set ["vehiclesCargoTrucks", ["B_Truck_01_flatbed_F"]];
 _vehiclesData set ["vehiclesAmmoTrucks", ["CUP_B_MTVR_Ammo_USA", "CUP_B_nM1038_Ammo_USA_DES", "CUP_B_nM1038_Ammo_DF_USA_DES"]];
 _vehiclesData set ["vehiclesRepairTrucks", ["CUP_B_nM1038_Repair_USA_DES", "CUP_B_nM1038_Repair_DF_USA_DES", "CUP_B_MTVR_Repair_USA"]];
 _vehiclesData set ["vehiclesFuelTrucks", ["CUP_B_MTVR_Refuel_USA"]];
-_vehiclesData set ["vehiclesMedical", ["CUP_B_nM997_DF_USA_DES", "CUP_B_nM997_USA_DES", "CUP_B_M1133_MEV_Desert"]];
-_vehiclesData set ["vehiclesLightAPCs", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA", "CUP_B_RG31_Mk19_USA", "CUP_B_RG31E_M2_USA", "CUP_B_RG31_M2_USA", "CUP_B_RG31_M2_GC_USA"]];
-_vehiclesData set ["vehiclesAPCs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]];     //   "CUP_B_M1129_MC_MK19_Desert"
-_vehiclesData set ["vehiclesIFVs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
-_vehiclesData set ["vehiclesTanks", ["CUP_B_M1A1SA_Desert_US_Army", "CUP_B_M1A1SA_Desert_TUSK_US_Army", "CUP_B_M1A2SEP_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_II_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_Desert_US_Army", "CUP_B_M1A2C_Desert_US_Army", "CUP_B_M1A2C_TUSK_II_Desert_US_Army", "CUP_B_M1A2C_TUSK_Desert_US_Army", "CUP_B_M1128_MGS_Desert"]];
-_vehiclesData set ["vehiclesAA", ["CUP_B_M6LineBacker_USA_D", "CUP_B_nM1097_AVENGER_USA_DES", "CUP_B_M163_Vulcan_USA"]];
-_vehiclesData set ["vehiclesAirborne", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA"]];
-_vehiclesData set ["vehiclesLightTanks",  ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_vehiclesData set ["vehiclesMedical", []];
+_vehiclesData set ["vehiclesLightAPCs", []];
+_vehiclesData set ["vehiclesAPCs", []];
+_vehiclesData set ["vehiclesIFVs", []];
+_vehiclesData set ["vehiclesTanks", []];
+_vehiclesData set ["vehiclesAA", []];
+_vehiclesData set ["vehiclesAirborne", []];
+_vehiclesData set ["vehiclesLightTanks",  []];
 
 _vehiclesData set ["vehiclesTransportBoats", ["B_Boat_Transport_01_F"]];
 _vehiclesData set ["vehiclesGunBoats", ["CUP_B_RHIB2Turret_USMC"]];
@@ -46,12 +46,11 @@ _vehiclesData set ["vehiclesPlanesCAS", ["CUP_B_A10_DYN_USA"]];
 _vehiclesData set ["vehiclesPlanesAA", ["CUP_B_AV8B_DYN_USMC"]];
 _vehiclesData set ["vehiclesPlanesTransport", ["CUP_B_C130J_USMC", "CUP_B_MV22_USMC_RAMPGUN"]];
 
-_vehiclesData set ["vehiclesHelisLight", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA"]];
-_vehiclesData set ["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_FFV_US", "CUP_B_UH60M_Unarmed_US", "CUP_B_UH60M_Unarmed_FFV_US"]];
-_vehiclesData set ["vehiclesHelisLightAttack", ["CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]];
-_vehiclesData set ["vehiclesHelisAttack", ["CUP_B_AH64D_DL_USA"]];
-
-_vehiclesData set ["vehiclesAirPatrol", ["CUP_B_MH6M_USA", "CUP_B_MH6J_USA","CUP_B_AH6M_USA", "CUP_B_AH6J_USA"]];
+_vehiclesData set ["vehiclesHelisLight", []];
+_vehiclesData set ["vehiclesHelisTransport", []];
+_vehiclesData set ["vehiclesHelisLightAttack", []];
+_vehiclesData set ["vehiclesHelisAttack", []];
+_vehiclesData set ["vehiclesAirPatrol", []];
 
 _vehiclesData set ["vehiclesArtillery", ["CUP_B_M270_HE_USA"]];
 _vehiclesData set ["magazines", createHashMapFromArray [["CUP_B_M270_HE_USA", ["CUP_12Rnd_MLRS_HE"]]]];
@@ -85,8 +84,54 @@ _vehiclesData set ["minefieldAT", ["CUP_Mine"]];
 _vehiclesData set ["minefieldAPERS", ["APERSMine"]];
 
 private _eliteVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+_eliteVehiclesData set ["vehiclesLightUnarmed", ["CUP_B_nM1151_Unarmed_USA_DES", "CUP_B_nM1151_Unarmed_DF_USA_DES", "CUP_B_M1151_USA"]];
+_eliteVehiclesData set ["vehiclesLightArmed", ["CUP_B_RG31_Mk19_USA", "CUP_B_RG31E_M2_USA", "CUP_B_RG31_M2_USA", "CUP_B_RG31_M2_GC_USA"]];
+_eliteVehiclesData set ["vehiclesMedical", ["CUP_B_M1133_MEV_Desert"]];
+_eliteVehiclesData set ["vehiclesLightAPCs", ["CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]];
+_eliteVehiclesData set ["vehiclesAPCs", ["CUP_B_M7Bradley_USA_D", "CUP_B_M1126_ICV_M2_Desert"]];
+_eliteVehiclesData set ["vehiclesIFVs", ["CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_eliteVehiclesData set ["vehiclesTanks", ["CUP_B_M1A1SA_Desert_TUSK_US_Army", "CUP_B_M1A2SEP_TUSK_II_Desert_US_Army", "CUP_B_M1A2SEP_TUSK_Desert_US_Army", "CUP_B_M1A2C_TUSK_II_Desert_US_Army", "CUP_B_M1A2C_TUSK_Desert_US_Army"]];
+_eliteVehiclesData set ["vehiclesAA", ["CUP_B_M6LineBacker_USA_D"]];
+_eliteVehiclesData set ["vehiclesLightTanks",  ["CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_eliteVehiclesData set ["vehiclesHelisLight", ["CUP_B_MH6M_USA"]];
+_eliteVehiclesData set ["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_FFV_US", "CUP_B_MH47E_USA"]];
+_eliteVehiclesData set ["vehiclesHelisLightAttack", ["CUP_B_AH6M_USA", "CUP_B_MH60L_DAP_2x_US", "CUP_B_MH60L_DAP_4x_US"]];
+_eliteVehiclesData set ["vehiclesHelisAttack", ["CUP_B_AH64D_DL_USA"]];
+_eliteVehiclesData set ["vehiclesAirPatrol", ["CUP_B_MH6M_USA", "CUP_B_AH6M_USA"]];
+
 private _militaryVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+_militaryVehiclesData set ["vehiclesLightUnarmed", ["CUP_B_nM1151_Unarmed_USA_DES", "CUP_B_nM1151_Unarmed_DF_USA_DES", "CUP_B_M1151_USA"]];
+_militaryVehiclesData set ["vehiclesLightArmed", ["CUP_B_HMMWV_M2_GPK_USA", "CUP_B_nM1151_ogpk_m2_USA_DES", "CUP_B_nM1151_ogpk_m2_DF_USA_DES", "CUP_B_nM1151_ogpk_m240_USA_DES", "CUP_B_nM1151_ogpk_m240_DF_USA_DES", "CUP_B_nM1151_ogpk_mk19_USA_DES", "CUP_B_nM1151_ogpk_mk19_DF_USA_DES", "CUP_B_M1151_M2_USA", "CUP_B_M1151_Deploy_USA", "CUP_B_M1151_Mk19_USA", "CUP_B_M1165_GMV_USA", "CUP_B_M1167_USA"]];
+_militaryVehiclesData set ["vehiclesMedical", ["CUP_B_M1133_MEV_Desert"]];
+_militaryVehiclesData set ["vehiclesLightAPCs", ["CUP_B_RG31_Mk19_USA", "CUP_B_RG31E_M2_USA", "CUP_B_RG31_M2_USA", "CUP_B_RG31_M2_GC_USA"]];
+_militaryVehiclesData set ["vehiclesAPCs", ["CUP_B_M2Bradley_USA_D", "CUP_B_M7Bradley_USA_D", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]];
+_militaryVehiclesData set ["vehiclesIFVs", ["CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_militaryVehiclesData set ["vehiclesTanks", ["CUP_B_M1A1SA_Desert_US_Army", "CUP_B_M1A2SEP_Desert_US_Army", "CUP_B_M1A2C_Desert_US_Army"]];
+_militaryVehiclesData set ["vehiclesAA", ["CUP_B_M6LineBacker_USA_D", "CUP_B_M163_Vulcan_USA"]];
+_militaryVehiclesData set ["vehiclesLightTanks",  ["CUP_B_M7Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D", "CUP_B_M2A3Bradley_USA_D"]];
+_militaryVehiclesData set ["vehiclesHelisLight", ["CUP_B_MH6J_USA"]];
+_militaryVehiclesData set ["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_Unarmed_US", "CUP_B_CH47F_USA"]];
+_militaryVehiclesData set ["vehiclesHelisLightAttack", ["CUP_B_AH6J_USA"]];
+_militaryVehiclesData set ["vehiclesHelisAttack", ["CUP_B_AH64_DL_USA"]];
+_militaryVehiclesData set ["vehiclesAirPatrol", ["CUP_B_MH6J_USA", "CUP_B_AH6J_USA"]];
+
 private _militiaVehiclesData = _vehiclesData call _fnc_copyLoadoutData;
+_militiaVehiclesData set ["vehiclesLightUnarmed", ["CUP_B_nM1025_Unarmed_USA_DES", "CUP_B_nM1025_Unarmed_DF_USA_DES", "CUP_B_M1152_USA", "CUP_B_nM1038_USA_DES", "CUP_B_nM1038_DF_USA_DES", "CUP_B_nM1038_4s_USA_DES", "CUP_B_nM1038_4s_DF_USA_DES"]];
+_militiaVehiclesData set ["vehiclesLightArmed", ["CUP_B_nM1025_M2_USA_DES", "CUP_B_nM1025_M2_DF_USA_DES", "CUP_B_nM1025_M240_USA_DES", "CUP_B_nM1025_M240_DF_USA_DES", "CUP_B_HMMWV_Crows_M2_USA", "CUP_B_HMMWV_Crows_MK19_USA", "CUP_B_nM1025_Mk19_USA_DES", "CUP_B_nM1025_Mk19_DF_USA_DES", "CUP_B_nM1036_TOW_USA_DES", "CUP_B_nM1036_TOW_DF_USA_DES"]];
+_militiaVehiclesData set ["vehiclesMedical", ["CUP_B_nM997_DF_USA_DES", "CUP_B_nM997_USA_DES"]];
+_militiaVehiclesData set ["vehiclesLightAPCs", ["CUP_B_M113A3_desert_USA"]];
+_militiaVehiclesData set ["vehiclesAPCs", ["CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_M2_Desert", "CUP_B_M1126_ICV_MK19_Desert"]];
+_militiaVehiclesData set ["vehiclesIFVs", ["CUP_B_M2Bradley_USA_D"]];
+_militiaVehiclesData set ["vehiclesTanks", ["CUP_B_M1128_MGS_Desert", "CUP_B_M1128_MGS_Desert", "CUP_B_M1A1SA_Desert_US_Army"]];
+_militiaVehiclesData set ["vehiclesAA", ["CUP_B_nM1097_AVENGER_USA_DES"]];
+_militiaVehiclesData set ["vehiclesAirborne", ["CUP_B_M113A3_desert_USA", "CUP_B_M113A3_desert_USA"]];
+_militiaVehiclesData set ["vehiclesLightTanks",  ["CUP_B_M2Bradley_USA_D"]];
+_militiaVehiclesData set ["vehiclesHelisLight", ["CUP_B_MH6J_USA"]];
+_militiaVehiclesData set ["vehiclesHelisTransport", ["CUP_B_UH60M_US", "CUP_B_UH60M_Unarmed_US", "CUP_B_CH47F_USA"]];
+_militiaVehiclesData set ["vehiclesHelisLightAttack", ["CUP_B_UH60M_US"]];
+_militiaVehiclesData set ["vehiclesHelisAttack", []];
+_militiaVehiclesData set ["vehiclesAirPatrol", ["CUP_B_MH6J_USA", "CUP_B_UH60M_US"]];
+
 
 ["vehiclesData", [
     _militiaVehiclesData,

--- a/A3A/addons/core/functions/OrgPlayers/fn_tierCheck.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_tierCheck.sqf
@@ -26,5 +26,5 @@ if (_tierWar != tierWar) then
 	if (!_silent) then { [petros,"tier",""] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]] };
 	//Updates the vehicles and groups for the sites
 	[] call A3A_fnc_updatePreference;
-	[] call A3U_fnc_updateVehiclesData;
+	{ _x call A3U_fnc_updateVehiclesData } forEach ["occ", "inv"];
 };

--- a/A3A/addons/core/functions/OrgPlayers/fn_tierCheck.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_tierCheck.sqf
@@ -26,4 +26,5 @@ if (_tierWar != tierWar) then
 	if (!_silent) then { [petros,"tier",""] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]] };
 	//Updates the vehicles and groups for the sites
 	[] call A3A_fnc_updatePreference;
+	[] call A3U_fnc_updateVehiclesData;
 };

--- a/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
+++ b/A3A/addons/core/functions/Templates/fn_loadFaction.sqf
@@ -81,6 +81,16 @@ private _fnc_saveNames = {
     ["lastNames", _lastNames] call _fnc_saveToTemplate;
 };
 
+private _fnc_saveVehiclesToTemplate = {
+	params ["_name", "_data"];
+
+	// add array of all vehiclesData hashmaps to faction hashmap for use when war level changes
+	_this call _fnc_saveToTemplate;
+
+	// set faction hashmap kv pairs for the current war level
+	{ [_x, _y] call _fnc_saveToTemplate } forEach ([_data] call SCRT_fnc_unit_getTiered);
+};
+
 {
 	call compile preprocessFileLineNumbers _x;
 } forEach _filepaths;

--- a/A3A/addons/ultimate/functions/vehicles/fn_updateVehiclesData.sqf
+++ b/A3A/addons/ultimate/functions/vehicles/fn_updateVehiclesData.sqf
@@ -1,0 +1,40 @@
+/*
+    Author:
+        Creep'nCrunch
+    
+    Description:
+        Updates the occupier / invader faction data hashmaps (e.g. A3A_faction_occ / A3A_faction_inv) vehicles according to war level.
+    
+    Params:
+        N/A
+    
+    Dependencies:
+        N/A
+    
+    Scope:
+        Server
+    
+    Environment:
+        Unscheduled
+    
+    Usage:
+		[] call A3U_fnc_updateVehiclesData;
+    
+    Return:
+        N/A
+*/
+
+{
+	private _data = + _x;
+	private _vehiclesData = _data get "vehiclesData";
+	if (isNil "_vehiclesData") then { continue };
+	
+	{
+		_data set [_x, _y];
+	} forEach (_vehiclesData call SCRT_fnc_unit_getTiered);
+
+	call A3A_fnc_compileMissionAssets;
+	{
+    	publicVariable ("A3A_faction_"+_x);
+	} forEach ["occ", "inv", "all"];
+} forEach [A3A_faction_occ, A3A_faction_inv];

--- a/A3A/addons/ultimate/functions/vehicles/fn_updateVehiclesData.sqf
+++ b/A3A/addons/ultimate/functions/vehicles/fn_updateVehiclesData.sqf
@@ -6,7 +6,7 @@
         Updates the occupier / invader faction data hashmaps (e.g. A3A_faction_occ / A3A_faction_inv) vehicles according to war level.
     
     Params:
-        N/A
+        _faction <STRING> 
     
     Dependencies:
         N/A
@@ -18,23 +18,25 @@
         Unscheduled
     
     Usage:
-		[] call A3U_fnc_updateVehiclesData;
+		["occ"] call A3U_fnc_updateVehiclesData;
+        OR
+        "inv" call A3U_fnc_updateVehiclesData;
     
     Return:
         N/A
 */
 
-{
-	private _data = + _x;
-	private _vehiclesData = _data get "vehiclesData";
-	if (isNil "_vehiclesData") then { continue };
-	
-	{
-		_data set [_x, _y];
-	} forEach (_vehiclesData call SCRT_fnc_unit_getTiered);
+params ["_faction"];
 
-	call A3A_fnc_compileMissionAssets;
-	{
-    	publicVariable ("A3A_faction_"+_x);
-	} forEach ["occ", "inv", "all"];
-} forEach [A3A_faction_occ, A3A_faction_inv];
+if (isNil "_faction") exitWith {};
+private _factionData = missionNamespace getVariable "A3A_faction_" + _faction;
+private _data = + _factionData;
+private _vehiclesData = [_data get "vehiclesData"];
+if (isNil "_vehiclesData") exitWith {};
+
+{
+    _data set [_x, _y];
+} forEach (_vehiclesData call SCRT_fnc_unit_getTiered);
+missionNamespace setVariable ["A3A_faction_" + _faction, _data];
+call A3A_fnc_compileMissionAssets;
+publicVariable ("A3A_faction_" + _faction);


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [x] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

**Proof of Concept**

This PR adds the ability for faction templates to define vehicles for each tier, similar to loadouts.

The main use case is for better support of "faction coalition" style templates, where good content either has to be cut because it doesn't make sense for every tier, or where certain vehicles are too overpowered to be used throughout the game but would be beneficial in later war levels. E.g. NATOxAAF, my Lombakkan Crisis extender with UN forces, @stutpip123's multi-era templates, etc

`vehiclesData` is the hashmap for defaults. Just like with loadouts, `eliteVehiclesData`, `militaryVehiclesData`, and `militiaVehiclesData` are deep copied from vehiclesData.

A K,V pair of `["vehiclesData",  [eliteVehiclesData, militaryVehiclesData, militiaVehiclesData]]` is added to the faction data hashmap. On server init and each time the war level changes, `SCRT_fnc_unit_getTiered` is used to select the appropriate vehicles hashmap from the array of hashmaps, and finally `A3U_fnc_updateVehiclesData` updates each of the `vehiclesXXX` keys in the global faction data hashmap to reflect.

### Please specify which Issue this PR Resolves (If Applicable).
N/A

### Please verify the following.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [X] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

- Modify a faction template with different vehicles in each tier.
- Start a game, check the faction data (e.g. `A3A_faction_occ get "vehiclesLightArmed"`
- Increase (or decrease) war level, by playing or with `tierWar = xx`
- Wait for war level check, or run either `[] call A3A_fnc_tierCheck` or `["occ"] A3U_fnc_updateVehiclesData` directly
- Re-check faction data for appropriate change(s)

********************************************************
Notes:

This is mainly a PoC, or in Community's terminology, an RFC. More than likely when I get some more time to work out all the bugs with #534, I'll merge both together. Or if we want this sooner, I can leave them separate.

Only one faction has been modified thus far for testing. I imagine we'd want to at least implement this on the appropriate Vanilla factions for merge.

`vehiclesMilitiaXXX` cannot be removed without modifying functions, which would require updating *every* supported and extender template. Thus they're left in for backwards compat. Since I'm updating all the functions in #534 anyway, it would be a bear but could remove them there. As it is, this code is fully compatible with existing templates.