### PR TITLE
Radio keys save and load

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -65,6 +65,8 @@ if (isServer) then {
 	//Antistasi Ultimate variables
 	["revealedZones"] call A3A_fnc_getStatVariable; publicVariable "revealedZones";
 	["unlockedVehicleTypes"] call A3A_fnc_getStatVariable; publicVariable "unlockedVehicleTypes";
+	["occupantsRadioKeys"] call A3A_fnc_getStatVariable; publicVariable "occupantsRadioKeys";
+	["invaderRadioKeys"] call A3A_fnc_getStatVariable; publicVariable "invaderRadioKeys";
 
 	//===========================================================================
 

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -42,7 +42,8 @@ if (isNil "specialVarLoads") then {
         "destroyedMilAdmins",
         "rebelLoadouts", "randomizeRebelLoadoutUniforms",
         "areRivalsDefeated", "areRivalsDiscovered", "inactivityRivals", "rivalsLocationsMap", "rivalsExcludedLocations",
-        "nextRivalsLocationReveal", "isRivalsDiscoveryQuestAssigned", "revealedZones"
+        "nextRivalsLocationReveal", "isRivalsDiscoveryQuestAssigned", "revealedZones",
+        "occupantsRadioKeys", "invaderRadioKeys"
     ] createHashMapFromArray [];
 };
 
@@ -713,6 +714,16 @@ if (_varName in specialVarLoads) then {
 
             publicVariable "unlockedVehicleTypes";
         };
+
+        case 'occupantsRadioKeys': {
+			occupantsRadioKeys = _varValue;
+			publicVariable "occupantsRadioKeys";
+		};
+		
+		case 'invaderRadioKeys': {
+			invaderRadioKeys = _varValue;
+			publicVariable "invaderRadioKeys";
+		};
     };
 } else {
     call compile format ["%1 = %2",_varName,_varValue];

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -716,14 +716,14 @@ if (_varName in specialVarLoads) then {
         };
 
         case 'occupantsRadioKeys': {
-			occupantsRadioKeys = _varValue;
-			publicVariable "occupantsRadioKeys";
-		};
+            occupantsRadioKeys = _varValue;
+            publicVariable "occupantsRadioKeys";
+        };
 		
-		case 'invaderRadioKeys': {
-			invaderRadioKeys = _varValue;
-			publicVariable "invaderRadioKeys";
-		};
+        case 'invaderRadioKeys': {
+            invaderRadioKeys = _varValue;
+            publicVariable "invaderRadioKeys";
+        };
     };
 } else {
     call compile format ["%1 = %2",_varName,_varValue];

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -135,6 +135,7 @@ if (isNil "unlockedVehicleTypes") then {
 
 ["invaderRadioKeys", invaderRadioKeys] call A3A_fnc_setStatVariable;
 ["occupantsRadioKeys", occupantsRadioKeys] call A3A_fnc_setStatVariable;
+
 Info_1("Saving revealed zones: %1", _revealedZones);
 Info_1("Saving unlocked vehicle types: %1", unlockedVehicleTypes);
 Info_1("Saving invaders radio keys: %1", invaderRadioKeys);

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -133,8 +133,12 @@ if (isNil "unlockedVehicleTypes") then {
 
 ["unlockedVehicleTypes", unlockedVehicleTypes] call A3A_fnc_setStatVariable;
 
+["invaderRadioKeys", invaderRadioKeys] call A3A_fnc_setStatVariable;
+["occupantsRadioKeys", occupantsRadioKeys] call A3A_fnc_setStatVariable;
 Info_1("Saving revealed zones: %1", _revealedZones);
 Info_1("Saving unlocked vehicle types: %1", unlockedVehicleTypes);
+Info_1("Saving invaders radio keys: %1", invaderRadioKeys);
+Info_1("Saving occupants radio keys: %1", occupantsRadioKeys);
 //Antistasi Ultimate variables ^
 
 private ["_hrBackground","_resourcesBackground","_veh","_typeVehX","_weaponsX","_ammunition","_items","_backpcks","_containers","_arrayEst","_posVeh","_dierVeh","_prestigeOPFOR","_prestigeBLUFOR","_city","_dataX","_markersX","_garrison","_arrayMrkMF","_positionOutpost","_typeMine","_posMine","_detected","_typesX","_exists","_friendX"];


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [X] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> This adds enemy Radio Keys to the save and load routines (gained keys are saved between game sessions).

**How can your changes be tested, or reproduced?**

> Change the amount of occupantsRadioKeys and/or invaderRadioKeys and save the game. Next time it's loaded, the amount should remain the same. Originally they are reset back to 0.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [X] These changes are my own, or I have written permission to use them. `*`
- [X] These changes are ready for review, or will be marked as a draft. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
None

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>