### PR TITLE
Fix mission request break when no near markers for conquest

### DIFF
--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -44,7 +44,7 @@ switch (_type) do {
 			};
 		} forEach _controlsX;
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros,"globalChat", localize "STR_chats_mission_request_no_AS"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint", format [localize "STR_chats_mission_request_no_AS_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -83,26 +83,27 @@ switch (_type) do {
 	case "CON": {
 		//find apropriate sites
 		_possibleMarkers = [outposts + milAdministrationsX + seaports + factories + resourcesX + (controlsX select {isOnRoad (getMarkerPos _x)}), petros, true] call A3A_fnc_findIfNearAndHostile;
-		private _possibleMarkersForFrontline = [airportsX + milbases + outposts + seaports + factories + resourcesX, petros, true] call A3A_fnc_findIfNearAndHostile;
-		private _possibleFrontlineMarker = selectRandom _possibleMarkersForFrontline;
-		private _frontlineSite = [_possibleFrontlineMarker] call A3A_fnc_isFrontlineNoFIA;
-		if (count _possibleMarkers == 0) then {
+		
+		if (_possibleMarkers isEqualTo []) exitWith {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_CON"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_CON_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
 			};
+		};
+		
+		private _milAdmins = _possibleMarkers select {_x in milAdministrationsX };
+		if (_milAdmins isNotEqualTo []) exitWith {
+			_site = selectRandom _milAdmins;
+			[[_site],"A3A_fnc_CON_MilAdmin"] remoteExec ["A3A_fnc_scheduler",2];
+		};
+
+		private _possibleFrontlineMarkers = ([airportsX + milbases + outposts + seaports + factories + resourcesX, petros, true] call A3A_fnc_findIfNearAndHostile) select {_x call A3A_fnc_isFrontlineNoFia};
+		if (_possibleFrontlineMarkers isNotEqualTo []) exitWith {
+			_site = selectRandom _possibleFrontlineMarkers;
+			[[_site],"A3A_fnc_CON_Outpost_Compet"] remoteExec ["A3A_fnc_scheduler",2];
 		} else {
-			private _milAdmins = _possibleMarkers select {_x in milAdministrationsX };
-			private _site = if (_milAdmins isNotEqualTo []) then {selectRandom _milAdmins} else {selectRandom _possibleMarkers};
-			if (_site in milAdministrationsX) then {
-				[[_site],"A3A_fnc_CON_MilAdmin"] remoteExec ["A3A_fnc_scheduler",2];
-			} else {
-				if (_frontlineSite) then {
-					[[_possibleFrontlineMarker],"A3A_fnc_CON_Outpost_Compet"] remoteExec ["A3A_fnc_scheduler",2];
-				} else {
-					[[_site],"A3A_fnc_CON_Outpost"] remoteExec ["A3A_fnc_scheduler",2];
-				};
-			};
+			_site = selectRandom _possibleMarkers;
+			[[_site],"A3A_fnc_CON_Outpost"] remoteExec ["A3A_fnc_scheduler",2];
 		};
 	};
 
@@ -133,7 +134,7 @@ switch (_type) do {
 				) then {_possibleMarkers pushBack _x};
 		}forEach antennas;
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_DES"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_DES_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -177,7 +178,7 @@ switch (_type) do {
 			} forEach banks;
 		};
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_LOG"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint", format [localize "STR_chats_mission_request_no_LOG_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -217,7 +218,7 @@ switch (_type) do {
 			};
 		}forEach (citiesX - destroyedSites);
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_SUPP"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_SUPP_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -241,7 +242,7 @@ switch (_type) do {
 			if (_spawner != 0) then {_possibleMarkers pushBack _x};
 		} forEach ([airportsX + outposts + milbases, petros, true] call A3A_fnc_findIfNearAndHostile);
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros,"globalChat","I have no rescue missions for you. Move our HQ closer to the enemy."] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint","Rescue Missions require Cities or Airports closer than 4Km from your HQ.", "Missions"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -317,7 +318,7 @@ switch (_type) do {
 			};
 		} forEach _markers;
 
-		if (count _possibleMarkers == 0) then
+		if (_possibleMarkers isEqualTo []) then
 		{
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_CONVOY"] remoteExec ["A3A_fnc_commsMP",_requester];


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Fixes mission request dialog breaking / not working after requesting a conquest mission when not in mission distance of an appropriate marker.
> Resisted the urge to refactor the rest of it...

**How can your changes be tested, or reproduced?**

> Set `missionDistance` to something really low like 100m and request a bunch of missions, including conquest missions. Ensure the dialog continues to work.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>