### PR TITLE
Fix bug with returning weapon(s) to crate when selling loaded mags

### DIFF
--- a/A3A/addons/hals/Addons/store/functions/system/cargo/fn_removeContainerItem.sqf
+++ b/A3A/addons/hals/Addons/store/functions/system/cargo/fn_removeContainerItem.sqf
@@ -43,7 +43,7 @@ try {
 
                     _weapons set [_curIndex, []];
                 } else {
-                    _weapon set [_forEachIndex, ""];
+                    _weapon set [_forEachIndex, ["", []] select (_forEachIndex in [4, 5])];
                 };
 
                 throw true;


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [s] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Fixes structure of weapons array in trader remove item function, causing weapons to be removed when they have a mag loaded and player sells that mag type.

**How can your changes be tested, or reproduced?**

> Put weapon with loaded mag in crate, attempt to sell that mag type at trader. Ensure mag is sold and weapon is not removed from crate.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #670 

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>