### PR TITLE
Prevent automatic rearm after surrender

### DIFF
--- a/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
+++ b/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
@@ -85,6 +85,11 @@ if (_backpack != "") then {
 };
 _unit setUnitLoadout [ [], [], [], [uniform _unit, []], [], [], "", "", [], ["","","","","",""] ];
 
+//find and properly dispose dropped weapons
+{
+	_boxX addWeaponWithAttachmentsCargoGlobal [(weaponsItemsCargo _x) select 0, 1];
+	deleteVehicle _x;
+} forEach nearestObjects [_unit,["WeaponHolderSimulated"],5,true];
 
 if (_unitSide == Occupants) then {
 	[-2, 0, getPos _unit] remoteExec ["A3A_fnc_citySupportChange", 2];


### PR DESCRIPTION
If a weapon is dropped before going unconscious, ACE routine will try to re-equip it after surrender. Fixed by copying the weapon into a surrender box and disposing of original thus preventing the action.

## What type of PR is this?
- [ ] Bug
- [X] Change
- [ ] Feature
- [X] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [X] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> ACE can cause AI to drop their weapon under certain conditions. If the weapon is dropped before the unit goes unconscious, ACE attempts to re-equip it once the unit wakes up. This can also happen after the unit has surrendered, ignoring disabled AI behaviors, leading to weapon recovery or broken AI states. This is fixed by moving nearby dropped weapons into the surrender crate and deleting the original weapon holder, preventing ACE from executing the re-equip action.

**How can your changes be tested, or reproduced?**

> Set ACE -> Hit Reactions -> AI Weapon Drop Chance (Arm Hit) to 100%. Shoot an enemy in the right arm to force a weapon drop, then knock the unit unconscious and heal them.
Before: the unit attempts to recover the weapon and may re-equip it or end up in a broken / frozen state (NB! they are able to do other things like self-healing, which also changes posture).

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [X] These changes are my own, or I have written permission to use them. `*`
- [X] These changes are ready for review, or will be marked as a draft. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).


<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>