### PR TITLE
Fix preventing AI from manning weapons at emplacements

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -120,7 +120,7 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _side] spawn {
 			waitUntil { sleep 0.1; !isNil "serverInitDone" };
 			params ["_veh", "_side"];
-			_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave}));
+			if (locked _veh < 2) then { _veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave})) };
 			[_veh, "static"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
 		};
 	} else {


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Don't run lockStatic/unlockStatic code on locked vehicles (BI engine-native locking, not the emplacement locking) to prevent wrong code being run against MG/AA/AT emplacement weapons preventing their crew from manning them.
>
> In future we can explore making fn_updateRebelStatics work for the emplacement markers and revert this, but I'm not sure what the real use-case would be to prevent AI manning an emplacement...

**How can your changes be tested, or reproduced?**

> Create an emplacement. Ensure AI man the weapon.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #736

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>