### PR TITLE
Show arsenal update message until acknowledged

### DIFF
--- a/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
+++ b/A3A/addons/jeroen_arsenal/JNA/fn_arsenal.sqf
@@ -302,6 +302,7 @@ switch _mode do {
 		["SaveTFAR"] call jn_fnc_arsenal;
 		private _object = missionnamespace getVariable ["jna_object",objNull];
 		["Open",[nil,_object,player,false]] call bis_fnc_arsenal;
+		if (isNil {profileNamespace getVariable "A3U_11_8_5_arsenal_update_ack"} && {uiNamespace getVariable ["isLoadoutArsenal", false]}) then { ["ShowUpdateMessage"] spawn SCRT_fnc_arsenal_loadoutArsenal };
 	};
 
 	///////////////////////////////////////////////////////////////////////////////////////////

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -330,6 +330,22 @@ switch _mode do {
 		missionnamespace setvariable ["bis_fnc_arsenal_data",_data];
 	};
 
+	case "ShowUpdateMessage": {
+		private _display = uiNamespace getVariable "arsenalDisplay";
+		private _ackUpdate = [
+			format [localize "STR_A3U_arsenal_update_message", localize "STR_A3U_arsenal_update_ack"],
+			localize "STR_A3U_arsenal_update_header",
+			localize "STR_A3U_arsenal_update_ack",
+			localize "STR_A3U_arsenal_update_ok",
+			_display,
+			false,
+			false
+		] call BIS_fnc_guiMessage;
+		if (!_ackUpdate) exitWith {};
+		profileNamespace setVariable ["A3U_11_8_5_arsenal_update_ack", true];
+		saveProfileNamespace;
+	};
+
 	/////////////////////////////////////////////////////////////////////////////////////////// Externaly called
 	case "Open": {
 		diag_log "JNA open arsenal";

--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -151,6 +151,34 @@
                 <Korean>. 하지만 몇 번만 쏠 양 밖에 없다</Korean>
                 <French>mais il n'y a que peu de photos pour cela</French>
             </Key>
+            <Key ID="STR_A3U_arsenal_update_header">
+                <Original>AU 11.8.5 AI Custom Loadouts</Original>
+                <Russian>AU 11.8.5 Пользовательские снаряжения ИИ</Russian>
+                <Chinesesimp>AU 11.8.5 AI 自定义装备</Chinesesimp>
+                <Korean>AU 11.8.5 AI 커스텀 장비 구성</Korean>
+                <French>AU 11.8.5 Équipements personnalisés de l'IA</French>
+            </Key>
+            <Key ID="STR_A3U_arsenal_update_message">
+                <Original>Custom loadout functionality has changed. Double-click an item in the list to save it into your custom loadout. Double-click again to unsave. Note that saving a cargo container (Uniform, Vest, or Backpack) also saves all of the contents of that container. When saved, the tab icon for the item should turn green. Click %1 to not show this message again.</Original>
+                <Russian>Функциональность пользовательского снаряжения изменилась. Дважды кликните по предмету из списка, чтобы сохранить его в пользовательском наборе. Дважды кликните ещё раз для снятия сохранения. Обратите внимание, что сохранение грузового контейнера (формы, жилета или рюкзака) также сохраняет всё содержимое этого контейнера. При сохранении значок вкладки для предмета должен стать зелёным. Нажмите %1, чтобы не показывать это сообщение снова.</Russian>
+                <Chinesesimp>自定义装备功能发生了变化。 双击列表中的物品以保存到你的自定义装备中。 再次双击以取消保存。 注意，保存货物容器（制服、背心或背包）也会保存该容器的所有内容。 保存后，该物品的标签图标应变为绿色。 点击%1以避免再次显示此信息。</Chinesesimp>
+                <Korean>커스텀 로드아웃 기능이 변경되었습니다. 목록에서 아이템을 더블 클릭하면 사용자 지정 로드아웃에 저장됩니다. 저장 해제하려면 다시 더블 클릭하세요. 화물 컨테이너(유니폼, 조끼, 배낭)를 저장하면 해당 컨테이너의 모든 내용물이 저장됩니다. 이 메시지가 다시 나타나지 않도록 %1을 클릭하세요.</Korean>
+                <French>La fonctionnalité d'équipement personnalisé a changé. Double-cliquez sur un élément de la liste pour l'enregistrer dans votre équipement personnalisé. Double-cliquez à nouveau pour désenregistrer. Note que sauvegarder un conteneur (uniforme, gilet ou sac à dos) sauvegarde également tout le contenu de ce conteneur. Une fois enregistré, l'icône d'onglet de l'article devrait devenir verte. Cliquez sur %1 pour ne plus afficher ce message.</French>
+            </Key>
+            <Key ID="STR_A3U_arsenal_update_ack">
+                <Original>Acknowledge</Original>
+                <Russian>Подтвердить</Russian>
+                <Chinesesimp>收到</Chinesesimp>
+                <Korean>확인해 드립니다</Korean>
+                <French>Accuser réception</French>
+            </Key>
+            <Key ID="STR_A3U_arsenal_update_ok">
+                <Original>OK</Original>
+                <Russian>ХОРОШО</Russian>
+                <Chinesesimp>还行</Chinesesimp>
+                <Korean>그래</Korean>
+                <French>D'ACCORD</French>
+            </Key>
         </Container>
         <Container name="blackmarket">
             <Key ID="STR_A3AP_blackmarket_seap">


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [x] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Show arsenal update message on every loadout arsenal load (until acknowledged) to inform players of the changes to custom loadout functionality introduced in #590.
> Couldn't think of a more elegant way to do the messaging. Also couldn't figure out how to make line breaks work in the text...
> 
![arsenal_update_message](https://github.com/user-attachments/assets/a2344d0b-f5c2-484b-b2f7-dd94d4cd1398)


**How can your changes be tested, or reproduced?**

> Dialog / message should only show for AI custom loadout arsenal, not player loadouts.
> Should pop up on every arsenal load until the acknowledge button is pressed. Pressing OK or simply hitting escape to hide the dialog should cause it to keep showing on subsequent loads.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>