### PR TITLE
More vehicle to emplacement changes and fixes

### DIFF
--- a/A3A/addons/core/Includes/script_macros_common.hpp
+++ b/A3A/addons/core/Includes/script_macros_common.hpp
@@ -1025,3 +1025,22 @@ Author:
 ------------------------------------------- */
 #define IS_ADMIN_LOGGED_SYS(x) x##shutdown
 #define IS_ADMIN_LOGGED serverCommandAvailable 'IS_ADMIN_LOGGED_SYS(#)'
+
+/* -------------------------------------------
+Macro: XOR
+    Evaluates to true if exactly one of both values is true
+
+Parameters:
+    VAR1 - the first variable to evaluate
+    VAR2 - the second variable to evaluate
+
+Example:
+    (begin example)
+        // return "true" if exactly one of a and b is true
+        XOR(a, b);
+    (end)
+
+Author:
+    Bohemia Interactive (https://community.bistudio.com/wiki/Operators)
+------------------------------------------- */
+#define XOR(VAR1,VAR2) (((VAR1) || (VAR2)) && !((VAR1) && (VAR2)))

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,9 +12,9 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-if (_target in staticsToSave) then {
-    staticsToSave deleteAt (staticsToSave find _target);
-    publicVariable "staticsToSave";
+if (_target in staticsToMan) then {
+    staticsToMan deleteAt (staticsToMan find _target);
+    publicVariable "staticsToMan";
 };
 
 // kick any AIs out of the vehicle

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,9 +12,10 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-if (_target in staticsToMan) then {
-    staticsToMan deleteAt (staticsToMan find _target);
-    publicVariable "staticsToMan";
+private _index = staticsToFlip find _target;
+if (_index isNotEqualTo -1) then {
+    staticsToFlip deleteAt _index;
+    publicVariable "staticsToFlip";
 };
 
 // kick any AIs out of the vehicle

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,11 +12,8 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-private _index = staticsToFlip find _target;
-if (_index isNotEqualTo -1) then {
-    staticsToFlip deleteAt _index;
-    publicVariable "staticsToFlip";
-};
+if (A3U_enableVehiclesForAI) then { staticsToFlip pushBackUnique _target } else { staticsToFlip = staticsToFlip - [_target] };
+publicVariable "staticsToFlip";
 
 // kick any AIs out of the vehicle
 {

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,9 +12,9 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-if (!(_target in staticsToSave)) then {
-    staticsToSave pushBack _target;
-    publicVariable "staticsToSave";
+if (!(_target in staticsToMan)) then {
+    staticsToMan pushBack _target;
+    publicVariable "staticsToMan";
 };
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,10 +12,7 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-private _index = staticsToFlip find _target;
-if (_index isEqualTo -1) then {
-    staticsToFlip pushBack _target;
-    publicVariable "staticsToFlip";
-};
+if (A3U_enableVehiclesForAI) then { staticsToFlip = staticsToFlip - [_target] } else { staticsToFlip pushBackUnique _target };
+publicVariable "staticsToFlip";
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,9 +12,10 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-if (!(_target in staticsToMan)) then {
-    staticsToMan pushBack _target;
-    publicVariable "staticsToMan";
+private _index = staticsToFlip find _target;
+if (_index isEqualTo -1) then {
+    staticsToFlip pushBack _target;
+    publicVariable "staticsToFlip";
 };
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -30,7 +30,7 @@ if (_marker isEqualTo "") exitWith {};
 
 // Find all non-mortar statics within marker
 private _statics = staticsToSave inAreaArray _marker;
-_statics = _statics select {!(_x isKindOf "StaticMortar") and !(_x isKindOf "Air")};           // may include bunkers. Don't bother with mortars yet //why not bother with mortars?
+_statics = _statics select {!(_x isKindOf "Air")};           // may include bunkers.
 if (count _statics == 0) exitWith {};
 
 if (_target in ungaragedVehicles) then {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -113,7 +113,6 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 	private _markers = markersX select { _veh inArea _x && {sidesX getVariable [_x, sideUnknown] == teamPlayer} };
 	if (_markers isEqualTo []) exitWith {};
-	if (_typeX isKindOf "StaticMortar") exitWith {};
 	if (_side isNotEqualTo teamPlayer) exitWith {};
 	
 	private _staticVehInit = {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -123,12 +123,14 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
 		
 		if !(locked _veh < 2) exitWith {};
-		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select ((A3U_enableVehiclesForAI || {_veh in staticsToMan}) && {_veh in staticsToSave}));
+		private _saved = _veh in staticsToSave;
+		private _flipped = _veh in staticsToFlip;
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_saved && {XOR(A3U_enableVehiclesForAI, _flipped)}));
 
 		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
 		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop
 		// this just ensures that the vehicles left near rebel markers are saved regardless of whether they're manned or not
-		if (_veh in staticsToSave || {(objectParent _veh) in staticsToSave}) exitWith {};
+		if (_saved) exitWith {};
 		staticsToSave pushBack _veh;
 		publicVariable "staticsToSave";
 	};

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -115,21 +115,29 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 	if (_markers isEqualTo []) exitWith {};
 	if (_typeX isKindOf "StaticMortar") exitWith {};
 	if (_side isNotEqualTo teamPlayer) exitWith {};
+	
+	private _staticVehInit = {
+		waitUntil { sleep 0.1; !isNil "serverInitDone" };
+		params ["_veh", "_flagAction"];
+		
+		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
+		
+		if !(locked _veh < 2) exitWith {};
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_veh in staticsToSave && {_veh in staticsToMan || {A3U_enableVehiclesForAI}}));
+
+		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
+		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop
+		// this just ensures that the vehicles left near rebel markers are saved regardless of whether they're manned or not
+		if (_veh in staticsToSave || {(objectParent _veh) in staticsToSave}) exitWith {};
+		staticsToSave pushBack _veh;
+		publicVariable "staticsToSave";
+	};
+
 	if (_veh isKindOf "StaticWeapon") then {
 		_veh setCenterOfMass [(getCenterOfMass _veh) vectorAdd [0, 0, -1], 0];
-		[_veh, _side] spawn {
-			waitUntil { sleep 0.1; !isNil "serverInitDone" };
-			params ["_veh", "_side"];
-			if (locked _veh < 2) then { _veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave})) };
-			[_veh, "static"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
-		};
+		[_veh, "static"] spawn _staticVehInit;
 	} else {
-		[_veh, _side] spawn {
-			waitUntil { sleep 0.1; !isNil "serverInitDone" };
-			params ["_veh", "_side"];
-			_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave}));
-			[_veh, "vehiclestatic"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
-		};
+		[_veh, "vehiclestatic"] spawn _staticVehInit;
 	};
 };
 

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -123,7 +123,7 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
 		
 		if !(locked _veh < 2) exitWith {};
-		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_veh in staticsToSave && {_veh in staticsToMan || {A3U_enableVehiclesForAI}}));
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select ((A3U_enableVehiclesForAI || {_veh in staticsToMan}) && {_veh in staticsToSave}));
 
 		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
 		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,7 +381,7 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state"];
+                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_manned"];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -417,8 +417,12 @@ if (_varName in specialVarLoads) then {
                 if (!isNil "_state") then {
                     [_veh, _state] call HR_GRG_fnc_setState;
                 };
+                if (!isNil "_manned" && {_manned}) then {
+                    staticsToMan pushBack _veh;
+                };
             };
             publicVariable "staticsToSave";
+            publicVariable "staticsToMan";
             publicVariable "A3A_buildingsToSave";
         };
 

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,7 +381,7 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_manned"];
+                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped"];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -420,12 +420,12 @@ if (_varName in specialVarLoads) then {
                 if (!isNil "_customization") then {
                     ([_veh] + _customization) call BIS_fnc_initVehicle;
                 };
-                if (!isNil "_manned" && {_manned}) then {
-                    staticsToMan pushBack _veh;
+                if (!isNil "_flipped" && {_flipped}) then {
+                    staticsToFlip pushBack _veh;
                 };
             };
             publicVariable "staticsToSave";
-            publicVariable "staticsToMan";
+            publicVariable "staticsToFlip";
             publicVariable "A3A_buildingsToSave";
         };
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -208,7 +208,7 @@ private _nearFriendlyMarker = {
 
 {
 	if ((!alive _x) || {(surfaceIsWater position _x) || {(!isNull attachedTo _x) || {(!(_x call _nearFriendlyMarker))}}}) then { continue };
-	_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x, nil, [_x] call BIS_fnc_getVehicleCustomization, _x in staticsToMan];
+	_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x, nil, [_x] call BIS_fnc_getVehicleCustomization, _x in staticsToFlip];
 } forEach staticsToSave;
 
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -203,10 +203,15 @@ _arrayEst = [];
 } forEach (vehicles inAreaArray [markerPos respawnTeamPlayer, 100, 100] select { alive _x });
 
 
+private _nearFriendlyMarker = {
+	params ["_obj"];
+	private _nearestMarker = [markersX, _obj] call BIS_fnc_nearestPosition;
+	(sidesX getVariable [_nearestMarker, sideUnknown] isEqualTo teamPlayer) && {_obj inArea _nearestMarker};
+};
+
 {
-	if ((alive _x) and !(surfaceIsWater position _x) and (isNull attachedTo _x)) then {
-		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
-	};
+	if ((!alive _x) || {(surfaceIsWater position _x) || {(!isNull attachedTo _x) || {(!(_x call _nearFriendlyMarker))}}}) then { continue };
+	_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x, nil, _x in staticsToMan];
 } forEach staticsToSave;
 
 

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -78,6 +78,7 @@ DECLARE_SERVER_VAR(A3A_activeTasks, []);
 DECLARE_SERVER_VAR(A3A_taskCount, 0);
 //List of statics (MGs, AA, etc) that will be saved and loaded.
 DECLARE_SERVER_VAR(staticsToSave, []);
+DECLARE_SERVER_VAR(staticsToMan, []);
 DECLARE_SERVER_VAR(ungaragedVehicles, []);
 //Whether the players have access to radios.
 DECLARE_SERVER_VAR(haveRadio, false);

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -78,7 +78,7 @@ DECLARE_SERVER_VAR(A3A_activeTasks, []);
 DECLARE_SERVER_VAR(A3A_taskCount, 0);
 //List of statics (MGs, AA, etc) that will be saved and loaded.
 DECLARE_SERVER_VAR(staticsToSave, []);
-DECLARE_SERVER_VAR(staticsToMan, []);
+DECLARE_SERVER_VAR(staticsToFlip, []);
 DECLARE_SERVER_VAR(ungaragedVehicles, []);
 //Whether the players have access to radios.
 DECLARE_SERVER_VAR(haveRadio, false);


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Major features:
> - First and foremost, this PR decouples whether a vehicle is saved (persisted) from whether it's manned by AI or not.
> - Along with ^^, manual choices for AI manning are now also persisted. E.g., if auto vehicle manning for AI is enabled but a specific vehicle is disabled, this choice will be persisted.
> - Vehicles / statics are now *truly* persisted when within a friendly marker, regardless of whether they're manned by AI or not.
> - AI manning static mortars is re-enabled

> Retained features:
> - Vehicles pulled from garage or rebel store will not be automatically manned by AI regardless of param setting until they're manually allowed, so you don't have to kick them out right after grabbing a vehicle. However, if left at a rebel marker and the server restarted, they'll then be treated as any other saved static and manned according to param value / user choice.

> Fixes the following issues:
> - Vehicles not saved / persisted unless AI allowed to man them
> - AA/AT/HMG emplacement weapons not being manned by their AI
> - Manual choices for AI manning not persisting
> - Marker unloading when player gets in an AI-manned vehicle

> Basic tech details:
> - All non-air rebel vehicles are added to `staticsToSave`. Any vehicle that has been flipped from the default manning state (e.g. allow AI to man, but disable for this specific vehicle) is added to `staticsToFlip`.
> - During the save loop, existing logic is used for the vehicles in `staticsToSave` except that we now check if the vehicle is actually within a friendly marker. This PR re-uses the now not appropriately named `staticsToSave` instead of renaming or creating a new var because *a lot* of other functions use `staticsToSave` and changing all of them would make this PR annoying to review.
> I *believe* `ungaragedVehicles` is now irrelevant, but tbh didn't think about it until writing this so I didn't test if all works normally with it removed.

> Implications for other PRs:
> - ~~#740 would be redundant / superseded by this PR if approved.~~ removed from milestones, can be closed
> - ~~#743 is superseded by this PR (technically, it's the first commit in this PR but then reworked)~~ merged
> - ~~#738 will almost certainly have a merge conflict in `fn_loadStat` / `fn_saveLoop` (or vice versa, depending on what's merged first)~~ merged, conflict handled
> - ~~#693 is obsoleted by this PR~~ closed
> - If desired, we can use the larger area around a marker used for determining capture, with or without the changes introduced in #649

**How can your changes be tested, or reproduced?**

> Adjust parameter value for whether to enable AI to man vehicles by default.
> Place a variety of vehicles, from garage / store / trader / captured from enemy. Ensure all work as expected.
> Place vehicles within the area of a rebel marker and outside, and ensure only those within a rebel marker are persisted through server reloads.
> Manually set some vehicles to the opposite of the default param value and ensure on next server load these choices are persisted.
> Create an emplacement and ensure AI man the static weapon.

> ~~Needs testing on DS~~

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> This PR also adds an XOR Macro for use where needed.

</details>