### PR TITLE
Side relations fix

### DIFF
--- a/A3A/addons/core/functions/Base/fn_addAggression.sqf
+++ b/A3A/addons/core/functions/Base/fn_addAggression.sqf
@@ -56,7 +56,7 @@ if (!_doNotAdjust) then { _aggroChange = _aggroChange / A3A_balancePlayerScale }
 
 private _decayRate = [_aggroChange, _aggroTime] call _fn_convertMinutesToDecayRate;
 
-if(gameMode != 4 && (_side == Occupants)) then
+if(_side == Occupants) then
 {
     aggressionStackOccupants pushBack [_aggroChange, _decayRate];
 };

--- a/A3A/addons/core/functions/Base/fn_statistics.sqf
+++ b/A3A/addons/core/functions/Base/fn_statistics.sqf
@@ -36,13 +36,6 @@ switch (gameMode) do {
 			_aggrString = "";
 		};
 	};
-	case 4: {
-		if (!areInvadersDefeated) then {
-			_aggrString = format [localize "STR_info_bar_aggr", A3A_faction_inv get "name", [aggressionLevelInvaders] call A3A_fnc_getAggroLevelString];
-		} else {
-			_aggrString = "";
-		};
-	};
 	default {
 		switch (true) do {
 			case (!areOccupantsDefeated && {!areInvadersDefeated}): {

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -26,227 +26,227 @@ A3A_hasIFA = false;
 
 //IFA Detection
 if (isClass (configfile >> "CfgPatches" >> "LIB_core")) then {
-  A3A_hasIFA = true;
-  [2,"Iront Front Detected.",_fnc_scriptName] call A3A_fnc_log;
+    A3A_hasIFA = true;
+    [2,"Iront Front Detected.",_fnc_scriptName] call A3A_fnc_log;
 };
 
 _isControl = if (isOnRoad _positionX) then {true} else {false};
 
 if (_isControl) then
 {
-	if (_sideX == Occupants) then
-	{
-	if ((random 10 > (tierWar + difficultyCoef)) and (!([_markerX] call A3A_fnc_isFrontline))) then
-		{
-			_isFIA = true;
-		}
-	};
+    if (_sideX == Occupants) then
+    {
+    if ((random 10 > (tierWar + difficultyCoef)) and (!([_markerX] call A3A_fnc_isFrontline))) then
+        {
+            _isFIA = true;
+        }
+    };
 
-	// Attempt to find nearby road with two connected roads
-	_radiusX = 20;
-	while {_radiusX < 100} do
-	{
-		_roads = _positionX nearRoads _radiusX;
-		_roads = _roads select { count (roadsConnectedTo _x) == 2 };
-		if (count _roads > 0) exitWith {};
-		_radiusX = _radiusX + 10;
-	};
+    // Attempt to find nearby road with two connected roads
+    _radiusX = 20;
+    while {_radiusX < 100} do
+    {
+        _roads = _positionX nearRoads _radiusX;
+        _roads = _roads select { count (roadsConnectedTo _x) == 2 };
+        if (count _roads > 0) exitWith {};
+        _radiusX = _radiusX + 10;
+    };
 
-	if (_radiusX >= 100) then {
-		// fallback case, shouldn't happen unless the map is very broken
+    if (_radiusX >= 100) then {
+        // fallback case, shouldn't happen unless the map is very broken
         Error_2("Roadblock error for %1 at %2", _markerX, _positionX);
-		_roads = _positionX nearRoads 20;		// guaranteed due to isOnRoad check
-		_dirveh = random 360;
-	} else {
-		private _roadscon = roadsConnectedto (_roads select 0);
-		_dirveh = [_roads select 0, _roadscon select 0] call BIS_fnc_DirTo;
-	};
+        _roads = _positionX nearRoads 20;		// guaranteed due to isOnRoad check
+        _dirveh = random 360;
+    } else {
+        private _roadscon = roadsConnectedto (_roads select 0);
+        _dirveh = [_roads select 0, _roadscon select 0] call BIS_fnc_DirTo;
+    };
 
-	if (!_isFIA) then
-	{
-		_groupE = grpNull;
-		if !(A3A_hasIFA) then
-		{
-			_pos = [getPos (_roads select 0), 7, _dirveh + 270] call BIS_Fnc_relPos;
-			if (worldname == "SPE_Normandy") then {
-				_bunker = "Land_SPE_Sandbag_Nest" createVehicle _pos;
-				_bunker setDir _dirveh;
-				_pos = _bunker modelToWorld [-0.200684,-0.91333,-0.421184];
-			} else {
-				_bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
-				_bunker setDir _dirveh;
-				_pos = getPosATL _bunker;
-			};
-			_vehiclesX pushBack _bunker;
-			_typeVehX = selectRandom (_faction get "staticMGs");
-			_veh = _typeVehX createVehicle _positionX;
-			_vehiclesX pushBack _veh;
-			_veh setPosATL _pos;
-			_veh setDir _dirVeh;
+    if (!_isFIA) then
+    {
+        _groupE = grpNull;
+        if !(A3A_hasIFA) then
+        {
+            _pos = [getPos (_roads select 0), 7, _dirveh + 270] call BIS_Fnc_relPos;
+            if (worldname == "SPE_Normandy") then {
+                _bunker = "Land_SPE_Sandbag_Nest" createVehicle _pos;
+                _bunker setDir _dirveh;
+                _pos = _bunker modelToWorld [-0.200684,-0.91333,-0.421184];
+            } else {
+                _bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
+                _bunker setDir _dirveh;
+                _pos = getPosATL _bunker;
+            };
+            _vehiclesX pushBack _bunker;
+            _typeVehX = selectRandom (_faction get "staticMGs");
+            _veh = _typeVehX createVehicle _positionX;
+            _vehiclesX pushBack _veh;
+            _veh setPosATL _pos;
+            _veh setDir _dirVeh;
 
-			_groupE = createGroup _sideX;
-			private _typeUnit = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
-			_unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-			_unit moveInGunner _veh;
-			_soldiers pushBack _unit;
-			sleep 1;
-			_pos = [getPos (_roads select 0), 7, _dirveh + 90] call BIS_Fnc_relPos;
-			if (worldname == "SPE_Normandy") then {
-				_bunker = "Land_SPE_Sandbag_Nest" createVehicle _pos;
-				_bunker setDir _dirveh + 180;
-				_pos = _bunker modelToWorld [-0.200684,-0.91333,-0.421184];
-				_vehiclesX pushBack _bunker;
-				_typeVehX = selectRandom (_faction get "staticMGs");
-				_veh = _typeVehX createVehicle _positionX;
-				_vehiclesX pushBack _veh;
-				_veh setPosATL _pos;
-				_veh setDir _dirVeh + 180;
+            _groupE = createGroup _sideX;
+            private _typeUnit = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
+            _unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+            _unit moveInGunner _veh;
+            _soldiers pushBack _unit;
+            sleep 1;
+            _pos = [getPos (_roads select 0), 7, _dirveh + 90] call BIS_Fnc_relPos;
+            if (worldname == "SPE_Normandy") then {
+                _bunker = "Land_SPE_Sandbag_Nest" createVehicle _pos;
+                _bunker setDir _dirveh + 180;
+                _pos = _bunker modelToWorld [-0.200684,-0.91333,-0.421184];
+                _vehiclesX pushBack _bunker;
+                _typeVehX = selectRandom (_faction get "staticMGs");
+                _veh = _typeVehX createVehicle _positionX;
+                _vehiclesX pushBack _veh;
+                _veh setPosATL _pos;
+                _veh setDir _dirVeh + 180;
 
-				private _typeUnit = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
-				_unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-				_unit moveInGunner _veh;
-				_soldiers pushBack _unit;
-			} else {
-				_bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
-				_bunker setDir _dirveh + 180;
-				_pos = getPosATL _bunker;
-				_vehiclesX pushBack _bunker;
-			};
-			_pos = [getPos _bunker, 6, getDir _bunker] call BIS_fnc_relPos;
-			_typeVehX = _faction get "flag";
-			_veh = createVehicle [_typeVehX, _pos, [],0, "NONE"];
-			_vehiclesX pushBack _veh;
-			if (flagTexture _veh != (_faction get "flagTexture")) then {[_veh,(_faction get "flagTexture")] remoteExec ["setFlagTexture",_veh]};
-			_veh setPosATL _pos;
-			_veh setDir _dirVeh;
-			sleep 1;
-			_unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-			_unit moveInGunner _veh;
-			_soldiers pushBack _unit;
-			sleep 1;
-			{ [_x, _sideX] call A3A_fnc_AIVEHinit } forEach _vehiclesX;
-		};
+                private _typeUnit = [_faction get "unitTierStaticCrew"] call SCRT_fnc_unit_getTiered;
+                _unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+                _unit moveInGunner _veh;
+                _soldiers pushBack _unit;
+            } else {
+                _bunker = "Land_BagBunker_01_Small_green_F" createVehicle _pos;
+                _bunker setDir _dirveh + 180;
+                _pos = getPosATL _bunker;
+                _vehiclesX pushBack _bunker;
+            };
+            _pos = [getPos _bunker, 6, getDir _bunker] call BIS_fnc_relPos;
+            _typeVehX = _faction get "flag";
+            _veh = createVehicle [_typeVehX, _pos, [],0, "NONE"];
+            _vehiclesX pushBack _veh;
+            if (flagTexture _veh != (_faction get "flagTexture")) then {[_veh,(_faction get "flagTexture")] remoteExec ["setFlagTexture",_veh]};
+            _veh setPosATL _pos;
+            _veh setDir _dirVeh;
+            sleep 1;
+            _unit = [_groupE, _typeUnit, _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+            _unit moveInGunner _veh;
+            _soldiers pushBack _unit;
+            sleep 1;
+            { [_x, _sideX] call A3A_fnc_AIVEHinit } forEach _vehiclesX;
+        };
         private _typeGroup = selectRandom (_faction get "groupsMilitiaMedium");
-		_groupX = [_positionX,_sideX, _typeGroup, true] call A3A_fnc_spawnGroup;
-		if !(isNull _groupX) then
-		{
-			if !(A3A_hasIFA) then
-			{
-				{[_x] join _groupX} forEach units _groupE;
-				deleteGroup _groupE;
-			};
-			if (random 10 < 2.5) then
-			{
-				_dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
-				_dogs pushBack _dog;
-				[_dog,_groupX] spawn A3A_fnc_guardDog;
-			};
+        _groupX = [_positionX,_sideX, _typeGroup, true] call A3A_fnc_spawnGroup;
+        if !(isNull _groupX) then
+        {
+            if !(A3A_hasIFA) then
+            {
+                {[_x] join _groupX} forEach units _groupE;
+                deleteGroup _groupE;
+            };
+            if (random 10 < 2.5) then
+            {
+                _dog = [_groupX, "Fin_random_F",_positionX,[],0,"FORM"] call A3A_fnc_createUnit;
+                _dogs pushBack _dog;
+                [_dog,_groupX] spawn A3A_fnc_guardDog;
+            };
 
-			[_groupX, "Patrol_Defend", 0, 50, -1, true, _positionX, false] call A3A_fnc_patrolLoop;
-			_groups pushBack _groupX;
+            [_groupX, "Patrol_Defend", 0, 50, -1, true, _positionX, false] call A3A_fnc_patrolLoop;
+            _groups pushBack _groupX;
 
-			// Forced non-spawner as they're very static.
-			{[_x,"",false] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _groupX;
-		};
-	}
-	else
-	{
-		private _vehicleGet = "";
-		switch (true) do 
-		{
-			private _tier9Vehicle = (_faction getOrDefault ["vehiclesLightTanks", []]);
-			if (_tier9Vehicle isEqualTo []) then {
-				_tier9Vehicle = "vehiclesAirborne";
-			};
+            // Forced non-spawner as they're very static.
+            {[_x,"",false] call A3A_fnc_NATOinit; _soldiers pushBack _x} forEach units _groupX;
+        };
+    }
+    else
+    {
+        private _vehicleGet = "";
+        switch (true) do 
+        {
+            private _tier9Vehicle = (_faction getOrDefault ["vehiclesLightTanks", []]);
+            if (_tier9Vehicle isEqualTo []) then {
+                _tier9Vehicle = "vehiclesAirborne";
+            };
 
-			case (tierWar >= 9): // if higher or equal to 9, grab military light tank (or airborne, if light tank not found)
-			{
-				_vehicleGet = _tier9Vehicle;
-			};
-			case (tierWar >= 6): // if higher or equal to 6, grab military APC
-			{
-				_vehicleGet = "vehiclesAPCs";
-			};
-			case (tierWar >= 3): // if higher or equal to 3, grab militia light armed car
-			{
-				_vehicleGet = "vehiclesMilitiaLightArmed";
-			};
-			default // incase it's less than 3 (or something is broken), just grab militia car
-			{
-				_vehicleGet = "vehiclesMilitiaCars";
-			};
-		};
-		_typeVehX = selectRandom (_faction get _vehicleGet);
-		_veh = _typeVehX createVehicle getPos (_roads select 0);
-		_veh setDir _dirveh + 90;
-		[_veh, _sideX] call A3A_fnc_AIVEHinit;
-		_vehiclesX pushBack _veh;
-		sleep 1;
-		_typeGroup = selectRandom (_faction get "groupsMilitiaMedium");
-		_groupX = [_positionX, _sideX, _typeGroup, true] call A3A_fnc_spawnGroup;
-		if !(isNull _groupX) then
-		{
-			_unit = [_groupX, _faction get "unitMilitiaGrunt", _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
-			_unit moveInGunner _veh;
-			{_soldiers pushBack _x; [_x,"", false] call A3A_fnc_NATOinit} forEach units _groupX;
-		};
-	};
+            case (tierWar >= 9): // if higher or equal to 9, grab military light tank (or airborne, if light tank not found)
+            {
+                _vehicleGet = _tier9Vehicle;
+            };
+            case (tierWar >= 6): // if higher or equal to 6, grab military APC
+            {
+                _vehicleGet = "vehiclesAPCs";
+            };
+            case (tierWar >= 3): // if higher or equal to 3, grab militia light armed car
+            {
+                _vehicleGet = "vehiclesMilitiaLightArmed";
+            };
+            default // incase it's less than 3 (or something is broken), just grab militia car
+            {
+                _vehicleGet = "vehiclesMilitiaCars";
+            };
+        };
+        _typeVehX = selectRandom (_faction get _vehicleGet);
+        _veh = _typeVehX createVehicle getPos (_roads select 0);
+        _veh setDir _dirveh + 90;
+        [_veh, _sideX] call A3A_fnc_AIVEHinit;
+        _vehiclesX pushBack _veh;
+        sleep 1;
+        _typeGroup = selectRandom (_faction get "groupsMilitiaMedium");
+        _groupX = [_positionX, _sideX, _typeGroup, true] call A3A_fnc_spawnGroup;
+        if !(isNull _groupX) then
+        {
+            _unit = [_groupX, _faction get "unitMilitiaGrunt", _positionX, [], 0, "NONE"] call A3A_fnc_createUnit;
+            _unit moveInGunner _veh;
+            {_soldiers pushBack _x; [_x,"", false] call A3A_fnc_NATOinit} forEach units _groupX;
+        };
+    };
 }
 else
 {
-	_markersX = markersX select {(getMarkerPos _x distance _positionX < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] == teamPlayer)};
-	_markersX = _markersX - ["Synd_HQ"] - watchpostsFIA - roadblocksFIA - aapostsFIA - atpostsFIA - hmgpostsFIA;
-	_frontierX = if (count _markersX > 0) then {true} else {false};
-	if (_frontierX) then
-	{
-		_cfg =  selectRandom (_faction get "groupSpecOpsRandom");
-		if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then
-		{
-			_sideX = Occupants;
-		};
-		_size = [_markerX] call A3A_fnc_sizeMarker;
-		if ({if (_x inArea _markerX) exitWith {1}} count allMines == 0) then
-		{
-			Debug_1("Creating a Minefield at %1", _markerX);
-			private _mines = (_faction get "minefieldAPERS");
-			for "_i" from 1 to 45 do {
-				_mineX = createMine [ selectRandom _mines ,_positionX,[],_size];
-				_sideX revealMine _mineX;
-			};
-		};
-		_groupX = [_positionX,_sideX, _cfg] call A3A_fnc_spawnGroup;
+    _markersX = markersX select {(getMarkerPos _x distance _positionX < distanceSPWN) and (sidesX getVariable [_x,sideUnknown] == teamPlayer)};
+    _markersX = _markersX - ["Synd_HQ"] - watchpostsFIA - roadblocksFIA - aapostsFIA - atpostsFIA - hmgpostsFIA;
+    _frontierX = if (count _markersX > 0) then {true} else {false};
+    if (_frontierX) then
+    {
+        _cfg =  selectRandom (_faction get "groupSpecOpsRandom");
+        if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then
+        {
+            _sideX = Occupants;
+        };
+        _size = [_markerX] call A3A_fnc_sizeMarker;
+        if ({if (_x inArea _markerX) exitWith {1}} count allMines == 0) then
+        {
+            Debug_1("Creating a Minefield at %1", _markerX);
+            private _mines = (_faction get "minefieldAPERS");
+            for "_i" from 1 to 45 do {
+                _mineX = createMine [ selectRandom _mines ,_positionX,[],_size];
+                _sideX revealMine _mineX;
+            };
+        };
+        _groupX = [_positionX,_sideX, _cfg] call A3A_fnc_spawnGroup;
 
-		[_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
-		_groups pushBack _groupX;
+        [_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
+        _groups pushBack _groupX;
 
-		_typeVehX = selectRandom (_faction get "uavsPortable");
-		if !(isNil "_typeVehX") then
-		{
-			sleep 1;
-			{_soldiers pushBack _x} forEach units _groupX;
-			_uav = createVehicle [_typeVehX, _positionX, [], 0, "FLY"];
-			[_sideX, _uav] call A3A_fnc_createVehicleCrew;
-			_vehiclesX pushBack _uav;
-			_groupUAV = group (crew _uav select 1);
-			{[_x] joinSilent _groupX; _pilots pushBack _x} forEach units _groupUAV;
-			deleteGroup _groupUAV;
-		};
-		{[_x, "", false] call A3A_fnc_NATOinit} forEach units _groupX;
-	}
-	else
-	{
-		private _aggro = [aggressionOccupants, aggressionInvaders] select (_sideX == Invaders);
-		if ((random 100) > ((tierWar * 3) + (_aggro / 5))) then {
-			_leave = true;
-		} else {	
-			private _sniperPair = [_faction get "groupTierPatrolSniper"] call SCRT_fnc_unit_getTiered;
-			private _groupX = [_positionX,_sideX, _sniperPair] call A3A_fnc_spawnGroup;
+        _typeVehX = selectRandom (_faction get "uavsPortable");
+        if !(isNil "_typeVehX") then
+        {
+            sleep 1;
+            {_soldiers pushBack _x} forEach units _groupX;
+            _uav = createVehicle [_typeVehX, _positionX, [], 0, "FLY"];
+            [_sideX, _uav] call A3A_fnc_createVehicleCrew;
+            _vehiclesX pushBack _uav;
+            _groupUAV = group (crew _uav select 1);
+            {[_x] joinSilent _groupX; _pilots pushBack _x} forEach units _groupUAV;
+            deleteGroup _groupUAV;
+        };
+        {[_x, "", false] call A3A_fnc_NATOinit} forEach units _groupX;
+    }
+    else
+    {
+        private _aggro = [aggressionOccupants, aggressionInvaders] select (_sideX == Invaders);
+        if ((random 100) > ((tierWar * 3) + (_aggro / 5))) then {
+            _leave = true;
+        } else {	
+            private _sniperPair = [_faction get "groupTierPatrolSniper"] call SCRT_fnc_unit_getTiered;
+            private _groupX = [_positionX,_sideX, _sniperPair] call A3A_fnc_spawnGroup;
 
-			[_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
-			_groups pushBack _groupX;
-			{[_x, "", false] call A3A_fnc_NATOinit} forEach units _groupX;
-		};
-	};
+            [_groupX, "Patrol_Area", 25, 150, 300, false, [], false] call A3A_fnc_patrolLoop;
+            _groups pushBack _groupX;
+            {[_x, "", false] call A3A_fnc_NATOinit} forEach units _groupX;
+        };
+    };
 };
 if (_leave) exitWith {};
 
@@ -255,34 +255,34 @@ if (_leave) exitWith {};
 _spawnStatus = 0;
 while {(spawner getVariable _markerX != 2) and ({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers > 0)} do
 {
-	if ((spawner getVariable _markerX == 1) and (_spawnStatus != spawner getVariable _markerX)) then
-	{
-		_spawnStatus = 1;
-		if (isMultiplayer) then
-		{
-			{if (vehicle _x == _x) then {[_x,false] remoteExec ["enableSimulationGlobal",2]}} forEach _soldiers
-		}
-		else
-		{
-			{if (vehicle _x == _x) then {_x enableSimulationGlobal false}} forEach _soldiers
-		};
-	}
-	else
-	{
-		if ((spawner getVariable _markerX == 0) and (_spawnStatus != spawner getVariable _markerX)) then
-		{
-			_spawnStatus = 0;
-			if (isMultiplayer) then
-			{
-				{if (vehicle _x == _x) then {[_x,true] remoteExec ["enableSimulationGlobal",2]}} forEach _soldiers
-			}
-			else
-			{
-				{if (vehicle _x == _x) then {_x enableSimulationGlobal true}} forEach _soldiers
-			};
-		};
-	};
-	sleep 3;
+    if ((spawner getVariable _markerX == 1) and (_spawnStatus != spawner getVariable _markerX)) then
+    {
+        _spawnStatus = 1;
+        if (isMultiplayer) then
+        {
+            {if (vehicle _x == _x) then {[_x,false] remoteExec ["enableSimulationGlobal",2]}} forEach _soldiers
+        }
+        else
+        {
+            {if (vehicle _x == _x) then {_x enableSimulationGlobal false}} forEach _soldiers
+        };
+    }
+    else
+    {
+        if ((spawner getVariable _markerX == 0) and (_spawnStatus != spawner getVariable _markerX)) then
+        {
+            _spawnStatus = 0;
+            if (isMultiplayer) then
+            {
+                {if (vehicle _x == _x) then {[_x,true] remoteExec ["enableSimulationGlobal",2]}} forEach _soldiers
+            }
+            else
+            {
+                {if (vehicle _x == _x) then {_x enableSimulationGlobal true}} forEach _soldiers
+            };
+        };
+    };
+    sleep 3;
 };
 
 ["locationSpawned", [_markerX, "Control", true]] call EFUNC(Events,triggerEvent);
@@ -293,43 +293,43 @@ _conquered = false;
 _winner = Occupants;
 if (spawner getVariable _markerX != 2) then
 {
-	_conquered = true;
-	_allUnits = allUnits select {(side _x != civilian) and (side _x != _sideX) and (alive _x) and (!captive _x)};
-	_closest = [_allUnits,_positionX] call BIS_fnc_nearestPosition;
-	_winner = side _closest;
-	_loser = Occupants;
+    _conquered = true;
+    _allUnits = allUnits select {(side _x != civilian) and (side _x != _sideX) and (alive _x) and (!captive _x)};
+    _closest = [_allUnits,_positionX] call BIS_fnc_nearestPosition;
+    _winner = side _closest;
+    _loser = Occupants;
     Debug_3("Control %1 captured by %2. Is Roadblock: %3", _markerX, _winner, _isControl);
-	if (_isControl) then
-	{
-		["TaskSucceeded", ["", "Roadblock Destroyed"]] remoteExec ["BIS_fnc_showNotification",_winner];
-		["TaskFailed", ["", "Roadblock Lost"]] remoteExec ["BIS_fnc_showNotification",_sideX];
-	};
-	if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then
-	{
-		if (_winner == Invaders) then
-		{
-			_nul = [-5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-			sidesX setVariable [_markerX,Invaders,true];
-		}
-		else
-		{
-			sidesX setVariable [_markerX,teamPlayer,true];
-		};
-	}
-	else
-	{
-		_loser = Invaders;
-		if (_winner == Occupants) then
-		{
-			sidesX setVariable [_markerX,Occupants,true];
-			_nul = [5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		}
-		else
-		{
-			sidesX setVariable [_markerX,teamPlayer,true];
-			_nul = [0,5,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
-		};
-	};
+    if (_isControl) then
+    {
+        ["TaskSucceeded", ["", "Roadblock Destroyed"]] remoteExec ["BIS_fnc_showNotification",_winner];
+        ["TaskFailed", ["", "Roadblock Lost"]] remoteExec ["BIS_fnc_showNotification",_sideX];
+    };
+    if (sidesX getVariable [_markerX,sideUnknown] == Occupants) then
+    {
+        if (_winner == Invaders) then
+        {
+            _nul = [-5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
+            sidesX setVariable [_markerX,Invaders,true];
+        }
+        else
+        {
+            sidesX setVariable [_markerX,teamPlayer,true];
+        };
+    }
+    else
+    {
+        _loser = Invaders;
+        if (_winner == Occupants) then
+        {
+            sidesX setVariable [_markerX,Occupants,true];
+            _nul = [5,0,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
+        }
+        else
+        {
+            sidesX setVariable [_markerX,teamPlayer,true];
+            _nul = [0,5,_positionX] remoteExec ["A3A_fnc_citySupportChange",2];
+        };
+    };
 };
 
 waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
@@ -341,47 +341,47 @@ waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 { deleteGroup _x } forEach _groups;
 
 {
-	// delete all vehicles that haven't been captured
-	if (_x getVariable ["ownerSide", _sideX] == _sideX) then {
-		if (_x distance2d (_x getVariable "originalPos") < 100) then { deleteVehicle _x }
-		else { if !(_x isKindOf "StaticWeapon") then { [_x] spawn A3A_fnc_VEHdespawner } };
-	};
+    // delete all vehicles that haven't been captured
+    if (_x getVariable ["ownerSide", _sideX] == _sideX) then {
+        if (_x distance2d (_x getVariable "originalPos") < 100) then { deleteVehicle _x }
+        else { if !(_x isKindOf "StaticWeapon") then { [_x] spawn A3A_fnc_VEHdespawner } };
+    };
 } forEach _vehiclesX;
 
 
 if (_conquered) then
 {
-	_indexX = controlsX find _markerX;
-	if (_indexX > defaultControlIndex) then
-	{
-		_timeLimit = 120;//120
-		_dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
-		_dateLimitNum = dateToNumber _dateLimit;
-		waitUntil {sleep 60;(dateToNumber date > _dateLimitNum)};
-		_base = [(markersX - controlsX),_positionX] call BIS_fnc_nearestPosition;
-		if (sidesX getVariable [_base,sideUnknown] == Occupants) then
-		{
-			sidesX setVariable [_markerX,Occupants,true];
-		}
-		else
-		{
-			if (sidesX getVariable [_base,sideUnknown] == Invaders) then
-			{
-				sidesX setVariable [_markerX,Invaders,true];
-			};
-		};
-	}
-	else
-	{
-		if ((!_isControl) and (_winner == teamPlayer)) then
-			{
-			_size = [_markerX] call A3A_fnc_sizeMarker;
-			for "_i" from 1 to 60 do
-				{
-				_mineX = createMine ["APERSMine",_positionX,[],_size];
-				if (_loser == Occupants) then {Occupants revealMine _mineX} else {Invaders revealMine _mineX};
-				};
-			};
-	};
+    _indexX = controlsX find _markerX;
+    if (_indexX > defaultControlIndex) then
+    {
+        _timeLimit = 120;//120
+        _dateLimit = [date select 0, date select 1, date select 2, date select 3, (date select 4) + _timeLimit];
+        _dateLimitNum = dateToNumber _dateLimit;
+        waitUntil {sleep 60;(dateToNumber date > _dateLimitNum)};
+        _base = [(markersX - controlsX),_positionX] call BIS_fnc_nearestPosition;
+        if (sidesX getVariable [_base,sideUnknown] == Occupants) then
+        {
+            sidesX setVariable [_markerX,Occupants,true];
+        }
+        else
+        {
+            if (sidesX getVariable [_base,sideUnknown] == Invaders) then
+            {
+                sidesX setVariable [_markerX,Invaders,true];
+            };
+        };
+    }
+    else
+    {
+        if ((!_isControl) and (_winner == teamPlayer)) then
+            {
+            _size = [_markerX] call A3A_fnc_sizeMarker;
+            for "_i" from 1 to 60 do
+                {
+                _mineX = createMine ["APERSMine",_positionX,[],_size];
+                if (_loser == Occupants) then {Occupants revealMine _mineX} else {Invaders revealMine _mineX};
+                };
+            };
+    };
 };
 ["locationSpawned", [_markerX, "Control", false]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -34,25 +34,12 @@ _isControl = if (isOnRoad _positionX) then {true} else {false};
 
 if (_isControl) then
 {
-	if (gameMode != 4) then
+	if (_sideX == Occupants) then
 	{
-		if (_sideX == Occupants) then
+	if ((random 10 > (tierWar + difficultyCoef)) and (!([_markerX] call A3A_fnc_isFrontline))) then
 		{
-		if ((random 10 > (tierWar + difficultyCoef)) and (!([_markerX] call A3A_fnc_isFrontline))) then
-			{
-				_isFIA = true;
-			}
-		};
-	}
-	else
-	{
-		if (_sideX == Invaders) then
-		{
-			if ((random 10 > (tierWar + difficultyCoef)) and (!([_markerX] call A3A_fnc_isFrontline))) then
-			{
-				_isFIA = true;
-			}
-		};
+			_isFIA = true;
+		}
 	};
 
 	// Attempt to find nearby road with two connected roads

--- a/A3A/addons/core/functions/init/fn_briefing.sqf
+++ b/A3A/addons/core/functions/init/fn_briefing.sqf
@@ -99,9 +99,6 @@ switch (gameMode) do {
 	case 3: {
 		player createDiaryRecord ["Diary",[format [localize "STR_antistasi_journal_entry_header_gamemode"],format [localize "STR_antistasi_journal_entry_text_gamemode_2",_nameOcc,_nameReb]]]
 	};
-	case 4: {
-		player createDiaryRecord ["Diary",[format [localize "STR_antistasi_journal_entry_header_gamemode"],format [localize "STR_antistasi_journal_entry_text_gamemode_1",_nameInv,_nameReb]]]
-	};
 	Default {
 		player createDiaryRecord ["Diary",[format [localize "STR_antistasi_journal_entry_header_gamemode"],format [localize "STR_antistasi_journal_entry_text_gamemode_4",_nameOcc,_nameInv,_nameReb]]]
 	};

--- a/A3A/addons/core/functions/init/fn_initGarrisons.sqf
+++ b/A3A/addons/core/functions/init/fn_initGarrisons.sqf
@@ -21,7 +21,7 @@ _fnc_initGarrison =
 };
 
 private _updateMarkers = outposts + airportsX + milbases;			// To sort out the faction names & flags
-if (gameMode >= 3) then
+if (gameMode == 3) then
 {
     // Set everything to government control if we have no invaders
     {

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -98,11 +98,12 @@ boxX call jn_fnc_arsenal_init;
 [A3A_saveData] call A3A_fnc_initVarServer;
 
 // Parameter-dependent vars. Could be moved to initVarServer...
-if (gameMode != 1) then {
-    Occupants setFriend [Invaders,1];
-    Invaders setFriend [Occupants,1];
-    if (gameMode == 3) then {"CSAT_carrier" setMarkerAlpha 0};
-    if (gameMode == 4) then {"NATO_carrier" setMarkerAlpha 0};
+switch (gameMode) do {
+    case (2): {
+        Occupants setFriend [Invaders,1];
+        Invaders setFriend [Occupants,1];
+    };
+    case (3): { "CSAT_carrier" setMarkerAlpha 0 };
 };
 
 setTimeMultiplier settingsTimeMultiplier;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -325,7 +325,7 @@ A3A_factionEquipFlags = _occEquipFlags arrayIntersect _invEquipFlags;
 
 Debug_1("Faction equip flags: %1", A3A_factionEquipFlags);
 
-if (gameMode isEqualTo 3) {
+if (gameMode isEqualTo 3) then {
 	areInvadersDefeated = true;
 	publicVariable "areInvadersDefeated";
 };

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -325,15 +325,9 @@ A3A_factionEquipFlags = _occEquipFlags arrayIntersect _invEquipFlags;
 
 Debug_1("Faction equip flags: %1", A3A_factionEquipFlags);
 
-switch (gameMode) do {
-	case 3: {
-		areInvadersDefeated = true;
-		publicVariable "areInvadersDefeated";
-	};
-	case 4: {
-		areOccupantsDefeated = true;
-		publicVariable "areOccupantsDefeated";
-	};
+if (gameMode isEqualTo 3) {
+	areInvadersDefeated = true;
+	publicVariable "areInvadersDefeated";
 };
 
 // Build list of extra equipment mods so we can filter out the modern stuff as necessary

--- a/A3A/addons/patcom/functions/Patcom/fn_patrolGetEnemies.sqf
+++ b/A3A/addons/patcom/functions/Patcom/fn_patrolGetEnemies.sqf
@@ -6,27 +6,17 @@ private _side = side _group;
 private _enemySides = [];
 private _knownEnemies = [];
 
-if (_side isEqualTo Occupants) then {
-    if (gameMode != 1) then {
-        _enemySides = [teamPlayer, sideEnemy];
-    } else {
-        _enemySides = [Invaders, teamPlayer, sideEnemy];
+_enemySides = if (gameMode isEqualTo 2) then {
+    switch (_side) do {
+        case (teamPlayer): { [Occupants, Invaders, sideEnemy] };
+        case (Occupants);
+        case (Invaders): { [teamPlayer, sideEnemy] };
     };
-};
-
-if (_side isEqualTo Invaders) then {
-    if (gameMode != 1) then {
-        _enemySides = [teamPlayer, sideEnemy];
-    } else {
-        _enemySides = [Occupants, teamPlayer, sideEnemy];
-    };
-};
-
-if (_side isEqualTo teamPlayer) then {
-    if (gameMode != 1) then {
-        _enemySides = [Occupants, sideEnemy];
-    } else {
-        _enemySides = [Occupants, Invaders, sideEnemy];
+} else {
+    switch (_side) do {
+        case (teamPlayer): { [Occupants, Invaders, sideEnemy] };
+        case (Occupants): { [teamPlayer, Invaders, sideEnemy] };
+        case (Invaders): { [teamPlayer, Occupants, sideEnemy] };
     };
 };
 


### PR DESCRIPTION
## What type of PR is this?
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:

Fixes side relations when playing any gamemode other than default Reb vs. Occ vs. Inv.

Zombies and rivals will now attack blufor when invaders are disabled.

The major caveat is if you play gamemode 2 (Reb vs. Occ and Inv), opfor and blufor are aligned ==> zombies / rivals will not attack anyone except rebels (unless they're spawned as renegades) :(

### Please specify which Issue this PR Resolves (If Applicable).
This PR closes [discord](https://discord.com/channels/817005365740044289/1361463584911134812/1361465091584954508)

### Please verify the following.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [ ] No
2. [x] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:

********************************************************
Notes:

Also removes a bunch of legacy code used for the now-removed gamemode 4 (Reb vs. Inv). Could use thorough testing to ensure no unintended side-effects.