### PR TITLE
Allow for A3UE parameters, add save game events

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -727,13 +727,6 @@ class Params
         type = "A3UE";
         lockOnSave = 0;
     };
-    class TitleA3UE: A3UEParams
-    {
-        title = $STR_params_A3UE_header;
-        values[] = {""};
-        texts[] = {""};
-        default = "";
-    };
 
     class BalanceParams
     {

--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -8,7 +8,7 @@ class Params
         };
 
         * params need to inherit from that class,
-        * and you need to add the type string to A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+        * and you need to register the params category to A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
 
         * Example:
 
@@ -31,40 +31,27 @@ class Params
             default = 69;
         };
 
-        * and in A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf (case ("update")):
+        * and on the top of A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf:
 
-        private _shownTypes = switch (lbCurSel A3A_IDC_SETUP_PARAMSTYPE) do {
-            case (-1): { [] }; // lbCurSel is -1 until params tab is loaded
-            case (0): { ["Basic"] };
-            case (1): { ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot", "SuperDuperCool"] }; // Generally, new sections can probably be added here to show up as a section under "Advanced Params"
-            case (2): { ["Experimental"] };
-            case (3): { ["Development"] };
-        };
+        private _paramsCategories = [
+            [localize "STR_antistasi_dialogs_setup_params_basic_label", ["Basic"]],
+            [localize "STR_antistasi_dialogs_setup_params_adv_label", ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot", "SuperDuperCool"]], // <-- append here
+            [localize "STR_antistasi_dialogs_setup_params_exp_label", ["Experimental"]],
+            [localize "STR_antistasi_dialogs_setup_params_a3ue_label", ["A3UE"]],
+            [localize "STR_antistasi_dialogs_setup_params_dev_label", ["Development"]]
+        ];
 
         * if you want your section to show up as an entirely new option in the Parameter Types Dropdown ComboBox,
-        * you'll need to add the type to the dropdown under case ("onLoad") like: 
+        * simply add it to the _paramsCategories array above, like so:
 
-        // * Populate the Parameter Type Dropdown
-        private _basicParamsIndex =  _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_basic_label");
-        private _advParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_adv_label");
-        private _expParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_exp_label");
-        private _devParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_dev_label");
-        private _sdcParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_sdc_label"); // give it a text value here
-
-        _paramsType lbSetValue [_basicParamsIndex, 0];
-        _paramsType lbSetValue [_advParamsIndex, 1];
-        _paramsType lbSetValue [_expParamsIndex, 2];
-        _paramsType lbSetValue [_devParamsIndex, 3];
-        _paramsType lbSetValue [_sdcParamsIndex, 4]; // and give it an integer value here
-
-        _paramsType lbSetCurSel _basicParamsIndex;
-
-        * and then add a new case with the above integer value in the _shownTypes switch like:
-
-        private _shownTypes = switch (lbCurSel A3A_IDC_SETUP_PARAMSTYPE) do {
-            ...
-            case (4): { ["SuperDuperCool"] };
-        };
+        private _paramsCategories = [
+            [localize "STR_antistasi_dialogs_setup_params_basic_label", ["Basic"]],
+            [localize "STR_antistasi_dialogs_setup_params_adv_label", ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot"]],
+            [localize "STR_antistasi_dialogs_setup_params_exp_label", ["Experimental"]],
+            [localize "STR_antistasi_dialogs_setup_params_a3ue_label", ["A3UE"]],
+            [localize "STR_SuperDuperCool_params_name", ["SuperDuperCool"]], // <-- add this line
+            [localize "STR_antistasi_dialogs_setup_params_dev_label", ["Development"]]
+        ];
 
     */
 

--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -722,6 +722,19 @@ class Params
         default = 5;
     };
 
+    class A3UEParams
+    {
+        type = "A3UE";
+        lockOnSave = 0;
+    };
+    class TitleA3UE: A3UEParams
+    {
+        title = $STR_params_A3UE_header;
+        values[] = {""};
+        texts[] = {""};
+        default = "";
+    };
+
     class BalanceParams
     {
         type = "Balance";

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -9,6 +9,8 @@ savingServer = true;
 Info("Starting persistent save");
 [localize "STR_A3A_save_persisent_save",localize "STR_A3A_save_save_game_starting"] remoteExecCall ["A3A_fnc_customHint",0,false];
 
+["GameSaveBefore"] call A3A_Events_fnc_triggerEvent;
+
 // Set next autosave time, so that we won't run another shortly after a manual save
 autoSaveTime = time + autoSaveInterval;
 
@@ -475,6 +477,8 @@ _fuelAmountleftArray = [];
 
 //Saving the state of the testing timer
 ["testingTimerIsActive", testingTimerIsActive] call A3A_fnc_setStatVariable;
+
+["GameSaveAfter"] call A3A_Events_fnc_triggerEvent;
 
 if (_saveToNewNamespace) then { saveMissionProfileNamespace } else { saveProfileNamespace };
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -9,6 +9,8 @@ savingServer = true;
 Info("Starting persistent save");
 [localize "STR_A3A_save_persisent_save",localize "STR_A3A_save_save_game_starting"] remoteExecCall ["A3A_fnc_customHint",0,false];
 
+["GameSaveBefore"] call A3A_Events_fnc_triggerEvent;
+
 // Set next autosave time, so that we won't run another shortly after a manual save
 autoSaveTime = time + autoSaveInterval;
 
@@ -474,6 +476,8 @@ _fuelAmountleftArray = [];
 
 //Saving the state of the testing timer
 ["testingTimerIsActive", testingTimerIsActive] call A3A_fnc_setStatVariable;
+
+["GameSaveAfter"] call A3A_Events_fnc_triggerEvent;
 
 if (_saveToNewNamespace) then { saveMissionProfileNamespace } else { saveProfileNamespace };
 

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -154,17 +154,6 @@ class Events {
         isLocal = 1;
         class params {};
     };
-    // Triggered before putting a vehicle in the garage; event code may modify vehicle's `A3A_Vehicle_ShouldGarage` variable to prevent it from being garaged
-    class VehicleGaragedBefore {
-        isLocal = 1;
-        class params {
-            class _0 {
-                description = "Vehicle being garaged";
-                types[] = {"OBJECT"};
-                optional = 0;
-            };
-        };
-    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -144,6 +144,27 @@ class Events {
             };
         };
     };
+    // Triggered after saving core game data, at the bottom of `A3A_fnc_saveLoop` before `saveMissionProfileNamespace`
+    class GameSaveAfter {
+        isLocal = 1;
+        class params {};
+    };
+    // Triggered before saving core game data, at the top of `A3A_fnc_saveLoop` right after `savingServer` flag
+    class GameSaveBefore {
+        isLocal = 1;
+        class params {};
+    };
+    // Triggered before putting a vehicle in the garage; event code may modify vehicle's `A3A_Vehicle_ShouldGarage` variable to prevent it from being garaged
+    class VehicleGaragedBefore {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Vehicle being garaged";
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -153,6 +153,13 @@ private _unloadAceCargo = {
 if (_vehicle getVariable ["HR_GRG_Garaging", false]) exitWith {};
 _vehicle setVariable ["HR_GRG_Garaging", true];
 
+_vehicle setVariable ["A3A_Vehicle_ShouldGarage", true];
+["VehicleGaragedBefore", [_vehicle]] call A3A_Events_fnc_triggerEvent;
+
+if !(_vehicle getVariable "A3A_Vehicle_ShouldGarage") exitWith {
+    _vehicle setVariable ["HR_GRG_Garaging", false];
+};
+
 private _addVehicle = {
     //check if compatible with garage
     private _class = typeOf _this;

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -153,13 +153,6 @@ private _unloadAceCargo = {
 if (_vehicle getVariable ["HR_GRG_Garaging", false]) exitWith {};
 _vehicle setVariable ["HR_GRG_Garaging", true];
 
-_vehicle setVariable ["A3A_Vehicle_ShouldGarage", true];
-["VehicleGaragedBefore", [_vehicle]] call A3A_Events_fnc_triggerEvent;
-
-if !(_vehicle getVariable "A3A_Vehicle_ShouldGarage") exitWith {
-    _vehicle setVariable ["HR_GRG_Garaging", false];
-};
-
 private _addVehicle = {
     //check if compatible with garage
     private _class = typeOf _this;

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -3262,6 +3262,17 @@
                 <Portuguese>Parâmetros experimentais</Portuguese>
                 <Chinesesimp>实验参数</Chinesesimp>
             </Key>
+            <Key ID="STR_antistasi_dialogs_setup_params_a3ue_label">
+                <Original>A3UE Parameters</Original>
+                <Czech>Parametry A3UE</Czech>
+                <French>Paramètres A3UE</French>
+                <Italian>Parametri A3UE</Italian>
+                <Korean>A3UE 매개 변수</Korean>
+                <Russian>Параметры A3UE</Russian>
+                <Polish>Parametry A3UE</Polish>
+                <Portuguese>Parâmetros A3UE</Portuguese>
+                <Chinesesimp>A3UE 参数</Chinesesimp>
+            </Key>
             <Key ID="STR_antistasi_dialogs_setup_params_dev_label">
                 <Original>Development Parameters</Original>
                 <Czech>Parametry vývoje</Czech>

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -25,12 +25,14 @@ switch (_mode) do
         private _basicParamsIndex =  _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_basic_label");
         private _advParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_adv_label");
         private _expParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_exp_label");
+        private _a3ueParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_a3ue_label");
         private _devParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_dev_label");
 
         _paramsType lbSetValue [_basicParamsIndex, 0];
         _paramsType lbSetValue [_advParamsIndex, 1];
         _paramsType lbSetValue [_expParamsIndex, 2];
-        _paramsType lbSetValue [_devParamsIndex, 3];
+        _paramsType lbSetValue [_a3ueParamsIndex, 3];
+        _paramsType lbSetValue [_devParamsIndex, 4];
 
         _paramsType lbSetCurSel _basicParamsIndex;
 
@@ -192,7 +194,8 @@ switch (_mode) do
             case (0): { ["Basic"] };
             case (1): { ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot"] };
             case (2): { ["Experimental"] };
-            case (3): { ["Development"] };
+            case (3): { ["A3UE"] };
+            case (4): { ["Development"] };
         };
 
         private _rowCount = -1;

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupParamsTab.sqf
@@ -17,29 +17,55 @@ private _display = findDisplay A3A_IDD_SETUPDIALOG;
 private _paramsTable = _display displayCtrl A3A_IDC_SETUP_PARAMSTABLE;
 private _paramsType = _display displayCtrl A3A_IDC_SETUP_PARAMSTYPE;
 
+private _paramsCategories = [
+    [localize "STR_antistasi_dialogs_setup_params_basic_label", ["Basic"]],
+    [localize "STR_antistasi_dialogs_setup_params_adv_label", ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot"]],
+    [localize "STR_antistasi_dialogs_setup_params_exp_label", ["Experimental"]],
+    [localize "STR_antistasi_dialogs_setup_params_a3ue_label", ["A3UE"]],
+    [localize "STR_antistasi_dialogs_setup_params_dev_label", ["Development"]]
+];
+
+/**
+ * Creates a map from the selection index to the parameter types.
+ *
+ * Resulting map looks like this:
+ * ```
+ * [
+ *     [0, ["Basic"]],
+ *     [1, ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot"]],
+ *     // etc.
+ * ]
+ * ```
+ */
+private _selectionToTypesMap = createHashMapFromArray([] call {
+    private _map = [];
+
+    {
+        _map pushBack[_foreachIndex, _x select 1];
+    } forEach _paramsCategories;
+
+    _map;
+});
+
 switch (_mode) do
 {
     case ("onLoad"):
     {
         // * Populate the Parameter Type Dropdown
-        private _basicParamsIndex =  _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_basic_label");
-        private _advParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_adv_label");
-        private _expParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_exp_label");
-        private _a3ueParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_a3ue_label");
-        private _devParamsIndex = _paramsType lbAdd (localize "STR_antistasi_dialogs_setup_params_dev_label");
+        {
+            _x params[["_title", "", [""]]];
+            private _index = _paramsType lbAdd _title;
+            _paramsType lbSetValue[_index, _foreachIndex];
+        } forEach _paramsCategories;
 
-        _paramsType lbSetValue [_basicParamsIndex, 0];
-        _paramsType lbSetValue [_advParamsIndex, 1];
-        _paramsType lbSetValue [_expParamsIndex, 2];
-        _paramsType lbSetValue [_a3ueParamsIndex, 3];
-        _paramsType lbSetValue [_devParamsIndex, 4];
-
-        _paramsType lbSetCurSel _basicParamsIndex;
+        _paramsType lbSetCurSel 0;
 
         // * Create ALL the param controls
         private _allCtrls = [];
         private _allTextCtrls = [];
         private _allValsCtrls = [];
+        private _optionsSeen = createHashMap;
+
         {
             private _type = getText (_x/"type");
             private _title = getText (_x/"title");
@@ -49,18 +75,20 @@ switch (_mode) do
             private _default = getNumber (_x/"default");
             private _defaultIndex = _vals find _default;
 
-            if (!isNil "_title") then {
-                private _textCtrl = _display ctrlCreate ["A3A_Text_Small", A3A_IDC_SETUP_PARAMSTEXT + _forEachIndex, _paramsTable];
-                _allTextCtrls pushBack [configName _x, _textCtrl];
-                _textCtrl ctrlEnable false;
-                _textCtrl ctrlSetFade 1;
-                _textCtrl ctrlSetText _title;
-                if (_tooltip isNotEqualTo "") then {
-                    _textCtrl ctrlSetTooltip _tooltip;
-                };
-                _textCtrl setVariable ["type", _type];
-                _textCtrl ctrlCommit 0;
+            if isText(_x / "title") then {
+                _optionsSeen set[_type, true]; // seen at least one instance of this type
             };
+
+            private _textCtrl = _display ctrlCreate ["A3A_Text_Small", A3A_IDC_SETUP_PARAMSTEXT + _forEachIndex, _paramsTable];
+            _allTextCtrls pushBack [configName _x, _textCtrl];
+            _textCtrl ctrlEnable false;
+            _textCtrl ctrlSetFade 1;
+            _textCtrl ctrlSetText _title;
+            if (_tooltip isNotEqualTo "") then {
+                _textCtrl ctrlSetTooltip _tooltip;
+            };
+            _textCtrl setVariable ["type", _type];
+            _textCtrl ctrlCommit 0;
 
             if (_title isNotEqualTo "" && {_texts isNotEqualTo [""]}) then {
                 private _valsCtrl = _display ctrlCreate ["A3A_ComboBox_Small", A3A_IDC_SETUP_PARAMSVALS + _forEachIndex, _paramsTable];
@@ -184,20 +212,29 @@ switch (_mode) do
         _paramsTable setVariable ["allTextCtrls", _allTextCtrls];
         _paramsTable setVariable ["allValsCtrls", _allValsCtrls];
 
+        // Now look for empty listbox rows and remove them (right now to suppress showing empty "A3UE" section)
+        _selectionToTypesMap apply {
+            private _selection = _x;
+            private _types = _y;
+            private _found = (keys _optionsSeen findIf { _x in _types }) isNotEqualTo -1;
+
+            if (!_found) then {
+                for "_i" from 0 to ((lbSize A3A_IDC_SETUP_PARAMSTYPE) - 1) do {
+                    if (lbValue[A3A_IDC_SETUP_PARAMSTYPE, _i] isEqualTo _selection) then {
+                        lbDelete[A3A_IDC_SETUP_PARAMSTYPE, _i];
+                        break;
+                    };
+                };
+            };            
+        };
+
         ["update"] call A3A_fnc_setupParamsTab;
     };
 
 	case ("update"):
     {
-        private _shownTypes = switch (lbCurSel A3A_IDC_SETUP_PARAMSTYPE) do {
-            case (-1): { [] }; // lbCurSel is -1 until params tab is loaded
-            case (0): { ["Basic"] };
-            case (1): { ["Ultimate", "Script", "Plus", "Member", "Builder", "Balance", "Equipment", "Loot"] };
-            case (2): { ["Experimental"] };
-            case (3): { ["A3UE"] };
-            case (4): { ["Development"] };
-        };
-
+        private _selection = lbValue[A3A_IDC_SETUP_PARAMSTYPE, lbCurSel A3A_IDC_SETUP_PARAMSTYPE];
+        private _shownTypes = _selectionToTypesMap getOrDefault[_selection, []];
         private _rowCount = -1;
         private _allValsCtrls = createHashMapFromArray (_paramsTable getVariable "allValsCtrls");
         {


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [X] Change
- [ ] Feature
- [X] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [X] Config
- [X] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Added an additional parameters section to allow for A3UEs to be configured via A3U server setup dialog.

This way, A3UE authors can use Antistasi's setup dialog to configure themselves (maybe instead of spamming the CBA addon options). In e.g. the `config.cpp` of an Antistasi Ultimate extension, they'll put:

```
class A3A {
    class Params {
        class A3UEParams;

        class GVAR(Header): A3UEParams {
            title = CSTRING(Title);
            values[] = {""};
            texts[] = {""};
            default = "";
        };

        class GVAR(EnableModFeature): A3UEParams {
            title = "Enable Feature";
            values[] = {0,1};
            texts[] = {"$STR_antistasi_dialogs_generic_button_no_text", "$STR_antistasi_dialogs_generic_button_yes_text"};
            default = 1;
        };
    };
};
```

If no subclasses of `A3UEParams` are found, the drop down in setup dialog won't show the "A3UE Parameters" option.

> Added two events to subscribe to before and after using the persistent save so A3UEs can save their game data, too.

**How can your changes be tested, or reproduced?**

1. Download a copy of my A3UE ("Friendly Skies") that has been prepared for the above feature and install it as a local mod [from here](https://gitlab.perfect-co.de/arma3/a3ue-friendly-skies/-/blob/feature/a3ue-config/a3uefs-latest.zip?ref_type=heads).
2. Mission setup dialog should now show the "A3UE Parameters" drop down option
3. Uninstall local mod, run the game again
4. Mission setup dialog should NOT show the "A3UE Parameters" drop down option


**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following (If possible).

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review, or will be marked as a draft. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
