### PR TITLE
Don't punish throwing grenades at HQ if under attack

### DIFF
--- a/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
+++ b/A3A/addons/core/functions/Base/fn_chooseAttack.sqf
@@ -123,6 +123,7 @@ if (_targetMrk == "Synd_HQ") exitWith {
     Info_2("Starting HQ attack from %1", _originMrk);
     [-400, _side, "attack"] call A3A_fnc_addEnemyResources;
     bigAttackInProgress = true; publicVariable "bigAttackInProgress";
+    HQAttackInProgress = true; publicVariable "HQAttackInProgress";
     [_side, _originMrk] spawn A3A_fnc_attackHQ;
     true;
 };

--- a/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
@@ -114,6 +114,7 @@ if (!alive _origPetros) then {
 };
 
 bigAttackInProgress = false; publicVariable "bigAttackInProgress";
+HQAttackInProgress = false; publicVariable "HQAttackInProgress";
 forcedSpawn = forcedSpawn - ["Synd_HQ"]; publicVariable "forcedSpawn";
 
 [_taskId, "DEF_HQ", 1200] spawn A3A_fnc_taskDelete;

--- a/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
+++ b/A3A/addons/core/functions/Punishment/fn_punishment_FF_checkNearHQ.sqf
@@ -42,6 +42,7 @@ private _fileName = "fn_punishment_FF_checkNearHQ";
 if !(_weapon in ["Put","Throw"]) exitWith {false};
 private _distancePetros = _unit distance petros;
 if !(_distancePetros <= 75) exitWith {false};
+if (HQAttackInProgress) exitWith {false}; // Don't punish during HQ attack
 
 deleteVehicle _projectile;
 [_unit, 60, 0.4, objNull, localize "STR_A3A_punishment_no_grenades"] remoteExec ["A3A_fnc_punishment_evaluateEvent",2,false];

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -54,6 +54,7 @@ DECLARE_SERVER_VAR(A3A_activePlayerCount, 1);
 DECLARE_SERVER_VAR(difficultyCoef, 0);
 
 //Mostly state variables, used by various parts of Antistasi.
+DECLARE_SERVER_VAR(HQAttackInProgress, false);
 DECLARE_SERVER_VAR(bigAttackInProgress, false);
 DECLARE_SERVER_VAR(AAFpatrols,0);
 


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title. Adds new `HQAttackInProgress` global var instead of using the existing `bigAttackInProgress` + `forcedSpawn` variables because IDK what else touches forcedSpawn and a dedicated var could be useful elsewhere.

**How can your changes be tested, or reproduced?**

> Attempt to throw grenade at HQ as normal, be punished.
>
> Run `[Occupants, "airport_4"] spawn A3A_fnc_attackHQ;` (Altis, occupants, change as needed) and check the variable value and attempt to throw a grenade, see that it works normally.
>
> Need to test on DS.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>