### PR TITLE
Added more cargo nodes for CUP and fixed some missing vehicles. Added SFP cargo nodes.

### DIFF
--- a/A3A/addons/logistics/CfgLogistics.hpp
+++ b/A3A/addons/logistics/CfgLogistics.hpp
@@ -18,6 +18,7 @@ class DOUBLES(ADDON,Nodes)
     #include "Nodes\RHS.hpp"
     #include "Nodes\RNT.hpp"
     #include "Nodes\Scion.hpp"
+	#include "Nodes\SFP.hpp"
     #include "Nodes\SPE.hpp"
     #include "Nodes\SPEX.hpp"
     #include "Nodes\IFA.hpp"

--- a/A3A/addons/logistics/Nodes/CUP.hpp
+++ b/A3A/addons/logistics/Nodes/CUP.hpp
@@ -296,7 +296,7 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_unarmed : TRIPLES(AD
     };
 };
 
-class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_armored_unarmed : TRIPLES(ADDON,Nodes,Base)
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_awed_unarmed : TRIPLES(ADDON,Nodes,Base)
 {
     class Nodes
     {
@@ -366,6 +366,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_GMG_BAF : TRIPLES(AD
     };
 };
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_L2A1_BAF : CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_GMG_BAF {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_GMG_BAF_w : CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_GMG_BAF {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_L2A1_BAF_w : CUP_WheeledVehicles_CUP_WheeledVehicles_Coyote_Coyote_GMG_BAF {};
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_GMG_p3d : TRIPLES(ADDON,Nodes,Base)
 {
@@ -375,25 +377,17 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_
         class Node1
         {
             offset[] = {0,-2.2,0.83};
+			seats[] = {4,5};
         };
     };
 };
 class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_HMG_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_GMG_p3d {};
-
-class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_MG_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_GMG_p3d
-{
-    canLoadWeapon = 0;
-    class Nodes
-    {
-        class Node1
-        {
-            offset[] = {0,-2.2,0.83};
-        };
-    };
-};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_MG_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_GMG_p3d {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_LeftHand_CUP_LR_Special_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_RightHand_CUP_LR_Special_GMG_p3d {};
 
 class cup_wheeledvehicles_cup_wheeledvehicles_wolfhound_CUP_wolfhound_GMG_p3d : TRIPLES(ADDON,Nodes,Base)
 {
+	canLoadWeapon = 1;
     class Nodes
     {
         class Node1
@@ -478,6 +472,7 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_NewM998_model_CUP_nM1038_4s_p3d : 
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d : TRIPLES(ADDON,Nodes,Base)
 {
+	canLoadWeapon = 0;
     class Nodes
     {
         class Node1
@@ -489,6 +484,48 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d : TRIP
 class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_ogpk_m2_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d {};
 class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_ogpk_m240_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d {};
 class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_ogpk_mk19_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.5,-1.59};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1114_dsk_acr_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_M1114_AGS_ACR_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d {};
+class cup_wheeledvehicles_cup_wheeledvehicles_hmmwv_model_CUP_M998_crows_Mk19 : CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d {};
+class cup_wheeledvehicles_cup_wheeledvehicles_hmmwv_model_cup_M998_crows : CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_Deploy_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.5,-1.57};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_Deploy_p3d {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_MK19_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_Deploy_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_GMV_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.35,-1.5,-1.04};
+        };
+    };
+};
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_TowingTractor_CUP_TowingTractor : TRIPLES(ADDON,Nodes,Base)
 {
@@ -633,6 +670,1193 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Ural_cup_Ural_open_p3d : TRIPLES(A
         {
             offset[] = {0.05,-2.6,1.52};
             seats[] = {8,9};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_SUV_CUP_SUV_Armored_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+	   canLoadWeapon = 0;
+       class Nodes
+    {
+       class Node1
+       {
+           offset[] = {0,-2.25,-0.2};
+       };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_MG_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+	   canLoadWeapon = 0;
+       class Nodes
+   {
+       class Node1
+       {
+           offset[] = {0,-2.1,-1};
+       };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_MG_p3d {};
+
+/* pending turn out seat fix
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.8,-1.3};
+			seats[] = {0,1,3,4,5,6};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_hmg_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d {};
+*/
+
+/* pending turn out seat fix
+class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP_bvp1 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0; 
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.6,-2.4,-1.3};
+			seats[] = {5,7};
+        };
+    };
+};
+*/
+
+/* pending turn out seat fix
+class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {-0.6,-2.3,-1.2};
+			seats[] = {8};
+        };
+    };
+};
+*/
+
+/* pending turret seat fix
+class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_ambulance : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.95,0.35};
+			seats[] = {};
+        };
+        class Node2
+        {
+            offset[] = {0,-2.75,0.35};
+			seats[] = {};
+        };
+    };
+};
+*/
+
+class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_HQ : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.5,-4.07};
+        };
+    };
+};
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_BMP3_CUP_BMP3 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.45,-1.25};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BRDM2_CUP_BRDM2_HQ_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.3,-0.11};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_cup_btr40 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.8,-0.62};
+			seats[] = {4,5};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_CUP_btr40_dskm : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.8,-1.09};
+			seats[] = {4,5};
+        };
+    };
+};
+
+/* pending turn out seat fix
+class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.4,-0.05};
+			seats[] = {1,4};
+        };
+		class Node2
+        {
+            offset[] = {0,-2.2,-0.05};
+			seats[] = {2,5};
+        };
+    };
+};
+*/
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.75,-0.3};
+			seats[] = {11,12};
+        };
+        class Node2
+        {
+            offset[] = {0,-2.55,-0.3};
+			seats[] = {7,12};
+        };
+        class Node3
+        {
+            offset[] = {0,-3.35,-0.3};
+			seats[] = {7,8};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80A_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR90_CUP_BTR90_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.8,-0.31};
+			seats[] = {2,5,6,7};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR90_CUP_BTR90_HQ : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.85,-0.85};
+        };
+    };
+};
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_MTLB_CUP_MTLB_pk_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 1;
+    class Nodes
+    {
+        // trunk
+        class Node1
+        {
+            offset[] = {0,-2.1,-1.06};
+			seats[] = {2,3,7};
+        };
+
+        //roof
+        class Node2
+        {
+            offset[] = {0,-0.6,-0.26};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.4,-0.26};
+        };
+        class Node4
+        {
+            offset[] = {0,-2.2,-0.26};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_Unarmed_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 1;
+    class Nodes
+    {
+        // trunk
+        class Node1
+        {
+            offset[] = {0,-2.1,-1.05};
+			seats[] = {4,5,6,7};
+        };
+
+        //roof
+        class Node2
+        {
+            offset[] = {0,-0.9,-0.07};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.7,-0.07};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2,-1.05};
+			seats[] = {4,5,6,7};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_GMG_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_HMG_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.3,-1.05};
+			seats[] = {0,1};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_KPVT_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_HMG_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_MedEvac_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 1;
+    class Nodes
+    {
+        // trunk
+        class Node1
+        {
+            offset[] = {0,-2,-1.05};
+			seats[] = {1,2};
+        };
+
+        //roof
+        class Node2
+        {
+            offset[] = {0,-0.9,-0.07};
+        };
+        class Node3
+        {
+            offset[] = {0,-1.7,-0.07};
+        };
+    };
+};
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog_RWS : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2,-0.45};
+			seats[] = {4,5,6,7};
+        };
+    };
+};
+class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog : CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog_RWS {};
+
+/* pending turn out seat fix
+class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.05,-0.45};
+			seats[] = {5,6,7};
+        };
+    };
+};
+*/
+
+/* pending turn out seat fix
+class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_ambulance_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.7,-0.02};
+			seats[] = {1,5};
+        };
+    };
+};
+*/
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_FV510_CUP_FV510_BAF : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.2,-1.7};
+			seats[] = {0,3,4,5};
+        };
+    };
+};
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_MCV80_CUP_MCV80_BAF : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.2,-2.1};
+			seats[] = {0,3,4,5};
+        };
+    };
+};
+
+class cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-3.85,1.25};
+			seats[] = {0,1};
+        };
+    };
+};
+class cup_wheeledvehicles_cup_wheeledvehicles_mastiff_CUP_mastiff_LMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_p3d {};
+class cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_GMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_p3d {};
+
+class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.55,1.25};
+			seats[] = {0,1};
+        };
+    };
+};
+class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_LMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d {};
+class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_GMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d {};
+
+/* pending turn out seat fix
+class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_AAV_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.3,-1.47};
+			seats[] = {4,9,12};
+        };
+        class Node2
+        {
+            offset[] = {0,-3.1,-1.47};
+			seats[] = {5,6,7,10};
+        };
+    };
+};
+*/
+
+/* pending turn out seat fix
+class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_aav_unarmed_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.3,-1.31};
+			seats[] = {4,9,12};
+        };
+        class Node2
+        {
+            offset[] = {0,-3.1,-1.31};
+			seats[] = {5,6,7,10};
+        };
+    };
+};
+*/
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0.25,-1.2,-1.91};
+			seats[] = {2,3,5,7};
+        };
+    };
+};
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_p3d : CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_p3d {};
+
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mhq_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0.25,-0.6,-0.52};
+        };
+        class Node2
+        {
+            offset[] = {0.25,-1.4,-0.52};
+        };
+    };
+};
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mev_p3d : CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mhq_p3d {};
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_mev_p3d : CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mhq_p3d {};
+class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_mhq_p3d : CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mhq_p3d {};
+
+class cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M2A2_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.2,-1.6};
+			seats[] = {2,3,4,5};
+        };
+    };
+};
+class cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M2A2_ERA_p3d : cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M2A2_p3d {};
+class cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M7_p3d : cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M2A2_p3d {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.7,1.15};
+			seats[] = {2,3,6,7};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_mk19 : CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1133_MEV : CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 {};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1130_CV : CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 {};
+
+/* pending turn out seat fix
+class cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.2,-1.5};
+			seats[] = {2,3,4,5};
+        };
+    };
+};
+class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav25m240_p3d : cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d {};
+*/
+
+class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav_hq_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 1;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0.02,-1.6,-0.66};
+        };
+        class Node2
+        {
+            offset[] = {0.02,-2.4,-0.66};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.3,-1.35};
+			seats[] = {3,4};
+        };
+    };
+};
+class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_mk19 : CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50 {};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50_GC : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.15,-1.35};
+			seats[] = {3,4};
+        };
+    };
+};
+
+class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_MK5E_50 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.55,-1.35};
+			seats[] = {2,3};
+        };
+        class Node2
+        {
+            offset[] = {0,-2.35,-1.35};
+			seats[] = {4,5,6,7};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_mi6_int73_mi6a_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,5.8,-1.34};
+        };
+        class Node2
+        {
+            offset[] = {0,5,-1.34};
+        };
+        class Node3
+        {
+            offset[] = {0,4.2,-1.34};
+        };
+        class Node4
+        {
+            offset[] = {0,3.4,-1.34};
+        };
+        class Node5
+        {
+            offset[] = {0,2.6,-1.34};
+        };
+        class Node6
+        {
+            offset[] = {0,1.8,-1.34};
+        };
+        class Node7
+        {
+            offset[] = {0,0.999999,-1.34};
+        };
+        class Node8
+        {
+            offset[] = {0,0.199999,-1.34};
+        };
+        class Node9
+        {
+            offset[] = {0,-0.600001,-1.34};
+        };
+        class Node10
+        {
+            offset[] = {0,-1.4,-1.34};
+        };
+        class Node11
+        {
+            offset[] = {0,-2.2,-1.34};
+        };
+        class Node12
+        {
+            offset[] = {0,-3,-1.34};
+        };
+        class Node13
+        {
+            offset[] = {0,-3.8,-1.34};
+        };
+        class Node14
+        {
+            offset[] = {0,-4.6,-1.34};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_mi6_int73_mi6t_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-4.2,-1.45};
+        };
+        class Node2
+        {
+            offset[] = {0,-5,-1.45};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT_VIV : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,3.4,-0.9};
+        };
+        class Node2
+        {
+            offset[] = {0,2.6,-0.9};
+        };
+        class Node3
+        {
+            offset[] = {0,1.8,-0.9};
+        };
+        class Node4
+        {
+            offset[] = {0,1,-0.9};
+        };
+        class Node5
+        {
+            offset[] = {0,0.2,-0.9};
+        };
+        class Node6
+        {
+            offset[] = {0,-0.6,-0.9};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8MT : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,3.9,-2.29};
+			seats[] = {2,3};
+        };
+        class Node2
+        {
+            offset[] = {0,3.1,-2.29};
+			seats[] = {4,5};
+        };
+        class Node3
+        {
+            offset[] = {0,2.3,-2.29};
+			seats[] = {6,7,9};
+        };
+        class Node4
+        {
+            offset[] = {0,1.5,-2.29};
+			seats[] = {8,9};
+        };
+        class Node5
+        {
+            offset[] = {0,0.7,-2.29};
+			seats[] = {10,11};
+        };
+        class Node6
+        {
+            offset[] = {0,-0.0999998,-2.29};
+			seats[] = {1,12,13};
+        };
+    };
+};
+class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8MTV_3 : CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8MT {};
+
+class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,3.4,-0.9};
+			seats[] = {4,5};
+        };
+        class Node2
+        {
+            offset[] = {0,2.6,-0.9};
+			seats[] = {6,7};
+        };
+        class Node3
+        {
+            offset[] = {0,1.8,-0.9};
+			seats[] = {8,9};
+        };
+        class Node4
+        {
+            offset[] = {0,1,-0.9};
+			seats[] = {10,11};
+        };
+        class Node5
+        {
+            offset[] = {0,0.2,-0.9};
+			seats[] = {12,13};
+        };
+        class Node6
+        {
+            offset[] = {0,-0.6,-0.9};
+			seats[] = {14,15};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_viv_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,6.9,-3.97};
+        };
+        class Node2
+        {
+            offset[] = {0,6.1,-3.97};
+        };
+        class Node3
+        {
+            offset[] = {0,5.3,-3.97};
+        };
+        class Node4
+        {
+            offset[] = {0,4.5,-3.97};
+        };
+        class Node5
+        {
+            offset[] = {0,3.7,-3.97};
+        };
+        class Node6
+        {
+            offset[] = {0,2.9,-3.97};
+        };
+        class Node7
+        {
+            offset[] = {0,2.1,-3.97};
+        };
+        class Node8
+        {
+            offset[] = {0,1.3,-3.97};
+        };
+        class Node9
+        {
+            offset[] = {0,0.5,-3.97};
+        };
+        class Node10
+        {
+            offset[] = {0,-0.3,-3.97};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,6.9,-3.97};
+        };
+        class Node2
+        {
+            offset[] = {0,6.1,-3.97};
+			seats[] = {0,1,2,3};
+        };
+        class Node3
+        {
+            offset[] = {0,5.3,-3.97};
+			seats[] = {4,5,6,7};
+        };
+        class Node4
+        {
+            offset[] = {0,4.5,-3.97};
+			seats[] = {8,9};
+        };
+        class Node5
+        {
+            offset[] = {0,3.7,-3.97};
+			seats[] = {10,11,12,13};
+        };
+        class Node6
+        {
+            offset[] = {0,2.9,-3.97};
+			seats[] = {14,15,16,17};
+        };
+        class Node7
+        {
+            offset[] = {0,2.1,-3.97};
+			seats[] = {18,19};
+        };
+        class Node8
+        {
+            offset[] = {0,1.3,-3.97};
+			seats[] = {20,21,22,23};
+        };
+        class Node9
+        {
+            offset[] = {0,0.5,-3.97};
+			seats[] = {24,25,26,27};
+        };
+        class Node10
+        {
+            offset[] = {0,-0.3,-3.97};
+			seats[] = {28,29};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_VIV_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,3.7,-2.68};
+        };
+        class Node2
+        {
+            offset[] = {0,2.9,-2.68};
+        };
+        class Node3
+        {
+            offset[] = {0,2.1,-2.68};
+        };
+        class Node4
+        {
+            offset[] = {0,1.3,-2.68};
+        };
+        class Node5
+        {
+            offset[] = {0,0.5,-2.68};
+        };
+        class Node6
+        {
+            offset[] = {0,-0.3,-2.68};
+        };
+        class Node7
+        {
+            offset[] = {0,-1.1,-2.68};
+        };
+        class Node8
+        {
+            offset[] = {0,-1.9,-2.68};
+        };
+        class Node9
+        {
+            offset[] = {0,-2.7,-2.68};
+        };
+        class Node10
+        {
+            offset[] = {0,-3.5,-2.68};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,3.7,-2.68};
+        };
+        class Node2
+        {
+            offset[] = {0,2.9,-2.68};
+			seats[] = {0,1};
+        };
+        class Node3
+        {
+            offset[] = {0,2.1,-2.68};
+			seats[] = {2,3,22,23};
+        };
+        class Node4
+        {
+            offset[] = {0,1.3,-2.68};
+			seats[] = {4,21};
+        };
+        class Node5
+        {
+            offset[] = {0,0.5,-2.68};
+			seats[] = {5,19};
+        };
+        class Node6
+        {
+            offset[] = {0,-0.3,-2.68};
+			seats[] = {6,7,17,18};
+        };
+        class Node7
+        {
+            offset[] = {0,-1.1,-2.68};
+			seats[] = {8,16};
+        };
+        class Node8
+        {
+            offset[] = {0,-1.9,-2.68};
+			seats[] = {9,15};
+        };
+        class Node9
+        {
+            offset[] = {0,-2.7,-2.68};
+			seats[] = {10,14};
+        };
+        class Node10
+        {
+            offset[] = {0,-3.5,-2.68};
+			seats[] = {11,12,13,20};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_MH47E_CUP_MH47E_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-4.3,0.87};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_mv22_CUP_MV22_VIV_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,2.8,-2.39};
+        };
+        class Node2
+        {
+            offset[] = {0,2,-2.39};
+        };
+        class Node3
+        {
+            offset[] = {0,1.2,-2.39};
+        };
+        class Node4
+        {
+            offset[] = {0,0.4,-2.39};
+        };
+        class Node5
+        {
+            offset[] = {0,-0.4,-2.39};
+        };
+        class Node6
+        {
+            offset[] = {0,-1.2,-2.39};
+        };
+        class Node7
+        {
+            offset[] = {0,-2,-2.39};
+        };
+        class Node8
+        {
+            offset[] = {0,-2.8,-2.39};
+        };
+    };
+};
+
+class cup_airvehicles_cup_airvehicles_mv22_cup_mv22_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,2.8,-2.39};
+			seats[] = {2,3};
+        };
+        class Node2
+        {
+            offset[] = {0,2,-2.39};
+			seats[] = {4,5,6,7};
+        };
+        class Node3
+        {
+            offset[] = {0,1.2,-2.39};
+			seats[] = {8,9};
+        };
+        class Node4
+        {
+            offset[] = {0,0.4,-2.39};
+			seats[] = {10,11,12,13};
+        };
+        class Node5
+        {
+            offset[] = {0,-0.4,-2.39};
+			seats[] = {14,15};
+        };
+        class Node6
+        {
+            offset[] = {0,-1.2,-2.39};
+			seats[] = {16,17,18,19};
+        };
+        class Node7
+        {
+            offset[] = {0,-2,-2.39};
+			seats[] = {20,21};
+        };
+        class Node8
+        {
+            offset[] = {0,-2.8,-2.39};
+			seats[] = {0,1,22,23};
+        };
+    };
+};
+class cup_airvehicles_cup_airvehicles_mv22_CUP_MV22_RampGun_p3d : cup_airvehicles_cup_airvehicles_mv22_cup_mv22_p3d {};
+
+class CUP_AirVehicles_CUP_AirVehicles_C130J_CUP_c130j_Cargo_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,6.45,-4.56};
+        };
+        class Node2
+        {
+            offset[] = {0,5.65,-4.56};
+        };
+        class Node3
+        {
+            offset[] = {0,4.85,-4.56};
+        };
+        class Node4
+        {
+            offset[] = {0,4.05,-4.56};
+        };
+        class Node5
+        {
+            offset[] = {0,3.25,-4.56};
+        };
+        class Node6
+        {
+            offset[] = {0,2.45,-4.56};
+        };
+        class Node7
+        {
+            offset[] = {0,1.65,-4.56};
+        };
+        class Node8
+        {
+            offset[] = {0,0.849999,-4.56};
+        };
+        class Node9
+        {
+            offset[] = {0,0.0499994,-4.56};
+        };
+        class Node10
+        {
+            offset[] = {0,-0.750001,-4.56};
+        };
+        class Node11
+        {
+            offset[] = {0,-1.55,-4.56};
+        };
+        class Node12
+        {
+            offset[] = {0,-2.35,-4.56};
+        };
+        class Node13
+        {
+            offset[] = {0,-3.15,-4.56};
+        };
+        class Node14
+        {
+            offset[] = {0,-3.95,-4.56};
+        };
+        class Node15
+        {
+            offset[] = {0,-4.75,-4.56};
+        };
+    };
+};
+
+class CUP_AirVehicles_CUP_AirVehicles_C130J_CUP_c130j_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-4.35,-4.56};
         };
     };
 };

--- a/A3A/addons/logistics/Nodes/CUP.hpp
+++ b/A3A/addons/logistics/Nodes/CUP.hpp
@@ -296,7 +296,7 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_unarmed : TRIPLES(AD
     };
 };
 
-class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_awed_unarmed : TRIPLES(ADDON,Nodes,Base)
+class CUP_WheeledVehicles_CUP_WheeledVehicles_Hilux_hiluxV2_armored_unarmed : TRIPLES(ADDON,Nodes,Base)
 {
     class Nodes
     {

--- a/A3A/addons/logistics/Nodes/SFP.hpp
+++ b/A3A/addons/logistics/Nodes/SFP.hpp
@@ -1,0 +1,181 @@
+class sfp_tgb_sfp_tgb11 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.3,0.91};
+        };
+    };
+};
+class sfp_tgb_sfp_tgb1112_p3d : sfp_tgb_sfp_tgb11 {};
+
+class sfp_tgb_sfp_tgb1111 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.9,1.45};
+        };
+    };
+};
+
+class sfp_tgb_sfp_tgb1111_sog_ksp58 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.15,-0.38};
+        };
+    };
+};
+
+class sfp_tgb_sfp_tgb13_ksp58 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-0.9,-1.37};
+        };
+        class Node2
+        {
+            offset[] = {0,-1.7,-1.37};
+        };
+    };
+};
+
+class sfp_tgb_sfp_tgb1314 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.5,0.91};
+        };
+    };
+};
+
+class sfp_bv206_sfp_bv206_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        // trunk
+        class Node1
+        {
+            offset[] = {0,-3,-0.94};
+			seats[] = {11,12,13,14};
+        };
+
+        //roof
+        class Node2
+        {
+            offset[] = {0,-1.6,0.23};
+        };
+        class Node3
+        {
+            offset[] = {0,-2.4,0.23};
+        };
+    };
+};
+
+class sfp_tgb16_sfp_tgb16_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+    canLoadWeapon = 0;
+    class Nodes
+    {
+        // trunk
+        class Node1
+        {
+            offset[] = {0,-2.05,0.32};
+        };
+
+        //roof
+        class Node2
+        {
+            offset[] = {0,-1.95,1.22};
+        };
+    };
+};
+
+class sfp_tgb16_sfp_tgb16_ksp58 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.05,0.32};
+        };
+    };
+};
+
+class sfp_pbv302_sfp_pbv302a : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-1.3,-1.63};
+			seats[] = {2,3,4,5};
+        };
+    };
+};
+
+class sfp_patgb360_sfp_patgb360_p3d : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-4,1};
+			seats[] = {6,7};
+        };
+    };
+};
+
+class sfp_strf90_sfp_strf90c : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0,-2.3,0.5};
+			seats[] = {2,3,4,5};
+        };
+    };
+};
+
+class sfp_hkp4_sfp_hkp4 : TRIPLES(ADDON,Nodes,Base)
+{
+		canLoadWeapon = 0;
+        class Nodes
+    {
+        class Node1
+        {
+            offset[] = {0.2,-0.5,-2.6};
+			seats[] = {8,9,10,11};
+        };
+        class Node2
+        {
+            offset[] = {0.2,-1.3,-2.6};
+			seats[] = {16,17,18,19};
+        };
+        class Node3
+        {
+            offset[] = {0.2,-2.1,-2.6};
+			seats[] = {20,21,18,19};
+        };
+    };
+};


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [x] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Added cargo nodes for many APCs, MRAPs, Armored vehicles and helicopters for CUP. Added SFP (Swedish Forces Pack) vehicles cargo nodes. 

**How can your changes be tested, or reproduced?**

> Obtain armored vehicles and try to load cargo in them.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [x] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #676

<hr><details><summary><i><b>
Notes: 
</b></i></summary><br>

> "Turn out" passenger seats are not restricted by `seats[] = {};` as those count as "[Turrets](https://community.bistudio.com/wiki/moveInTurret)" and not "[Cargo](https://community.bistudio.com/wiki/moveInCargo)". Vehicles with those seats have been commented out. 

</details>