### PR TITLE
Prevent garrison units from mounting ACE loaded static emplacements #2

### DIFF
--- a/A3A/addons/patcom/functions/Patcom/fn_patrolArmStatics.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolArmStatics.sqf
@@ -36,8 +36,14 @@ _staticsNear = _staticsNear select {alive _x};
 // Only get statics which currently are not crewed.
 _staticsNear = _staticsNear select {(crew _x) isequalto []};
 
-// Only get statics which are not current assigned.
-_staticsNear = _staticsNear select {(_x getVariable ["PATCOM_STATIC_ASSIGNED", false]) == false};
+// Only get statics which are not currently assigned. Also no AI-locked or cargo-loaded statics.
+_staticsNear = _staticsNear select {
+    ((_x getVariable ["lockedForAi", false]) == false) &&
+    ((_x getVariable ["PATCOM_STATIC_ASSIGNED", false]) == false) && (
+        (isNull attachedTo _x) ||
+        { !(_x in (attachedTo _x getVariable["ace_cargo_loaded", []])) }
+    )
+};
 
 // Exit if no statics are near.
 if (count _staticsNear == 0) exitWith {};


### PR DESCRIPTION
## What type of PR is this?
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?

This is a follow-up on an issue that's been driving me nucking futs.

First attempt was [here](https://github.com/SilenceIsFatto/A3-Antistasi-Ultimate/pull/478/files). It didn't work. Garrison soldiers would _still_ mount cargo loaded mortars and I would Uber them around the battlefield until they ejected and then _walked_ back home.

This one finally solves the nightmare.

### Please specify which Issue this PR Resolves (If Applicable).

"This PR _really_ closes #476 !"

### Please verify the following.

1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
