### PR TITLE
Add factory and resource rebuilding functionality to Rebuild Assets button

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -166,6 +166,7 @@ class CfgFunctions
             class playableUnits {};
             class getSideRadioTowerInfluence {};
             class rebuildAssets {};
+            class rebuildEconomicAssets {};
             class rebuildRadioTower {};
             class relocateHQObjects {};
             class repairRuinedBuilding {};

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -152,16 +152,16 @@
                 <Polish>Odbuduj</Polish>
             </Key>
             <Key ID="STR_antistasi_dialogs_hq_button_rebuild_assets_tooltip">
-                <Original>Rebuilds radio towers and military buildings on selected marker. Cost 5000.</Original>
-                <French>Reconstruit les tours radio et les bâtiments militaires sur le marqueur sélectionné. Coût 5000.</French>
-                <Russian>Восстанавливает радиовышки и военные здания на выбранном маркере. Стоимость 5000.</Russian>
-                <German>Baut Funktürme und Militärgebäude auf ausgewählten Markern wieder auf. 5000 gekostet.</German>
-                <Czech>Obnovuje rádiové věže a vojenské budovy na vybrané značce. Cena 5000.</Czech>
-                <Chinesesimp>在选定的标记上重建无线电塔和军事建筑。 成本5000。</Chinesesimp>
-                <Korean>선택한 마커에 라디오 타워와 군사 건물을 재건설합니다. 비용 5000.</Korean>
-                <Italian>Ricostruisce le torri radio e gli edifici militari sull'indicatore selezionato. Costo 5000.</Italian>
-                <Spanish>Reconstruye torres de radio y edificios militares en el marcador seleccionado. Costo 5000.</Spanish>
-                <Polish>Odbudowuje wieże radiowe i budynki wojskowe na wybranym znaczniku. Koszt 5000.</Polish>
+                <Original>Rebuilds factories, resources, radio towers and military buildings on selected marker. Cost 5000.</Original>
+                <French>Reconstruit les usines, ressources, tours radio et bâtiments militaires sur le marqueur sélectionné. Coût 5000.</French>
+                <Russian>Восстанавливает фабрики, ресурсы, радиовышки и военные здания на выбранном маркере. Стоимость 5000.</Russian>
+                <German>Stellt Fabriken, Ressourcen, Funktürme und Militärgebäude am ausgewählten Marker wieder her. Kosten 5000.</German>
+                <Czech>Obnoví továrny, zdroje, radiové věže a vojenské budovy na vybraném markeru. Cena 5000.</Czech>
+                <Chinesesimp>在选定的标记上重建工厂, 资源, 无线电塔和军事建筑。费用5000。</Chinesesimp>
+                <Korean>선택한 마커에 공장, 자원, 무전탑 및 군사 건물을 재건합니다. 비용 5000.</Korean>
+                <Italian>Ricostruisce fabbriche, risorse, torri radio e edifici militari sul marcatore selezionato. Costo 5000.</Italian>
+                <Spanish>Reconstruye fábricas, recursos, torres de radio y edificios militares en el marcador seleccionado. Coste 5000.</Spanish>
+                <Polish>Odbudowuje fabryki, zasoby, wieże radiowe i budynki wojskowe na wybranym markerze. Koszt 5000.</Polish>
             </Key>
             <Key ID="STR_antistasi_dialogs_hq_button_train_ai_text">
                 <Original>Train Rebel Troops</Original>

--- a/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
@@ -6,6 +6,10 @@ params ["_site", "_position"];
 private _leave = false;
 private _antennaDead = objNull;
 
+// Rebuild Factories and Resources Variables Definition
+private _economyDead = "";
+private _repairTypes = ["Building", "House"]; // So depots and such in resources and factories can be rebuilt, could be too loose
+
 if (_site in outposts) then {
 	_antennasDead = antennasDead select {_x inArea _site};
 	if (count _antennasDead > 0) then {
@@ -13,11 +17,17 @@ if (_site in outposts) then {
 	};
 };
 
+// Check if the site is a destroyed economy site
+if ((_site in factories || _site in resourcesX) && _site in destroyedSites) then {
+	_economyDead = _site;
+	Debug_1("Rebuilding Economic Site %1", str _economyDead);
+};
+
 switch (true) do {
 	case (_site in citiesX): {
 		[0, 10, _position] remoteExec ["A3A_fnc_citySupportChange",2];
-    	[Occupants, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
-    	[Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
+		[Occupants, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
+		[Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
 
 		destroyedSites deleteAt(destroyedSites find _site);
 		publicVariable "destroyedSites";
@@ -30,12 +40,33 @@ switch (true) do {
 			30
 		] spawn SCRT_fnc_ui_showMessage;
 	};
+	// Rebuild Economic Assets and building repair start
+	case (_economyDead != ""): {
+		private _buildings = nearestObjects [_position, _repairTypes, 250,  true]; // Default 500 meters used for military buildings is too much for this case usually
+		Debug_1("Found %1 to repair", str _economyDead);
+		{
+			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2]; // Repair each building
+		} forEach _buildings;
+
+		Debug_1("Calling A3A_fnc_rebuildEconomicAssets for %1", str _economyDead);
+
+		[_economyDead] remoteExec ["A3A_fnc_rebuildEconomicAssets", 2]; // Call the actual function that rebuilds the economic site
+
+		private _name = [_site] call A3A_fnc_localizar;
+		[
+			localize "STR_notifiers_success_type",
+			localize "STR_notifiers_rebuild_assets_header",
+			parseText format [localize "STR_notifiers_rebuild_assets_success", _name],
+			30
+		] spawn SCRT_fnc_ui_showMessage;
+	};
+	// Rebuild Economic Assets and building repair end
 
 	case (!isNull _antennaDead): {
 		private _militaryBuildings = nearestObjects [_position, A3A_buildingWhitelist, 500,  true];
 
 		{
-			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2];
+			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2]; 
 		} forEach _militaryBuildings;
 
 		[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];

--- a/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildAssets.sqf
@@ -5,10 +5,7 @@ params ["_site", "_position"];
 
 private _leave = false;
 private _antennaDead = objNull;
-
-// Rebuild Factories and Resources Variables Definition
-private _economyDead = "";
-private _repairTypes = ["Building", "House"]; // So depots and such in resources and factories can be rebuilt, could be too loose
+private _economyDead = ""; // Rebuild Factories and Resources Variables Definition
 
 if (_site in outposts) then {
 	_antennasDead = antennasDead select {_x inArea _site};
@@ -20,14 +17,14 @@ if (_site in outposts) then {
 // Check if the site is a destroyed economy site
 if ((_site in factories || _site in resourcesX) && _site in destroyedSites) then {
 	_economyDead = _site;
-	Debug_1("Rebuilding Economic Site %1", str _economyDead);
+	Debug_1("Rebuilding Economic Site %1", _economyDead);
 };
 
 switch (true) do {
 	case (_site in citiesX): {
 		[0, 10, _position] remoteExec ["A3A_fnc_citySupportChange",2];
-		[Occupants, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
-		[Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
+    	[Occupants, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
+    	[Invaders, 10, 30] remoteExec ["A3A_fnc_addAggression",2];
 
 		destroyedSites deleteAt(destroyedSites find _site);
 		publicVariable "destroyedSites";
@@ -42,14 +39,7 @@ switch (true) do {
 	};
 	// Rebuild Economic Assets and building repair start
 	case (_economyDead != ""): {
-		private _buildings = nearestObjects [_position, _repairTypes, 250,  true]; // Default 500 meters used for military buildings is too much for this case usually
-		Debug_1("Found %1 to repair", str _economyDead);
-		{
-			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2]; // Repair each building
-		} forEach _buildings;
-
-		Debug_1("Calling A3A_fnc_rebuildEconomicAssets for %1", str _economyDead);
-
+		Debug_1("Calling A3A_fnc_rebuildEconomicAssets for %1", _economyDead);
 		[_economyDead] remoteExec ["A3A_fnc_rebuildEconomicAssets", 2]; // Call the actual function that rebuilds the economic site
 
 		private _name = [_site] call A3A_fnc_localizar;
@@ -66,7 +56,7 @@ switch (true) do {
 		private _militaryBuildings = nearestObjects [_position, A3A_buildingWhitelist, 500,  true];
 
 		{
-			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2]; 
+			[_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2];
 		} forEach _militaryBuildings;
 
 		[_antennaDead] remoteExec ["A3A_fnc_rebuildRadioTower", 2];

--- a/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
@@ -21,7 +21,7 @@ private _repairTypes = ["Building", "House"]; // So depots and such in resources
 private _economicSitePosition = getMarkerPos _economicSite;
 private _economicBuildings = nearestObjects [_economicSitePosition, _repairTypes, 250];
 {
-    [_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2];
+    [_x] call A3A_fnc_repairRuinedBuilding;
 } forEach _economicBuildings;
 
 // Notify players about successful rebuild

--- a/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
@@ -6,29 +6,26 @@ if (!isServer) exitWith { Error("Server-only function miscalled") };
 
 params ["_economicSite"];
 
-Debug_1("Entered A3A_fnc_rebuildEconomicAssets for %1", str _economicSite);
+Debug_1("Entered A3A_fnc_rebuildEconomicAssets for %1", _economicSite);
 
 if !(_economicSite in destroyedSites) exitWith { Error("Attempted to rebuild invalid economic site") };
 
-Info_2("Repairing %1 Site %2", 
-    if (_economicSite in factories) then {"Factory"} else {"Resource"}, 
-    str _economicSite);
+Info_1("Rebuilding %1", _economicSite);
 
 // Remove from destroyed sites
 destroyedSites = destroyedSites - [_economicSite];
 publicVariable "destroyedSites";
 
 // Repair factory or resource buildings at the site
+private _repairTypes = ["Building", "House"]; // So depots and such in resources and factories can be rebuilt, could be too loose
 private _economicSitePosition = getMarkerPos _economicSite;
-private _economicBuildings = nearestObjects [_economicSitePosition, A3A_buildingWhitelist, 500, true];
+private _economicBuildings = nearestObjects [_economicSitePosition, _repairTypes, 250];
 {
-    [_x] call A3A_fnc_repairRuinedBuilding;
+    [_x] remoteExec ["A3A_fnc_repairRuinedBuilding", 2];
 } forEach _economicBuildings;
 
 // Notify players about successful rebuild
 private _nameX = [_economicSite] call A3A_fnc_localizar;
 ["TaskSucceeded", ["", format [localize "STR_notifiers_rebuild_assets_success", _nameX]]] remoteExec ["BIS_fnc_showNotification",[teamPlayer, civilian]];
 
-Info_2("%1 Site %2 has been rebuilt.", 
-    if (_economicSite in factories) then {"Factory"} else {"Resource"}, 
-    str _economicSite);
+Info_1("%1 has been Rebuilt.", _economicSite);

--- a/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
+++ b/A3A/addons/core/functions/Base/fn_rebuildEconomicAssets.sqf
@@ -1,0 +1,34 @@
+// Repairs the destroyed factory or resource site.
+// Parameter should be a factory or resource site marker that is present in destroyedSites array
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+if (!isServer) exitWith { Error("Server-only function miscalled") };
+
+params ["_economicSite"];
+
+Debug_1("Entered A3A_fnc_rebuildEconomicAssets for %1", str _economicSite);
+
+if !(_economicSite in destroyedSites) exitWith { Error("Attempted to rebuild invalid economic site") };
+
+Info_2("Repairing %1 Site %2", 
+    if (_economicSite in factories) then {"Factory"} else {"Resource"}, 
+    str _economicSite);
+
+// Remove from destroyed sites
+destroyedSites = destroyedSites - [_economicSite];
+publicVariable "destroyedSites";
+
+// Repair factory or resource buildings at the site
+private _economicSitePosition = getMarkerPos _economicSite;
+private _economicBuildings = nearestObjects [_economicSitePosition, A3A_buildingWhitelist, 500, true];
+{
+    [_x] call A3A_fnc_repairRuinedBuilding;
+} forEach _economicBuildings;
+
+// Notify players about successful rebuild
+private _nameX = [_economicSite] call A3A_fnc_localizar;
+["TaskSucceeded", ["", format [localize "STR_notifiers_rebuild_assets_success", _nameX]]] remoteExec ["BIS_fnc_showNotification",[teamPlayer, civilian]];
+
+Info_2("%1 Site %2 has been rebuilt.", 
+    if (_economicSite in factories) then {"Factory"} else {"Resource"}, 
+    str _economicSite);


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Added rebel factory and resource rebuilding functionality to the Commander Menu > Rebuild Assets button to allow rebels to regain income from destroyed economy markers without having to first give those markers to the enemy for repairs. Also added building repair functionality around factory/resource markers (for Building and House config classes).
Video showcase: https://youtu.be/e3q5oNAlUDg (income tick is set to 15 seconds for demo purposes only)

**How can your changes be tested, or reproduced?**

1. Get a rebel resource or factory marker DESTROYED status by killing its 4 workers, or capture a DESTROYED enemy marker. 
2. Confirm the destroyed marker status using the "Show Map Info" action on HQ map asset.
3. Use the Rebuild Assets button (Battle Menu > Commander > Commander Menu > Rebel HQ > Rebuild Assets)
4. Confirm the "Resource/factory near X town is rebuilt" successful task notification appears, 5000 money is spent, Show Map Info details for the marker no longer shows "DESTROYED" text under the garrison info, and the next resource tick has increased money income.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes no active issue.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>