### PR TITLE
Increase distance threshold when validating fast-travel map clicks

### DIFF
--- a/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
+++ b/A3A/addons/core/functions/Dialogs/fn_fastTravelRadio.sqf
@@ -139,7 +139,7 @@ if ([getMarkerPos _base] call A3A_fnc_enemyNearCheck) exitWith {
 	openMap [false,false];
 };
 
-if (_positionTel distance getMarkerPos _base < 50) then {
+if (_positionTel distance getMarkerPos _base < 500) then {
 	private _positionX = [getMarkerPos _base, 10, random 360] call BIS_Fnc_relPos;
 	private _distanceX = round (((position _boss) distance _positionX)/200);
 	private _forcedX = false;


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

Right now, you must click within 50 meters of a marker when trying to fast travel or fast traveling will fail. This threshold does not depend on what the map's zoom level is, and makes for a frustrating experience when zoomed out.

This commit increases the threshold 10x to 500 meters.

**How can your changes be tested, or reproduced?**

Press Y -> Click Fast Travel -> Click within 500 meters of a friendly marker on the map.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
N/A

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>