### PR TITLE
Update A3A_rebelGear for ai equipping when items added to arsenal

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_arsenalManage.sqf
@@ -122,4 +122,7 @@ while {_totalNV >= minWeaps} do {
 // Publish the unlocked categories (once each)
 { publicVariable ("unlocked" + _x) } forEach keys _categoriesToPublish;
 
+// Update A3A_rebelGear
+[] call A3A_fnc_generateRebelGear;
+
 _updated


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title. 
>
> I often see questions about why AI aren't using items in the arsenal and have to explain that rebelGear only updates every 10min during the resource check loop. This should solve that.
>
> The hashmap is updated every time items are added instead of just when they're unlocked IOT to also work when unlocks are disabled. Honestly don't think it's that big of a deal.
>
> Not tested yet

**How can your changes be tested, or reproduced?**

> Put stuff in the arsenal, enough for AI to equip (varies according to params), and check `A3A_rebelGear` for changes.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>