### PR TITLE
cba_optics_fnc_restartCamera undefined in bare minimum runs

### DIFF
--- a/A3A/addons/scrt/Misc/fn_misc_followCamera.sqf
+++ b/A3A/addons/scrt/Misc/fn_misc_followCamera.sqf
@@ -12,4 +12,8 @@ waitUntil {!isMenuOpen};
 _camera cameraEffect ["Terminate", "Back"];
 camDestroy _camera;
 
-[call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+// Loading of optics addon can be fully suppressed; make sure function exists.
+// See CBA addons\optics\XEH_preInit.sqf:7
+if !(isNil "CBA_optics_fnc_restartCamera") then {
+    [call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+};

--- a/A3A/addons/scrt/Misc/fn_misc_orbitingCamera.sqf
+++ b/A3A/addons/scrt/Misc/fn_misc_orbitingCamera.sqf
@@ -30,4 +30,8 @@ while {isMenuOpen} do {
 _camera cameraEffect ["Terminate", "Back"];
 camDestroy _camera;
 
-[call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+// Loading of optics addon can be fully suppressed; make sure function exists.
+// See CBA addons\optics\XEH_preInit.sqf:7
+if !(isNil "CBA_optics_fnc_restartCamera") then {
+    [call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+};


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [X] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> `CBA_optics_fnc_restartCamera` can be undefined. Fix calls the function only, if it exists.
>
> Function is defined in the CBA optics addon on line 13. The previous check can terminate early, making the function unavailable.

<img width="952" height="483" alt="image" src="https://github.com/user-attachments/assets/a201299a-f7d8-4561-8271-361db4906a20" />

**How can your changes be tested, or reproduced?**

> No more of these in RPTs:

```
13:06:57 Error in expression <

[call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;>
13:06:57   Error position: <CBA_optics_fnc_restartCamera;>
13:06:57   Error Undefined variable in expression: cba_optics_fnc_restartcamera
13:06:57 File \x\A3A\addons\scrt\Misc\fn_misc_orbitingCamera.sqf [SCRT_fnc_misc_orbitingCamera]..., line 33
13:06:57  ➥ Context: 	[] L33 (\x\A3A\addons\scrt\Misc\fn_misc_orbitingCamera.sqf [SCRT_fnc_misc_orbitingCamera])
```

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes (See below)

## Please verify the following (If possible).

- [X] These changes are my own.
- [ ] These changes are ready for review, or will be marked as a draft.
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>