### PR TITLE
Don't show lockpick prompt when in a vehicle

### DIFF
--- a/A3A/addons/ultimate/functions/vehicles/fn_lockpick.sqf
+++ b/A3A/addons/ultimate/functions/vehicles/fn_lockpick.sqf
@@ -31,7 +31,7 @@ params ["_vehicle"];
     localize "STR_A3AU_action_lockpick_title",
     "\a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
     "\a3\ui_f\data\igui\cfg\actions\repair_ca.paa",
-    "(_this distance _target < 10) && {alive _target} && {_target call A3U_fnc_isLocked}",
+    "isNull objectParent _this && {_this distance _target < 10} && {alive _target} && {_target call A3U_fnc_isLocked}",
     "(_caller distance _target < 10) && {_caller call A3A_fnc_isEngineer}",
     {
         params ["_target", "_caller", "_actionId", "_arguments"];


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title
>
> Like #701, but fixes https://discord.com/channels/817005365740044289/1141731889221214279/1447447421167861840

**How can your changes be tested, or reproduced?**

> Get close to enemy vehicle with lockpicking enabled. Verify prompt to lockpick shows and works when not in a vehicle. Verify prompt *does not* show when in a vehicle.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [ ] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>