### PR TITLE
Add static weapons to "to be saved" array when ungaraging

### DIFF
--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -88,6 +88,11 @@ HR_GRG_fnc_vehInit = {
     if ((_this isKindOf  "LandVehicle") || (_this isKindOf  "Ship")) then {
 		ungaragedVehicles pushBack _this; 
 		publicVariable "ungaragedVehicles";
+
+        if (_this isKindOf "StaticWeapon") then {
+            staticsToSave pushBack _this;
+            publicVariable "staticsToSave";
+        };
 	};
     _this setVariable ["ownerX",getPlayerUID player,true];
     [_this, TeamPlayer] call A3A_fnc_AIVEHinit;


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [X] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Ungaraged static weapon emplacements aren't immediately save to `staticsToSave` when ungaraging.
>
> They _are_ added only after either moving them or (dis)allowing AI to use them.

**How can your changes be tested, or reproduced?**

> 1. Place AN/MPQ-105 radar
> 2. Garage it
> 3. Ungarage it
> 4. Save game, exit and reload
> 5. Without this fix, the radar is gone; with it... Not.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following (If possible).

- [X] These changes are my own.
- [ ] These changes are ready for review, or will be marked as a draft.
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>