### PR TITLE
chernarus 2020: fixed multiple vehicle markers

### DIFF
--- a/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
@@ -4926,7 +4926,7 @@ class Mission
 		{
 			dataType="Marker";
 			position[]={327.44272,294.71216,9425.6963};
-			name="outp_1_vehicle_1";
+			name="outp_9_vehicle";
 			markerType="RECTANGLE";
 			type="rectangle";
 			colorName="ColorGreen";

--- a/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
@@ -13975,7 +13975,7 @@ class Mission
 		{
 			dataType="Marker";
 			position[]={3725.3784,361.81479,14751.793};
-			name="outp_17_vehicle_1";
+			name="outp_25_vehicle";
 			markerType="RECTANGLE";
 			type="rectangle";
 			colorName="ColorGreen";

--- a/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
+++ b/A3A/addons/maps/Antistasi_cup_chernarus_A3.cup_chernarus_A3/mission.sqm
@@ -9326,7 +9326,7 @@ class Mission
 		{
 			dataType="Marker";
 			position[]={12684.431,235.94411,9666.127};
-			name="fact_5_vehicle_1";
+			name="fact_6_vehicle";
 			markerType="RECTANGLE";
 			type="rectangle";
 			colorName="ColorGreen";


### PR DESCRIPTION
## What type of PR is this?
1. [X] Bug
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?

On the Chernarus 2020 map, the vehicle marker in outpost 9 was incorrectly named `outp_1_vehicle_1`.
This PR changes the vehicle marker name to `outp_9_vehicle` so it will be associated with the correct outpost.

**EDIT: outpost 25 and factory 6 vehicle markers are also fixed by this PR.**

### Please specify which Issue this PR Resolves (If Applicable).
N/A

### Please verify the following.

1. [X] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [X] No
2. [ ] Yes (Please provide further detail below.)
