### PR TITLE
Ensure AI loadouts (or quick-equip loadouts) get map/compass/watch

### DIFF
--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -181,9 +181,10 @@ private _fnc_addAssignedItems = {
 
     if (isNil "_overrideClass") then {
         _unit call _fnc_addRadio;
-        _unit linkItem (selectRandom (A3A_faction_reb get "compasses"));
-        _unit linkItem (selectRandom (A3A_faction_reb get "maps"));
-        _unit linkItem (selectRandom (A3A_faction_reb get "watches"));
+        {
+            private _item = selectRandom _x;
+            if (!isNil {"_item"}) then { _unit linkItem _item };
+        } forEach [unlockedMaps, unlockedCompasses, unlockedWatches]; // should be populated even with no unlocks; GPS not included due to potential of including UAV terminals
     } else {
         { if (!isNil "_x") then { _unit linkItem _x } } forEach (_overrideClass);
     };


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> previous code was wrong. These keys don't exist in the faction hashmap, need to be pulled from `unlockedXXX` or the `jna_datalist` directly. `unlockedXXX` was easier.

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>