### PR TITLE
add missing parameter to A3A_fnc_SUP_mortarRoutine call

### DIFF
--- a/A3A/addons/core/functions/Supports/fn_SUP_howitzer.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_howitzer.sqf
@@ -61,7 +61,7 @@ if (_target isEqualType objNull) then {
 // name, side, suppType, pos, radius, remTargets, targets
 private _suppData = [_supportName, _side, "HOWITZER", markerPos _base, _maxRange, _targArray, _minRange];
 A3A_activeSupports pushBack _suppData;
-[_suppData, _vehicle, _group, _delay, _reveal] spawn A3A_fnc_SUP_mortarRoutine;
+[_suppData, _vehicle, _group, _delay, _reveal, true] spawn A3A_fnc_SUP_mortarRoutine;
 
 [_reveal, _side, "HOWITZER", _targPos, _delay] spawn A3A_fnc_showInterceptedSetupCall;
 


### PR DESCRIPTION
## What type of PR is this?
1. [X] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
missing parameter when calling A3A_fnc_SUP_mortarRoutine in fn_SUP_howitzer.sqf causes server crash.
### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #579!"

### Please verify the following.

1. [X] Have you loaded the mission in LAN host?
2. [X] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [X] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:
