### PR TITLE
Fix launcher magazine detection in arsenal / rebelGear generation

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_generateRebelGear.sqf
@@ -59,6 +59,7 @@ private _fnc_getAvailableMagazines = {
     private _hasMags = false;
     private _allMags = jna_dataList select IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL;
     private _cmpMags = compatibleMagazines ([[_baseClass, _class], _class] select (_baseClass == ""));
+    if (_cmpMags isEqualTo ["CBA_FakeLauncherMagazine"]) then { _cmpMags = compatibleMagazines (_class + "_Loaded") }; // handle fake launchers
     {
         _x params ["_magClass", "_magQty"];
         private _unlocked = [_magQty == -1, _magQty == -1 || {_magQty > A3A_guestItemLimit}] select (minWeaps < 0);


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> CUP (and maybe RHS?) use stupid fake launchers for loaded / unloaded / used variants. Only the loaded variant gives valid output for compatibleMagazines, causing the checks from #590 for available unlocked magazines to fail. This fixes the issue by using the loaded variant class to check for compatible magazines.

**How can your changes be tested, or reproduced?**

> Start new game, set jna_datalist equal to the datalist provided [here](https://discord.com/channels/817005365740044289/1141731889221214279/1441852556635537530). Check whether missiles for the AA launchers are populated correctly in the arsenal when an AA launcher is selected, and that A3A_rebelGear includes the AA launchers.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>