### PR TITLE
Add/remove items to/from arsenal and re-generate rebelGear when equipping

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -1208,6 +1208,13 @@ class Params
         texts[] = {"0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%"};
         default = 10;
     };
+    class A3U_AITakeFromArsenal : ExperimentalParams
+    {
+        title = $STR_params_AITakeFromArsenal;
+        values[] = {0, 1};
+        texts[] = {$STR_antistasi_dialogs_generic_button_no_text, $STR_antistasi_dialogs_generic_button_yes_text};
+        default = 1;
+    };
 
     class DevelopmentParamsSpacer : AllParams
     {

--- a/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
+++ b/A3A/addons/core/functions/REINF/fn_dismissPlayerGroup.sqf
@@ -28,7 +28,6 @@ waitUntil {sleep 1; time > _timeX or {{(_x distance getMarkerPos respawnTeamPlay
 
 private _hr = 0;
 private _resourcesFIA = 0;
-private _items = [];
 private ["_hr","_unit"];
 
 {
@@ -36,9 +35,7 @@ private ["_hr","_unit"];
 	if ([_unit] call A3A_fnc_canFight) then {
 		_resourcesFIA = _resourcesFIA + (server getVariable (_unit getVariable "unitType"));
 		_hr = _hr +1;
-		private _orgLoadout = flatten (_unit getVariable ["orgLoadout", []]) select {_x isEqualType ""};
-		private _curLoadout = flatten (getUnitLoadout _unit) select {_x isEqualType ""};
-		_items append (_curLoadout - _orgLoadout);
+		([_unit, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_addItem;
 	};
 	deleteVehicle _x;
 } forEach units _newGroup;
@@ -46,5 +43,4 @@ private ["_hr","_unit"];
 [_hr,0] remoteExec ["A3A_fnc_resourcesFIA",2]; 
 [_resourcesFIA] call A3A_fnc_resourcesPlayer;
 
-{ boxX addItemCargoGlobal [_x, 1] } forEach (_items);
 deleteGroup _newGroup;

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -278,6 +278,10 @@ private _fnc_addUniform = {
     };
 };
 
+// store player's current items in arsenal before emptying loadout
+([_unit, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_addItem;
+_unit setUnitLoadout (configFile >> "EmptyLoadout");
+            
 if (!isNil "_customLoadout") then {
     // * Apply the loadout, then override it
     private _tempLoadout = +_customLoadout;
@@ -320,4 +324,12 @@ if (backpackItems _unit isEqualTo []) then { removeBackpack _unit };
 
 Verbose_3("Class %1, type %2, loadout %3", _unitType, _recruitType, str (getUnitLoadout _unit));
 
-if (_recruitType isEqualTo 0) then { _unit setVariable ["orgLoadout", getUnitLoadout _unit, true] };
+if (A3U_AITakeFromArsenal) then {
+    // remove unit's current items from arsenal after equipping loadout (prevent item duplication with unlocks disabled)
+    ([_unit, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_removeItem;
+};
+
+// re-generate A3A_rebelGear to avoid equipping items that are no longer available or quantity decremented below min quantity for equipping
+// avoid filling JIP queue
+// do this every time, so *added* items are always reflected in generation, not just *removed* items
+[] remoteExecCall ["A3A_fnc_generateRebelGear", 2, false];

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_cargoToArray.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_cargoToArray.sqf
@@ -17,7 +17,7 @@
 
 
 private["_array","_addToArray","_unloadContainer"];
-params ["_container", ["_isPlayer", false]];
+params ["_container", ["_isUnit", false]];
 _array = [[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]];
 
 
@@ -38,7 +38,7 @@ _unloadContainer = {
 	_container_sub = _this;
 
 	//magazines(exl. loaded ones)
-	_mags = [magazinesAmmoCargo _container_sub, magazinesAmmo _container_sub] select (_isPlayer);
+	_mags = [magazinesAmmoCargo _container_sub, magazinesAmmo _container_sub] select (_isUnit);
 	{
 		_item = _x select 0;
 		_amount = _x select 1;
@@ -47,7 +47,7 @@ _unloadContainer = {
 	} forEach _mags;
 
 	//items
-	_items = [itemCargo _container_sub, (items _container_sub) + (assignedItems player)] select (_isPlayer);
+	_items = [itemCargo _container_sub, (items _container_sub) + (assignedItems player)] select (_isUnit);
 	{
 		_item = _x;
 		_index = _item call jn_fnc_arsenal_itemType;
@@ -55,7 +55,7 @@ _unloadContainer = {
 	} forEach _items;
 
 	//backpacks
-	_backpacks = [backpackCargo _container_sub, [backpack _container_sub]] select (_isPlayer);
+	_backpacks = [backpackCargo _container_sub, [backpack _container_sub]] select (_isUnit);
 	{
 		_item = _x call A3A_fnc_basicBackpack;
 		_index = IDC_RSCDISPLAYARSENAL_TAB_BACKPACK;
@@ -63,7 +63,7 @@ _unloadContainer = {
 	} forEach _backpacks;
 
 	//weapons and attachmetns
-	_attItems = [weaponsItemsCargo _container_sub, weaponsItems _container_sub] select (_isPlayer);
+	_attItems = [weaponsItemsCargo _container_sub, weaponsItems _container_sub] select (_isUnit);
 	// [["arifle_TRG21_GL_F","","","optic_dms",["ammo"],""]]
 	{
 		{
@@ -97,7 +97,7 @@ _unloadContainer = {
 
 
 	//sub containers;
-	if (_isPlayer) then {
+	if (_isUnit) then {
 		{
 			_item = _x;
 			if (_x isNotEqualTo "") then {

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -138,16 +138,7 @@ if(hasInterface)then{
                 case "I_G_engineer_F":  { "Engineer" };
                 default { "Rifleman" };
             };
-
-            // store player's current items in arsenal before emptying loadout
-            ([_player, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_addItem;
-            _player setUnitLoadout (configFile >> "EmptyLoadout");
             [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;
-            // remove player's current items from arsenal after equipping loadout, since equipRebel doesn't do it (prevent item duplication with unlocks disabled)
-            ([_player, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_removeItem;
-            // re-generate A3A_rebelGear to avoid equipping items that are no longer available or quantity decremented below min quantity for equipping
-            // avoid filling JIP queue
-            [] remoteExecCall ["A3A_fnc_generateRebelGear", 2, false];
         },
         [],
         6,

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -139,10 +139,12 @@ if(hasInterface)then{
                 default { "Rifleman" };
             };
 
-            private _array = [_player, true] call jn_fnc_arsenal_cargoToArray;
+            // store player's current items in arsenal before emptying loadout
+            ([_player, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_addItem;
             _player setUnitLoadout (configFile >> "EmptyLoadout");
             [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;
-            _array call jn_fnc_arsenal_addItem;
+            // remove player's current items from arsenal after equipping loadout, since equipRebel doesn't do it (prevent item duplication with unlocks disabled)
+            ([_player, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_removeItem;
         },
         [],
         6,

--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal_init.sqf
@@ -145,6 +145,9 @@ if(hasInterface)then{
             [_player, 0, _prefix + _loadout] call A3A_fnc_equipRebel;
             // remove player's current items from arsenal after equipping loadout, since equipRebel doesn't do it (prevent item duplication with unlocks disabled)
             ([_player, true] call jn_fnc_arsenal_cargoToArray) call jn_fnc_arsenal_removeItem;
+            // re-generate A3A_rebelGear to avoid equipping items that are no longer available or quantity decremented below min quantity for equipping
+            // avoid filling JIP queue
+            [] remoteExecCall ["A3A_fnc_generateRebelGear", 2, false];
         },
         [],
         6,


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> - Builds on #674 and invalidates / reworks #591

> - When equipping *any* rebel unit (player or AI), unit goes through a 4-step process:
>    - add current gear to arsenal
>    - equip unit (based on rebelGear and/or custom loadout)
>    - remove equipped items from arsenal (if param enabled)
>    - re-generate A3A_rebelGear

> - Should fix equipment duplication exploits with AI equipping and/or using quick-equip loadout feature
> - Makes issues like ^^ less prevalent and annoying to fix in general by just treating AI equipping the same as player equipping (and simplifies having to write code to address these edge cases)
> - With unlocks disabled and the param enabled, forces players to consider the over-use of AI given a limited arsenal for the AI

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [x] Needs further changes.
- [ ] Needs to be converted to a draft.

> - Need to handle cases where specific item is set in custom loadout but the item is no longer available (none left in arsenal, or remaining quantity lower than configured minimum amount for equipping).

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> JIP Queue effects / Performance data:
>
> The biggest concern is growing the JIP queue too large with much more frequent (if you use AI or quick-equip a lot) generation of rebel gear. A3A_fnc_generateRebelGear no longer publishes A3A_rebelGear itself, but instead the *version* of rebelGear. When certain functions need to use rebelGear, they use A3A_fnc_fetchRebelGear to fetch the latest *if* the local version is lower than the server version. Thus, the only item we're really concerned about is the version string / var being published too often. This was presumably done because this variable data is much smaller than the full A3A_rebelGear hashmap and thus *less* of a concern. Not sure this can really be tested easily, without just running extended length campaigns and seeing what happens. Nevertheless, here's some data collected with `exportJIPMessages`:

> Fresh server start:
> time = 61.058
> _initMessages - Total: 3119
> _initMessagesRE - Total: 27

> After adding some weapons to arsenal:
> time = 113.009
> _initMessages - Total: 3139
> _initMessagesRE - Total: 27

> After manually generating rebel gear (`[] call A3A_fnc_generateRebelGear`) and using quick-equip once:
> time = 135.880
> _initMessages - Total: 3149
> _initMessagesRE - Total: 27

> After spawning a few AI:
> time = 161.040
> _initMessages - Total: 3225
> _initMessagesRE - Total: 31

> After dismissing all the AI:
> time = 173.294
> _initMessages - Total: 3153
> _initMessagesRE - Total: 31

> I could use some help deciphering these numbers...
</details>