### PR TITLE
[BUG] Fix `nil` template values

### DIFF
--- a/A3A/addons/core/functions/Templates/fn_loadAddon.sqf
+++ b/A3A/addons/core/functions/Templates/fn_loadAddon.sqf
@@ -35,7 +35,7 @@ call compile preprocessFileLineNumbers _path;
 //add the addon data to the faction data
 private _faction = missionNamespace getVariable ["A3A_faction_"+_side, createHashMap];
 {
-    _faction set [_x, (_faction get _x) + _y];
+    _faction set [_x, (_faction getOrDefault[_x, []]) + _y];
 } forEach _addon;
 
 //update the faction data globaly


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [X] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> When loading addons, faction template values can be set to `nil` due to invalid array addition.

**How can your changes be tested, or reproduced?**

1. Set up game w/ CSLA civilian faction
2. Load all vehicle addons except Karts
3. `vehiclesCivPlanes` of `A3A_faction_civ` should be `nil` without this fix

This particular case popped up in an RPT leading to an infinite `waitUntil` in `fn_encounter_civPlane.sqf` effectively blocking future encounters for the whole session.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following (If possible).

`*` - Mandatory

- [X] These changes are my own.
- [ ] These changes are ready for review, or will be marked as a draft. `*`
- [X] I have loaded the mission in LAN host.
- [X] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
