### PR TITLE
Don't show builder prompts when in a vehicle

### DIFF
--- a/A3A/addons/core/functions/Builder/fn_addBuildingActions.sqf
+++ b/A3A/addons/core/functions/Builder/fn_addBuildingActions.sqf
@@ -15,7 +15,7 @@ params ["_plankObject", "_holdTime"];
     "Build",
     "a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
     "a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
-    "player call A3A_fnc_isEngineer and (player distance _target < 8)",
+    "isNull objectParent player && {player call A3A_fnc_isEngineer && {(player distance _target < 8)}}",
     "[player] call A3A_fnc_canFight and (player distance _target < 10)",
     {},
     {},

--- a/A3A/addons/core/functions/Builder/fn_initBuilderMonitors.sqf
+++ b/A3A/addons/core/functions/Builder/fn_initBuilderMonitors.sqf
@@ -49,7 +49,7 @@ while { true } do {
         "Destroy",
         "a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
         "a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
-        "true",                                         // was player getUnitTrait 'engineer'
+        "isNull objectParent player",                                         // was player getUnitTrait 'engineer'
         "[player] call A3A_fnc_canFight",
         {},
         {},


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title. Don't show builder build / destroy prompts while player is in a vehicle.

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>