### PR TITLE
Guided launchers & explosives respect unlock settings

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -31,6 +31,10 @@ private _fnc_addItemUnlocks = {
     if (_amount < 0) exitWith { _array append [_class, _arrayWeight] };
 };
 
+private _fnc_addGuidedLauncher = [_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowGuidedLaunchers isEqualTo 1 && {minWeaps > 0});
+
+private _fnc_addExplosiveCharge = [_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowUnlockedExplosives isEqualTo 1 && {minWeaps > 0});
+
 private _fnc_addItem = [_fnc_addItemUnlocks, _fnc_addItemNoUnlocks] select (minWeaps < 0);
 
 
@@ -105,11 +109,11 @@ private _opticsMidCount = 0;
                 switch true do {
                     case ("AA" in _categories): {
                         _array = _rebelGear getOrDefault ["MissileLaunchersAA", [], true];
-                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowGuidedLaunchers && {minWeaps > 0}));
+                        [_array, _class, _amount] call _fnc_addGuidedLauncher;
                     };
                     case ("AT" in _categories): {
                         _array = _rebelGear getOrDefault ["MissileLaunchersAT", [], true];
-                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowGuidedLaunchers && {minWeaps > 0}));
+                        [_array, _class, _amount] call _fnc_addGuidedLauncher;
                     };
                 };
             };
@@ -202,7 +206,7 @@ private _opticsMidCount = 0;
                     };
                     case ("ExplosiveCharges" in _categories): {
                         _array = _rebelGear getOrDefault ["ExplosiveCharges", [], true];
-                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowUnlockedExplosives && {minWeaps > 0}));
+                        [_array, _class, _amount] call _fnc_addExplosiveCharge;
                     };
                 };
             };

--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -105,11 +105,11 @@ private _opticsMidCount = 0;
                 switch true do {
                     case ("AA" in _categories): {
                         _array = _rebelGear getOrDefault ["MissileLaunchersAA", [], true];
-                        [_array, _class, _amount] call _fnc_addItemNoUnlocks
+                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowGuidedLaunchers && {minWeaps > 0}));
                     };
                     case ("AT" in _categories): {
                         _array = _rebelGear getOrDefault ["MissileLaunchersAT", [], true];
-                        [_array, _class, _amount] call _fnc_addItemNoUnlocks
+                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowGuidedLaunchers && {minWeaps > 0}));
                     };
                 };
             };
@@ -202,7 +202,7 @@ private _opticsMidCount = 0;
                     };
                     case ("ExplosiveCharges" in _categories): {
                         _array = _rebelGear getOrDefault ["ExplosiveCharges", [], true];
-                        [_array, _class, _amount] call _fnc_addItemNoUnlocks
+                        [_array, _class, _amount] call ([_fnc_addItemNoUnlocks, _fnc_addItemUnlocks] select (allowUnlockedExplosives && {minWeaps > 0}));
                     };
                 };
             };

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -3599,6 +3599,9 @@
             <Key ID="STR_antistasi_dialogs_setup_copy_save">
                 <Original>Copying save with ID: %1</Original>
             </Key>
+            <Key ID="STR_antistasi_dialogs_setup_unlocks_disabled">
+                <Original>This parameter cannot be changed when unlocks are globally disabled.</Original>
+            </Key>
         </Container>
         <Container name="setup_dialog_table">
             <Key ID="STR_antistasi_setup_dialog_table_map">

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -115,6 +115,34 @@ switch (_mode) do
                         _rivSelCtrl ctrlEnable !_rivDisabled;
                     }];
                 };
+
+                if (configName _x isEqualTo "minWeaps") then {
+                    _valsCtrl ctrlAddEventHandler ["LBSelChanged", {
+                        params ["_thisCtrl", "_index"];
+                        private _display = findDisplay A3A_IDD_SETUPDIALOG;
+                        private _unlocksDisabled = (_thisCtrl lbValue _index) isEqualTo -1;
+                        private _unlockMagazinesCtrl = _display displayCtrl (ctrlIDC _thisCtrl + 2);
+                        private _unlockGLaunchersCtrl = _display displayCtrl (ctrlIDC _thisCtrl + 3);
+                        private _unlockExplosivesCtrl = _display displayCtrl (ctrlIDC _thisCtrl + 4);
+
+                        if (_unlocksDisabled) then {
+                            for "_i" from 2 to 4 do {
+                                private _ctrl = _display displayCtrl (ctrlIDC _thisCtrl + _i);
+                                _ctrl lbSetCurSel 1;
+                                _ctrl ctrlSetTooltip (localize "STR_antistasi_dialogs_setup_unlocks_disabled");
+                                _ctrl setVariable ["locked", true];
+                                _ctrl ctrlEnable false;
+                            };
+                        } else {
+                            for "_i" from 2 to 4 do {
+                                private _ctrl = _display displayCtrl (ctrlIDC _thisCtrl + _i);
+                                _ctrl ctrlSetTooltip "";
+                                _ctrl setVariable ["locked", false];
+                                _ctrl ctrlEnable true;
+                            };
+                        };
+                    }];
+                };
             };
         } forEach ("true" configClasses (A3A_SETUP_CONFIGFILE/"A3A"/"Params"));
 


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug?
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR changes when and how guided launchers and explosive charges are added to the `A3A_rebelGear` hashmap for equipping rebels, for consistency and to alleviate confusion.

**Old behavior**:
Regardless of unlock qty or unlocks disabled, or whether unlocking guided launchers and explosives specifically was enabled or not, these items would be added to rebel gear as soon as their quantity in the arsenal surpassed 10; however, their weights / preference were multiplied by the ratio of quantity on hand to maximum quantity.

**New behavior**:
- Global unlocks _disabled_, specific unlocks enabled OR disabled: same as old behavior
- Global unlocks _enabled_, specific unlocks _disabled_: same as old behavior
- Global unlocks _enabled_, specific unlocks _enabled_: same as any other weapon - rebels must have the unlock quantity on hand (default 25) to unlock. Items will not be added to rebel gear hashmap until unlocked.


### Please specify which Issue this PR Resolves (If Applicable).
This PR closes [discord](https://discord.com/channels/817005365740044289/1218566036459229245/1363324474526793839)

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
