### PR TITLE
Add player items to arsenal when quick-equipping

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_cargoToArray.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_cargoToArray.sqf
@@ -16,8 +16,8 @@
 #include "\A3\Ui_f\hpp\defineResinclDesign.inc"
 
 
-private["_container","_array","_addToArray","_unloadContainer"];
-_container = _this;
+private["_array","_addToArray","_unloadContainer"];
+params ["_container", ["_isPlayer", false]];
 _array = [[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]];
 
 
@@ -38,7 +38,7 @@ _unloadContainer = {
 	_container_sub = _this;
 
 	//magazines(exl. loaded ones)
-	_mags = magazinesAmmoCargo _container_sub;
+	_mags = [magazinesAmmoCargo _container_sub, magazinesAmmo _container_sub] select (_isPlayer);
 	{
 		_item = _x select 0;
 		_amount = _x select 1;
@@ -47,7 +47,7 @@ _unloadContainer = {
 	} forEach _mags;
 
 	//items
-	_items = itemCargo _container_sub;
+	_items = [itemCargo _container_sub, (items _container_sub) + (assignedItems player)] select (_isPlayer);
 	{
 		_item = _x;
 		_index = _item call jn_fnc_arsenal_itemType;
@@ -55,7 +55,7 @@ _unloadContainer = {
 	} forEach _items;
 
 	//backpacks
-	_backpacks = backpackCargo _container_sub;
+	_backpacks = [backpackCargo _container_sub, [backpack _container_sub]] select (_isPlayer);
 	{
 		_item = _x call A3A_fnc_basicBackpack;
 		_index = IDC_RSCDISPLAYARSENAL_TAB_BACKPACK;
@@ -63,7 +63,7 @@ _unloadContainer = {
 	} forEach _backpacks;
 
 	//weapons and attachmetns
-	_attItems = weaponsItemsCargo _container_sub;
+	_attItems = [weaponsItemsCargo _container_sub, weaponsItems _container_sub] select (_isPlayer);
 	// [["arifle_TRG21_GL_F","","","optic_dms",["ammo"],""]]
 	{
 		{
@@ -97,9 +97,19 @@ _unloadContainer = {
 
 
 	//sub containers;
-	{
-		_x select 1 call _unloadContainer;
-	}foreach (everyContainer _container_sub);
+	if (_isPlayer) then {
+		{
+			_item = _x;
+			if (_x isNotEqualTo "") then {
+				_index = _item call jn_fnc_arsenal_itemType;
+				[_array,_index,_item,1]call _addToArray;
+			};
+		} forEach [uniform _container_sub, vest _container_sub, headgear _container_sub, goggles _container_sub];
+	} else {
+		{
+			_x select 1 call _unloadContainer;
+		} foreach (everyContainer _container_sub);
+	};
 };
 
 //startloop

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -139,7 +139,10 @@ if(hasInterface)then{
                 default { "Rifleman" };
             };
 
+            private _array = [_player, true] call jn_fnc_arsenal_cargoToArray;
+            _player setUnitLoadout (configFile >> "EmptyLoadout");
             [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;
+            _array call jn_fnc_arsenal_addItem;
         },
         [],
         6,


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Adds all items from player's loadout to arsenal before overriding their loadout with the "Quick Equip Loadout" function on the arsenal box, to prevent losing non-unlocked / infinite items to the void.
> Solves issues like [this](https://discord.com/channels/817005365740044289/1435044641715126342)

**How can your changes be tested, or reproduced?**

> Equip some non-unlocked / non-infinite items. Use quick equip loadout and ensure those items were added / added back to the arsenal.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>