### PR TITLE
Don't open commander or battle menu while in zeus or arsenal

### DIFF
--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -16,6 +16,8 @@ switch (_key) do {
     case QGVAR(battleMenu): {
         if (player getVariable ["incapacitated",false]) exitWith {};
         if (player getVariable ["owner",player] != player) exitWith {};
+        if (clientOwner in (server getVariable ["jna_playersInArsenal",[]])) exitWith {};
+        if (!isNull curatorCamera) exitWith {};
         GVAR(keys_battleMenu) = true; //used to block certain actions when menu is open
     #ifdef UseDoomGUI
         ERROR("Disabled due to UseDoomGUI Switch.")
@@ -80,6 +82,8 @@ switch (_key) do {
                 closeDialog 0;closeDialog 0;
             };
         };
+        if (clientOwner in (server getVariable ["jna_playersInArsenal",[]])) exitWith {};
+        if (!isNull curatorCamera) exitWith {};
 
         [] call SCRT_fnc_ui_toggleCommanderMenu;
     };


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title. As the title says, don't open commander menu or battle menu (y menu) dialog when pressing the keys bound for them while player is in arsenal, AI loadout arsenal, or zeus.
> Little thing that's annoyed me for years and I finally got around to fixing.


**How can your changes be tested, or reproduced?**

> Open arsenal, AI loadout arsenal, and/or zeus. Press bound key for commander menu and battle menu. Ensure they don't open or close the current dialog.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>