### PR TITLE
Unlock limited weapons from civ interaction; unlock magazines with them

### DIFF
--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -6081,13 +6081,13 @@
                 <Original>An informant gave you the location of a warehouse containing stashes of the<br/> %1.<br/> You have acquired %2 of this weapon.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_convoy">
-                <Original>A weapons convoy has been intercepted by local militia and rerouted to your HQ. You have received %1 of %2.</Original>
+                <Original>A weapons convoy has been intercepted by local militia and rerouted to your HQ. You have received %1x %2.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_truck">
-                <Original>A case of weapons has fallen off a truck while %1 moves around the AO. You have acquired %2 of %3.</Original>
+                <Original>A case of weapons has fallen off a truck while %1 moves around the AO. You have acquired %2x %3.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_trader">
-                <Original>As a gesture of good will and support for the cause, an anonymous arms trader has delivered a case of weapons to your HQ. You have received %1 of $2.</Original>
+                <Original>As a gesture of good will and support for the cause, an anonymous arms trader has delivered a case of weapons to your HQ. You have received %1x $2.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_supplydata">
                 <Original>You found the supply data for the<br/> %1<br/> You have acquired %2 of this weapon.</Original>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -6076,5 +6076,22 @@
                 <Korean>합계: %1. 탄창:</Korean>
             </Key>
         </Container>
+        <Container name="intel_civilian_interaction">
+            <Key ID="STR_antistasi_intel_weapon_informant">
+                <Original>An informant gave you the location of a warehouse containing stashes of the<br/> %1.<br/> You have acquired %2 of this weapon.</Original>
+            </Key>
+            <Key ID="STR_antistasi_intel_weapon_convoy">
+                <Original>A weapons convoy has been intercepted by local militia and rerouted to your HQ. You have received %1 of %2.</Original>
+            </Key>
+            <Key ID="STR_antistasi_intel_weapon_truck">
+                <Original>A case of weapons has fallen off a truck while %1 moves around the AO. You have acquired %2 of %3.</Original>
+            </Key>
+            <Key ID="STR_antistasi_intel_weapon_trader">
+                <Original>As a gesture of good will and support for the cause, an anonymous arms trader has delivered a case of weapons to your HQ. You have received %1 of $2.</Original>
+            </Key>
+            <Key ID="STR_antistasi_intel_weapon_supplydata">
+                <Original>You found the supply data for the<br/> %1<br/> You have acquired %2 of this weapon.</Original>
+            </Key>
+        </Container>
     </Package>
 </Project>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -6087,7 +6087,7 @@
                 <Original>A case of weapons has fallen off a truck while %1 moves around the AO. You have acquired %2x %3.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_trader">
-                <Original>As a gesture of good will and support for the cause, an anonymous arms trader has delivered a case of weapons to your HQ. You have received %1x $2.</Original>
+                <Original>As a gesture of good will and support for the cause, an anonymous arms trader has delivered a case of weapons to your HQ. You have received %1x %2.</Original>
             </Key>
             <Key ID="STR_antistasi_intel_weapon_supplydata">
                 <Original>You found the supply data for the<br/> %1<br/> You have acquired %2 of this weapon.</Original>

--- a/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
@@ -67,15 +67,44 @@ if (!isTraderQuestCompleted && !isTraderQuestAssigned) then {
     };
 };
 
+private _fnc_addWeapon = {
+    private _notYetUnlocked = allWeapons - unlockedWeapons;
+    private _newWeapon = selectRandom _notYetUnlocked;
+    private _magazine = selectRandom compatibleMagazines _newWeapon;
+    if (minWeaps > 0) then {
+        [_newWeapon] remoteExec ["A3A_fnc_unlockEquipment", 2];
+        [_magazine] remoteExec ["A3A_fnc_unlockEquipment", 2];
+    } else {
+        private _arsenalTab = 
+	    [
+            _newWeapon call jn_fnc_arsenal_itemType,
+            _newWeapon,
+            A3A_guestItemLimit max 20
+        ] call jn_fnc_arsenal_addItem;
+        [
+            _magazine call jn_fnc_arsenal_itemType,
+            _magazine,
+            (A3A_guestItemLimit max 20) * 6 * getNumber (configFile >> "CfgMagazines" >> _magazine >> "count")
+        ] call jn_fnc_arsenal_addItem;
+    };
+
+    private _return = [
+        getText (configFile >> "CfgWeapons" >> _newWeapon >> "displayName"),
+        ["acquired", "unlocked"] select (minWeaps > 0)
+    ];
+    _return;
+};
+
 if (_text isEqualTo "") then {
     switch (true) do {
         case (_intelType isEqualTo "Civilian"): {
-            _intelContent = selectRandomWeighted [
+            /*_intelContent = selectRandomWeighted [
                 MONEY, 0.2,
                 WEAPON, 0.2,
                 DECRYPTION_KEY, 0.2,
                 TRAITOR, 0.1
-            ];
+            ];*/
+            _intelContent = WEAPON;
 
             switch (_intelContent) do
             {
@@ -92,12 +121,8 @@ if (_text isEqualTo "") then {
                 };
                 case (WEAPON):
                 {
-                    private _notYetUnlocked = allWeapons - unlockedWeapons;
-                    private _newWeapon = selectRandom _notYetUnlocked;
-                    [_newWeapon] remoteExec ["A3A_fnc_unlockEquipment", 2];
-
-                    private _weaponName = getText (configFile >> "CfgWeapons" >> _newWeapon >> "displayName");
-                    _text = format ["A civilian gave you the location of a warehouse containing stashes of the<br/> %1.<br/> You have unlocked this weapon!", _weaponName];
+                    [] call _fnc_addWeapon params ["_weaponName", "_action"];
+                    _text = format ["A civilian gave you the location of a warehouse containing stashes of the<br/> %1.<br/> You have %2 this weapon!", _weaponName, _action];
                 };
                 case (TRAITOR):
                 {
@@ -287,12 +312,8 @@ if (_text isEqualTo "") then {
                 };
                 case (WEAPON):
                 {
-                    private _notYetUnlocked = allWeapons - unlockedWeapons;
-                    private _newWeapon = selectRandom _notYetUnlocked;
-                    [_newWeapon] remoteExec ["A3A_fnc_unlockEquipment", 2];
-
-                    private _weaponName = getText (configFile >> "CfgWeapons" >> _newWeapon >> "displayName");
-                    _text = format ["You found the supply data for the<br/> %1<br/> You have unlocked this weapon!", _weaponName];
+                    [] call _fnc_addWeapon params ["_weaponName", "_action"];
+                    _text = format ["You found the supply data for the<br/> %1<br/> You have %2 this weapon!", _weaponName, _action];
                 };
                 case (MONEY):
                 {

--- a/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
@@ -125,7 +125,7 @@ if (_text isEqualTo "") then {
                     private _texts = [
                         format [localize "STR_antistasi_intel_weapon_informant", _weaponName, _quantity],
                         format [localize "STR_antistasi_intel_weapon_convoy", _quantity, _weaponName],
-                        format [localize "STR_antistasi_intel_weapon_truck", _side, _quantity, _weaponName]
+                        format [localize "STR_antistasi_intel_weapon_truck", Faction(_side) get "name", _quantity, _weaponName]
                     ];
                     if (isTraderQuestCompleted) then { _texts pushBack (format [localize "STR_antistasi_intel_weapon_trader", _quantity, _weaponName]) };
                     _text = selectRandom (_texts);

--- a/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
+++ b/A3A/addons/core/functions/Intel/fn_selectIntel.sqf
@@ -98,13 +98,12 @@ private _fnc_addWeapon = {
 if (_text isEqualTo "") then {
     switch (true) do {
         case (_intelType isEqualTo "Civilian"): {
-            /*_intelContent = selectRandomWeighted [
+            _intelContent = selectRandomWeighted [
                 MONEY, 0.2,
                 WEAPON, 0.2,
                 DECRYPTION_KEY, 0.2,
                 TRAITOR, 0.1
-            ];*/
-            _intelContent = WEAPON;
+            ];
 
             switch (_intelContent) do
             {


### PR DESCRIPTION
## What type of PR is this?
1. [ ] Bug
2. [x] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

This PR changes how you unlock weapons from civilian interaction.

- add 'random' qty of weapons (potentially, but not always, enough to unlock if unlocks are enabled)
- add 6x qty weapons magazines
- add more dialogs

### Please specify which Issue this PR Resolves (If Applicable).
This PR closes [discord](https://discord.com/channels/817005365740044289/1365088462331707503)

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

`compatibleMagazines _newWeapon` is used instead of `configFile >> "CfgWeapons" >> _newWeapon >> "magazines"` for easier compat with weapons that don't have magazines defined but do have magwells defined.

Perhaps we can lower the amount of magazines given when unlocks are disabled, but wanted to make the weapons actually useful.
