### PR TITLE
11.8.7

### DIFF
--- a/A3A/addons/core/Includes/script_macros_common.hpp
+++ b/A3A/addons/core/Includes/script_macros_common.hpp
@@ -1025,3 +1025,22 @@ Author:
 ------------------------------------------- */
 #define IS_ADMIN_LOGGED_SYS(x) x##shutdown
 #define IS_ADMIN_LOGGED serverCommandAvailable 'IS_ADMIN_LOGGED_SYS(#)'
+
+/* -------------------------------------------
+Macro: XOR
+    Evaluates to true if exactly one of both values is true
+
+Parameters:
+    VAR1 - the first variable to evaluate
+    VAR2 - the second variable to evaluate
+
+Example:
+    (begin example)
+        // return "true" if exactly one of a and b is true
+        XOR(a, b);
+    (end)
+
+Author:
+    Bohemia Interactive (https://community.bistudio.com/wiki/Operators)
+------------------------------------------- */
+#define XOR(VAR1,VAR2) (((VAR1) || (VAR2)) && !((VAR1) && (VAR2)))

--- a/A3A/addons/core/Includes/script_version.hpp
+++ b/A3A/addons/core/Includes/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 11
 #define MINOR 8
-#define PATCHLVL 6
+#define PATCHLVL 7
 #define BUILD 0

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -6033,7 +6033,7 @@
             <Key ID="STR_A3AU_use_downed_notification">
                 <Original>Notify Players When Downed</Original>
                 <English>Notify Players When Downed</English>
-                <Russian>Я ранен, товарищи! Справка!</Russian>
+                <Russian>Уведомлять игроков при падении</Russian>
                 <Chinesesimp>玩家倒地时提示</Chinesesimp>
                 <Korean>쓰러질 시 플레이어에게 알림</Korean>
             </Key>

--- a/A3A/addons/core/Stringtable.xml
+++ b/A3A/addons/core/Stringtable.xml
@@ -11,11 +11,11 @@
                 <Chinesesimp>加载以前的个人存档?</Chinesesimp>
                 <Korean>이전 저장 데이터를 로드 하시겠습니까?</Korean>
                 <Italian>Caricare il salvataggio personale precedente?</Italian>
-                <Portuguese>Placeholder</Portuguese>
+                <Portuguese>Carregar o save pessoal anterior?</Portuguese>
                 <Spanish>¿Cargar el guardado personal?</Spanish>
-                <Japanese>Placeholder</Japanese>
+                <Japanese>以前の個人用セーブデータを読み込む?</Japanese>
                 <Polish>Załadować poprzedni zapis gry?</Polish>
-                <Turkish>Placeholder</Turkish>
+                <Turkish>Önceki kişisel kaydı yükleyelim mi?</Turkish>
             </Key>
         </Container>
         <Container name="dialog_headquarters">
@@ -727,8 +727,8 @@
             <Key ID="STR_A3AU_downed_help">
                 <Original>I am injured comrades! Help!</Original>
                 <English>I am injured comrades! Help!</English>
-                <Russian>Placeholder</Russian>
-                <Korean>Placeholder</Korean>
+                <Russian>Я ранен, товарищи! Справка!</Russian>
+                <Korean>나는 부상당했다, 동지들! 도움말!</Korean>
                 <Chinesesimp>我受伤了! 救命!</Chinesesimp>
             </Key>
         </Container>
@@ -6033,14 +6033,14 @@
             <Key ID="STR_A3AU_use_downed_notification">
                 <Original>Notify Players When Downed</Original>
                 <English>Notify Players When Downed</English>
-                <Russian>Placeholder</Russian>
+                <Russian>Я ранен, товарищи! Справка!</Russian>
                 <Chinesesimp>玩家倒地时提示</Chinesesimp>
                 <Korean>쓰러질 시 플레이어에게 알림</Korean>
             </Key>
             <Key ID="STR_A3AU_disable_trader">
                 <Original>Disable Arms Dealer</Original>
                 <English>Disable Arms Dealer</English>
-                <Russian>Placeholder</Russian>
+                <Russian>Обезвредить торговца оружием</Russian>
                 <Chinesesimp>取消军火商</Chinesesimp>
                 <Korean>암거래상 비활성화</Korean>
             </Key>

--- a/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_TKM.sqf
+++ b/A3A/addons/core/Templates/Templates/CUP/CUP_Reb_TKM.sqf
@@ -5,7 +5,7 @@
 ["name", "TKM"] call _fnc_saveToTemplate;
 
 ["flag", "Flag_FIA_F"] call _fnc_saveToTemplate;
-["flagTexture", "a3\data_f\flags\flag_fia_co.paa"] call _fnc_saveToTemplate;
+["flagTexture", "cup\baseconfigs\cup_baseconfigs\data\flags\flag_tkm_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "flag_FIA"] call _fnc_saveToTemplate;
 
 ["vehiclesBasic", ["I_Quadbike_01_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/RHS/RHS_Reb_NAPA.sqf
+++ b/A3A/addons/core/Templates/Templates/RHS/RHS_Reb_NAPA.sqf
@@ -7,7 +7,7 @@ private _hasLawsOfWar = "orange" in A3A_enabledDLC;
 ["name", "NAPA"] call _fnc_saveToTemplate; 						
 
 ["flag", "Flag_EAF_F"] call _fnc_saveToTemplate;
-["flagTexture", "\a3\Data_F_Enoch\Flags\flag_EAF_CO.paa"] call _fnc_saveToTemplate;
+["flagTexture", "rhsgref\addons\rhsgref_main\data\Flags\flag_NAPA_co.paa"] call _fnc_saveToTemplate;
 ["flagMarkerType", "flag_EAF"] call _fnc_saveToTemplate;
 
 ["vehiclesBasic", ["I_G_Quadbike_01_F"]] call _fnc_saveToTemplate;

--- a/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
+++ b/A3A/addons/core/functions/AI/fn_surrenderAction.sqf
@@ -85,6 +85,11 @@ if (_backpack != "") then {
 };
 _unit setUnitLoadout [ [], [], [], [uniform _unit, []], [], [], "", "", [], ["","","","","",""] ];
 
+//find and properly dispose dropped weapons
+{
+	_boxX addWeaponWithAttachmentsCargoGlobal [(weaponsItemsCargo _x) select 0, 1];
+	deleteVehicle _x;
+} forEach nearestObjects [_unit,["WeaponHolderSimulated"],5,true];
 
 if (_unitSide == Occupants) then {
 	[-2, 0, getPos _unit] remoteExec ["A3A_fnc_citySupportChange", 2];

--- a/A3A/addons/core/functions/Base/fn_distance.sqf
+++ b/A3A/addons/core/functions/Base/fn_distance.sqf
@@ -427,6 +427,7 @@ private _teamplayer = [];
 private _occupants = [];
 private _invaders = [];
 private _players = [];
+private _playerVehicles = [];
 
 private ["_markers", "_marker", "_position"];
 
@@ -456,10 +457,12 @@ do
         // Players array is used to spawn civilians in cities and rebel garrisons, so ignore remote controlled and airborne units
         // Players array is used to spawn civilians in cities and rebel garrisons, so ignore airborne units and translate remote-control
         _players = [];
+        _playerVehicles = [];
         {
             private _rp = _x getVariable ["owner", _x];         // real player unit in remote-control case
             private _veh = vehicle _rp;
-            if (_rp != effectiveCommander _veh) then { continue };
+            if (_veh in _playerVehicles) then { continue };
+            if (_veh isNotEqualTo _rp) then { _playerVehicles pushBackUnique _veh};
             if (_veh == _rp or {!(_veh isKindOf "Air" and speed _veh > 50)}) then { _players pushBack _rp };
         } forEach (allPlayers - entities "HeadlessClient_F");
     };

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,9 +12,9 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-if (_target in staticsToSave) then {
-    staticsToSave deleteAt (staticsToSave find _target);
-    publicVariable "staticsToSave";
+if (_target in staticsToMan) then {
+    staticsToMan deleteAt (staticsToMan find _target);
+    publicVariable "staticsToMan";
 };
 
 // kick any AIs out of the vehicle

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,9 +12,10 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-if (_target in staticsToMan) then {
-    staticsToMan deleteAt (staticsToMan find _target);
-    publicVariable "staticsToMan";
+private _index = staticsToFlip find _target;
+if (_index isNotEqualTo -1) then {
+    staticsToFlip deleteAt _index;
+    publicVariable "staticsToFlip";
 };
 
 // kick any AIs out of the vehicle

--- a/A3A/addons/core/functions/Base/fn_lockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_lockStatic.sqf
@@ -12,11 +12,8 @@ params ["_target"];      //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", true, true]; 
 
-private _index = staticsToFlip find _target;
-if (_index isNotEqualTo -1) then {
-    staticsToFlip deleteAt _index;
-    publicVariable "staticsToFlip";
-};
+if (A3U_enableVehiclesForAI) then { staticsToFlip pushBackUnique _target } else { staticsToFlip = staticsToFlip - [_target] };
+publicVariable "staticsToFlip";
 
 // kick any AIs out of the vehicle
 {

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,9 +12,9 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-if (!(_target in staticsToSave)) then {
-    staticsToSave pushBack _target;
-    publicVariable "staticsToSave";
+if (!(_target in staticsToMan)) then {
+    staticsToMan pushBack _target;
+    publicVariable "staticsToMan";
 };
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,10 +12,7 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-private _index = staticsToFlip find _target;
-if (_index isEqualTo -1) then {
-    staticsToFlip pushBack _target;
-    publicVariable "staticsToFlip";
-};
+if (A3U_enableVehiclesForAI) then { staticsToFlip = staticsToFlip - [_target] } else { staticsToFlip pushBackUnique _target };
+publicVariable "staticsToFlip";
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
+++ b/A3A/addons/core/functions/Base/fn_unlockStatic.sqf
@@ -12,9 +12,10 @@ params ["_target"];     //, "_caller", "_actionId", "_arguments"];
 
 _target setVariable ["lockedForAI", nil, true];
 
-if (!(_target in staticsToMan)) then {
-    staticsToMan pushBack _target;
-    publicVariable "staticsToMan";
+private _index = staticsToFlip find _target;
+if (_index isEqualTo -1) then {
+    staticsToFlip pushBack _target;
+    publicVariable "staticsToFlip";
 };
 
 [_target] remoteExec ["A3A_fnc_updateRebelStatics", 2];

--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -30,7 +30,7 @@ if (_marker isEqualTo "") exitWith {};
 
 // Find all non-mortar statics within marker
 private _statics = staticsToSave inAreaArray _marker;
-_statics = _statics select {!(_x isKindOf "StaticMortar") and !(_x isKindOf "Air")};           // may include bunkers. Don't bother with mortars yet //why not bother with mortars?
+_statics = _statics select {!(_x isKindOf "Air")};           // may include bunkers.
 if (count _statics == 0) exitWith {};
 
 if (_target in ungaragedVehicles) then {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -113,7 +113,6 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 	private _markers = markersX select { _veh inArea _x && {sidesX getVariable [_x, sideUnknown] == teamPlayer} };
 	if (_markers isEqualTo []) exitWith {};
-	if (_typeX isKindOf "StaticMortar") exitWith {};
 	if (_side isNotEqualTo teamPlayer) exitWith {};
 	
 	private _staticVehInit = {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -123,12 +123,14 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
 		
 		if !(locked _veh < 2) exitWith {};
-		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select ((A3U_enableVehiclesForAI || {_veh in staticsToMan}) && {_veh in staticsToSave}));
+		private _saved = _veh in staticsToSave;
+		private _flipped = _veh in staticsToFlip;
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_saved && {XOR(A3U_enableVehiclesForAI, _flipped)}));
 
 		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
 		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop
 		// this just ensures that the vehicles left near rebel markers are saved regardless of whether they're manned or not
-		if (_veh in staticsToSave || {(objectParent _veh) in staticsToSave}) exitWith {};
+		if (_saved) exitWith {};
 		staticsToSave pushBack _veh;
 		publicVariable "staticsToSave";
 	};

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -120,7 +120,7 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _side] spawn {
 			waitUntil { sleep 0.1; !isNil "serverInitDone" };
 			params ["_veh", "_side"];
-			_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave}));
+			if (locked _veh < 2) then { _veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave})) };
 			[_veh, "static"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
 		};
 	} else {

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -115,21 +115,29 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 	if (_markers isEqualTo []) exitWith {};
 	if (_typeX isKindOf "StaticMortar") exitWith {};
 	if (_side isNotEqualTo teamPlayer) exitWith {};
+	
+	private _staticVehInit = {
+		waitUntil { sleep 0.1; !isNil "serverInitDone" };
+		params ["_veh", "_flagAction"];
+		
+		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
+		
+		if !(locked _veh < 2) exitWith {};
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_veh in staticsToSave && {_veh in staticsToMan || {A3U_enableVehiclesForAI}}));
+
+		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
+		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop
+		// this just ensures that the vehicles left near rebel markers are saved regardless of whether they're manned or not
+		if (_veh in staticsToSave || {(objectParent _veh) in staticsToSave}) exitWith {};
+		staticsToSave pushBack _veh;
+		publicVariable "staticsToSave";
+	};
+
 	if (_veh isKindOf "StaticWeapon") then {
 		_veh setCenterOfMass [(getCenterOfMass _veh) vectorAdd [0, 0, -1], 0];
-		[_veh, _side] spawn {
-			waitUntil { sleep 0.1; !isNil "serverInitDone" };
-			params ["_veh", "_side"];
-			if (locked _veh < 2) then { _veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave})) };
-			[_veh, "static"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
-		};
+		[_veh, "static"] spawn _staticVehInit;
 	} else {
-		[_veh, _side] spawn {
-			waitUntil { sleep 0.1; !isNil "serverInitDone" };
-			params ["_veh", "_side"];
-			_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (A3U_enableVehiclesForAI && {_veh in staticsToSave}));
-			[_veh, "vehiclestatic"] remoteExec ["A3A_fnc_flagAction", [teamPlayer,civilian], _veh];
-		};
+		[_veh, "vehiclestatic"] spawn _staticVehInit;
 	};
 };
 

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -123,7 +123,7 @@ if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
 		[_veh, _flagAction] remoteExec ["A3A_fnc_flagAction", [teamPlayer, civilian], _veh];
 		
 		if !(locked _veh < 2) exitWith {};
-		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select (_veh in staticsToSave && {_veh in staticsToMan || {A3U_enableVehiclesForAI}}));
+		_veh call ([A3A_fnc_lockStatic, A3A_fnc_unlockStatic] select ((A3U_enableVehiclesForAI || {_veh in staticsToMan}) && {_veh in staticsToSave}));
 
 		// add *all* rebel vehicles to staticsToSave since we don't have an appropriate rebelVehicles var
 		// only vehicles in staticsToSave AND near a rebel marker will actually be saved during the save loop

--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -44,7 +44,7 @@ switch (_type) do {
 			};
 		} forEach _controlsX;
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros,"globalChat", localize "STR_chats_mission_request_no_AS"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint", format [localize "STR_chats_mission_request_no_AS_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -83,26 +83,27 @@ switch (_type) do {
 	case "CON": {
 		//find apropriate sites
 		_possibleMarkers = [outposts + milAdministrationsX + seaports + factories + resourcesX + (controlsX select {isOnRoad (getMarkerPos _x)}), petros, true] call A3A_fnc_findIfNearAndHostile;
-		private _possibleMarkersForFrontline = [airportsX + milbases + outposts + seaports + factories + resourcesX, petros, true] call A3A_fnc_findIfNearAndHostile;
-		private _possibleFrontlineMarker = selectRandom _possibleMarkersForFrontline;
-		private _frontlineSite = [_possibleFrontlineMarker] call A3A_fnc_isFrontlineNoFIA;
-		if (count _possibleMarkers == 0) then {
+		
+		if (_possibleMarkers isEqualTo []) exitWith {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_CON"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_CON_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
 			};
+		};
+		
+		private _milAdmins = _possibleMarkers select {_x in milAdministrationsX };
+		if (_milAdmins isNotEqualTo []) exitWith {
+			_site = selectRandom _milAdmins;
+			[[_site],"A3A_fnc_CON_MilAdmin"] remoteExec ["A3A_fnc_scheduler",2];
+		};
+
+		private _possibleFrontlineMarkers = ([airportsX + milbases + outposts + seaports + factories + resourcesX, petros, true] call A3A_fnc_findIfNearAndHostile) select {_x call A3A_fnc_isFrontlineNoFia};
+		if (_possibleFrontlineMarkers isNotEqualTo []) exitWith {
+			_site = selectRandom _possibleFrontlineMarkers;
+			[[_site],"A3A_fnc_CON_Outpost_Compet"] remoteExec ["A3A_fnc_scheduler",2];
 		} else {
-			private _milAdmins = _possibleMarkers select {_x in milAdministrationsX };
-			private _site = if (_milAdmins isNotEqualTo []) then {selectRandom _milAdmins} else {selectRandom _possibleMarkers};
-			if (_site in milAdministrationsX) then {
-				[[_site],"A3A_fnc_CON_MilAdmin"] remoteExec ["A3A_fnc_scheduler",2];
-			} else {
-				if (_frontlineSite) then {
-					[[_possibleFrontlineMarker],"A3A_fnc_CON_Outpost_Compet"] remoteExec ["A3A_fnc_scheduler",2];
-				} else {
-					[[_site],"A3A_fnc_CON_Outpost"] remoteExec ["A3A_fnc_scheduler",2];
-				};
-			};
+			_site = selectRandom _possibleMarkers;
+			[[_site],"A3A_fnc_CON_Outpost"] remoteExec ["A3A_fnc_scheduler",2];
 		};
 	};
 
@@ -133,7 +134,7 @@ switch (_type) do {
 				) then {_possibleMarkers pushBack _x};
 		}forEach antennas;
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_DES"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_DES_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -177,7 +178,7 @@ switch (_type) do {
 			} forEach banks;
 		};
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_LOG"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint", format [localize "STR_chats_mission_request_no_LOG_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -217,7 +218,7 @@ switch (_type) do {
 			};
 		}forEach (citiesX - destroyedSites);
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_SUPP"] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint",format [localize "STR_chats_mission_request_no_SUPP_hint_text", str distanceMission], localize "STR_chats_mission_request_header"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -241,7 +242,7 @@ switch (_type) do {
 			if (_spawner != 0) then {_possibleMarkers pushBack _x};
 		} forEach ([airportsX + outposts + milbases, petros, true] call A3A_fnc_findIfNearAndHostile);
 
-		if (count _possibleMarkers == 0) then {
+		if (_possibleMarkers isEqualTo []) then {
 			if (!_silent) then {
 				[petros,"globalChat","I have no rescue missions for you. Move our HQ closer to the enemy."] remoteExec ["A3A_fnc_commsMP",_requester];
 				[petros,"hint","Rescue Missions require Cities or Airports closer than 4Km from your HQ.", "Missions"] remoteExec ["A3A_fnc_commsMP",_requester];
@@ -317,7 +318,7 @@ switch (_type) do {
 			};
 		} forEach _markers;
 
-		if (count _possibleMarkers == 0) then
+		if (_possibleMarkers isEqualTo []) then
 		{
 			if (!_silent) then {
 				[petros, "globalChat", localize "STR_chats_mission_request_no_CONVOY"] remoteExec ["A3A_fnc_commsMP",_requester];

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,7 +381,7 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state"];
+                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization"];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -416,6 +416,9 @@ if (_varName in specialVarLoads) then {
                 };
                 if (!isNil "_state") then {
                     [_veh, _state] call HR_GRG_fnc_setState;
+                };
+                if (!isNil "_customization") then {
+                    ([_veh] + _customization) call BIS_fnc_initVehicle;
                 };
             };
             publicVariable "staticsToSave";

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,7 +381,7 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state"];
+                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_manned"];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -417,8 +417,12 @@ if (_varName in specialVarLoads) then {
                 if (!isNil "_state") then {
                     [_veh, _state] call HR_GRG_fnc_setState;
                 };
+                if (!isNil "_manned" && {_manned}) then {
+                    staticsToMan pushBack _veh;
+                };
             };
             publicVariable "staticsToSave";
+            publicVariable "staticsToMan";
             publicVariable "A3A_buildingsToSave";
         };
 

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,7 +381,7 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_manned"];
+                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped"];
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -420,12 +420,12 @@ if (_varName in specialVarLoads) then {
                 if (!isNil "_customization") then {
                     ([_veh] + _customization) call BIS_fnc_initVehicle;
                 };
-                if (!isNil "_manned" && {_manned}) then {
-                    staticsToMan pushBack _veh;
+                if (!isNil "_flipped" && {_flipped}) then {
+                    staticsToFlip pushBack _veh;
                 };
             };
             publicVariable "staticsToSave";
-            publicVariable "staticsToMan";
+            publicVariable "staticsToFlip";
             publicVariable "A3A_buildingsToSave";
         };
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -208,7 +208,7 @@ private _nearFriendlyMarker = {
 
 {
 	if ((!alive _x) || {(surfaceIsWater position _x) || {(!isNull attachedTo _x) || {(!(_x call _nearFriendlyMarker))}}}) then { continue };
-	_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x, nil, [_x] call BIS_fnc_getVehicleCustomization, _x in staticsToMan];
+	_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x, nil, [_x] call BIS_fnc_getVehicleCustomization, _x in staticsToFlip];
 } forEach staticsToSave;
 
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -203,10 +203,15 @@ _arrayEst = [];
 } forEach (vehicles inAreaArray [markerPos respawnTeamPlayer, 100, 100] select { alive _x });
 
 
+private _nearFriendlyMarker = {
+	params ["_obj"];
+	private _nearestMarker = [markersX, _obj] call BIS_fnc_nearestPosition;
+	(sidesX getVariable [_nearestMarker, sideUnknown] isEqualTo teamPlayer) && {_obj inArea _nearestMarker};
+};
+
 {
-	if ((alive _x) and !(surfaceIsWater position _x) and (isNull attachedTo _x)) then {
-		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
-	};
+	if ((!alive _x) || {(surfaceIsWater position _x) || {(!isNull attachedTo _x) || {(!(_x call _nearFriendlyMarker))}}}) then { continue };
+	_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x, nil, _x in staticsToMan];
 } forEach staticsToSave;
 
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -189,23 +189,20 @@ _arrayEst = [];
 {
     // Include buyable items marked as saveable
     // TODO: Do we need to refund the others?
-    if (typeof _x in A3A_utilityItemHM and {"save" in (A3A_utilityItemHM get typeof _x)#4}) then {
-        _arrayEst pushBack [typeof _x, getPosWorld _x, vectorUp _x, vectorDir _x, [_x] call HR_GRG_fnc_getState];
-        continue;
-    };
+    if !(typeof _x in A3A_utilityItemHM and {"save" in (A3A_utilityItemHM get typeof _x)#4}) then {
+		if (fullCrew [_x, "", true] isEqualTo []) then { continue };            // no crew seats, not in utilityItems, not saved
+		if (_x in staticsToSave) then { continue };  // Skip anything already being saved by staticsToSave
+		if ({(alive _x) and (!isPlayer _x)} count crew _x > 0) then { continue };        // no AI-crewed vehicles, those are refunded
+	};
 
-    if (fullCrew [_x, "", true] isEqualTo []) then { continue };            // no crew seats, not in utilityItems, not saved
-    if (_x in staticsToSave) then { continue };  // Skip anything already being saved by staticsToSave
-    if ({(alive _x) and (!isPlayer _x)} count crew _x > 0) then { continue };        // no AI-crewed vehicles, those are refunded
-
-    _arrayEst pushBack [typeof _x, getPosWorld _x, vectorUp _x, vectorDir _x, [_x] call HR_GRG_fnc_getState];
+    _arrayEst pushBack [typeof _x, getPosWorld _x, vectorUp _x, vectorDir _x, [_x] call HR_GRG_fnc_getState, [_x] call BIS_fnc_getVehicleCustomization];
 
 } forEach (vehicles inAreaArray [markerPos respawnTeamPlayer, 100, 100] select { alive _x });
 
 
 {
 	if ((alive _x) and !(surfaceIsWater position _x) and (isNull attachedTo _x)) then {
-		_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
+		_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x, nil, [_x] call BIS_fnc_getVehicleCustomization];
 	};
 } forEach staticsToSave;
 
@@ -216,7 +213,7 @@ _rebMarkers pushBack "Synd_HQ";
 	if (isOnRoad _x && {A3A_builderAllowRoads isEqualTo false}) then {continue};
 	if (surfaceIsWater getPosASL _x) then {continue};
 
-	_arrayEst pushBack [typeOf _x,getPosWorld _x,vectorUp _x, vectorDir _x];
+	_arrayEst pushBack [typeOf _x, getPosWorld _x, vectorUp _x, vectorDir _x];
 } forEach A3A_buildingsToSave;
 
 reverse _arrayEst;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -78,6 +78,7 @@ DECLARE_SERVER_VAR(A3A_activeTasks, []);
 DECLARE_SERVER_VAR(A3A_taskCount, 0);
 //List of statics (MGs, AA, etc) that will be saved and loaded.
 DECLARE_SERVER_VAR(staticsToSave, []);
+DECLARE_SERVER_VAR(staticsToMan, []);
 DECLARE_SERVER_VAR(ungaragedVehicles, []);
 //Whether the players have access to radios.
 DECLARE_SERVER_VAR(haveRadio, false);

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -78,7 +78,7 @@ DECLARE_SERVER_VAR(A3A_activeTasks, []);
 DECLARE_SERVER_VAR(A3A_taskCount, 0);
 //List of statics (MGs, AA, etc) that will be saved and loaded.
 DECLARE_SERVER_VAR(staticsToSave, []);
-DECLARE_SERVER_VAR(staticsToMan, []);
+DECLARE_SERVER_VAR(staticsToFlip, []);
 DECLARE_SERVER_VAR(ungaragedVehicles, []);
 //Whether the players have access to radios.
 DECLARE_SERVER_VAR(haveRadio, false);

--- a/A3A/addons/core/keybinds/fn_keyActions.sqf
+++ b/A3A/addons/core/keybinds/fn_keyActions.sqf
@@ -16,6 +16,8 @@ switch (_key) do {
     case QGVAR(battleMenu): {
         if (player getVariable ["incapacitated",false]) exitWith {};
         if (player getVariable ["owner",player] != player) exitWith {};
+        if (clientOwner in (server getVariable ["jna_playersInArsenal",[]])) exitWith {};
+        if (!isNull curatorCamera) exitWith {};
         GVAR(keys_battleMenu) = true; //used to block certain actions when menu is open
     #ifdef UseDoomGUI
         ERROR("Disabled due to UseDoomGUI Switch.")
@@ -80,6 +82,8 @@ switch (_key) do {
                 closeDialog 0;closeDialog 0;
             };
         };
+        if (clientOwner in (server getVariable ["jna_playersInArsenal",[]])) exitWith {};
+        if (!isNull curatorCamera) exitWith {};
 
         [] call SCRT_fnc_ui_toggleCommanderMenu;
     };

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -7,14 +7,14 @@
                 <French>Annuler</French>
                 <Russian>Отмена</Russian>
                 <Chinesesimp>取消</Chinesesimp>
-                <German>Placeholder</German>
+                <German>Abbrechen</German>
                 <Italian>Cancella</Italian>
-                <Portuguese>Placeholder</Portuguese>
+                <Portuguese>Cancelar</Portuguese>
                 <Spanish>Cancelar</Spanish>
                 <Korean>취소</Korean>
-                <Japanese>Placeholder</Japanese>
+                <Japanese>キャンセル</Japanese>
                 <Polish>Anuluj</Polish>
-                <Turkish>Placeholder</Turkish>
+                <Turkish>İptal</Turkish>
                 <Czech>Zrušit</Czech>
             </Key>
             <Key ID="STR_HR_GRG_Generic_Lock">

--- a/A3A/addons/gui/Stringtable.xml
+++ b/A3A/addons/gui/Stringtable.xml
@@ -9,13 +9,13 @@
                 <Spanish>RECLUTAR UNIDADES</Spanish>
                 <Italian>RECLUTA UNITA</Italian>
                 <Polish>ZWERBUJ JEDNOSTKI</Polish>
-                <Portuguese>Placeholder</Portuguese>
+                <Portuguese>UNIDADES DE RECRUTAMENTO</Portuguese>
                 <Russian>НАНЯТЬ СОЛДАТ</Russian>
-                <German>Placeholder</German>
+                <German>REKRUTIERUNGSEINHEITEN</German>
                 <Chinesesimp>招募单位</Chinesesimp>
                 <Korean>유닛 모집</Korean>
-                <Japanese>Placeholder</Japanese>
-                <Turkish>Placeholder</Turkish>
+                <Japanese>新兵部隊</Japanese>
+                <Turkish>YENI PERSONEL BIRIMLERI</Turkish>
             </Key>
             <Key ID="STR_antistasi_dialogs_recruit_units_militiaman">
                 <Original>Militiaman</Original>
@@ -951,13 +951,13 @@
             <Key ID="STR_antistasi_dialogs_main_fast_travel_tooltip">
                 <Original>This is a placeholder</Original>
                 <Korean>이건 꼭 필요한 요소는 아닙니다</Korean>
-                <Russian>/</Russian>
+                <Russian>Это временная заглушка</Russian>
                 <French>Ceci est un espace réservé</French>
                 <Chinesesimp>这是一个占位符</Chinesesimp>
                 <Czech>Toto je zástupný symbol</Czech>
                 <Italian>Questo è un segnaposto</Italian>
                 <Spanish>Esto es un marcador de posición</Spanish>
-                <Polish>To jest placeholder</Polish>
+                <Polish>To jest tymczasowy zastępca</Polish>
             </Key>
             <Key ID="STR_antistasi_dialogs_main_undercover">
                 <Original>Go Undercover</Original>

--- a/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
+++ b/A3A/addons/scrt/Arsenal/fn_arsenal_loadoutArsenal.sqf
@@ -1444,7 +1444,7 @@ switch _mode do {
 		_inventory = switch (_index) do {
 			// If item is in A3A_rebelGear, it should already be unlocked or its qty should be > jna_minItemMember select _index
 			case (IDC_RSCDISPLAYARSENAL_TAB_PRIMARYWEAPON): {
-				if !(limitWeaponsByUnitType) exitWith { _inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} } };
+				if !(limitWeaponsByUnitType) exitWith { _inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ([_index, _x select 0] call _minItemsMember)}} } };
 				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
 				switch (_loadoutName) do {
 					case ("MACHINEGUNNER"): { 
@@ -1466,7 +1466,7 @@ switch _mode do {
 				};
 			};
 			case (IDC_RSCDISPLAYARSENAL_TAB_SECONDARYWEAPON): {
-				if !(limitWeaponsByUnitType) exitWith { _inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} } };
+				if !(limitWeaponsByUnitType) exitWith { _inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ([_index, _x select 0] call _minItemsMember)}} } };
 				private _loadoutName = currentRebelLoadout call SCRT_fnc_misc_getLoadoutName;
 				switch (_loadoutName) do {
 					case ("RIFLEMAN"): {
@@ -1488,15 +1488,12 @@ switch _mode do {
 			case (IDC_RSCDISPLAYARSENAL_TAB_LOADEDMAG2);
 			case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAG);
 			case (IDC_RSCDISPLAYARSENAL_TAB_CARGOMAGALL): {
-				_inventory select {
-					private _amountCfg = getNumber (configfile >> "CfgMagazines" >> _x select 0 >> "count");
-					(_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ((jna_minItemMember select _index) * _amountCfg)}}
-				}
+				_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ([_index, _x select 0] call _minItemsMember)}} }
 			};
 
 			default {
 				// item unlocked (qty == -1) OR (unlocks disabled AND item qty more than min items)
-				_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= (jna_minItemMember select _index)}} }
+				_inventory select { (_x select 1) == -1 || {minWeaps < 0 && {(_x select 1) >= ([_index, _x select 0] call _minItemsMember)}} }
 			};
 		};
 		if (_index isEqualTo 0 && {_inventory isEqualTo []}) then {

--- a/A3A/addons/scrt/Misc/fn_misc_followCamera.sqf
+++ b/A3A/addons/scrt/Misc/fn_misc_followCamera.sqf
@@ -12,4 +12,8 @@ waitUntil {!isMenuOpen};
 _camera cameraEffect ["Terminate", "Back"];
 camDestroy _camera;
 
-[call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+// Loading of optics addon can be fully suppressed; make sure function exists.
+// See CBA addons\optics\XEH_preInit.sqf:7
+if !(isNil "CBA_optics_fnc_restartCamera") then {
+    [call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+};

--- a/A3A/addons/scrt/Misc/fn_misc_orbitingCamera.sqf
+++ b/A3A/addons/scrt/Misc/fn_misc_orbitingCamera.sqf
@@ -30,4 +30,8 @@ while {isMenuOpen} do {
 _camera cameraEffect ["Terminate", "Back"];
 camDestroy _camera;
 
-[call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+// Loading of optics addon can be fully suppressed; make sure function exists.
+// See CBA addons\optics\XEH_preInit.sqf:7
+if !(isNil "CBA_optics_fnc_restartCamera") then {
+    [call CBA_fnc_currentUnit, true] call CBA_optics_fnc_restartCamera;
+};


### PR DESCRIPTION
Changelog below.

---

# New Factions:
N/A

## Faction Updates:
N/A

# Localization:
- misc 11.8.7 fixes (#734 / #747)
> Add localization for all stringtable entries that used to be just "Placeholder"


# New Maps:
N/A

## Map Updates:
N/A

# New Features:
N/A

# Fixed:
- cba_optics_fnc_restartCamera undefined in bare minimum runs (#739)
> Fixes non-critical errors after closing commander / rebel menu when running without CBA optics
- misc 11.8.7 fixes (#734)
>  - Fixes rebel marker despawn when entering a vehicle that AI are manning
>  - Fixes CUP TKM and RHS NAPA flag textures
- Fix mission request break when no near markers for conquest (#741)
> Ability to request mission from Petros should not break after requesting a conquest mission when not in range of a suitable enemy location to conquer.
- Don't open commander or battle menu while in zeus or arsenal (#742)
> Pressing the keys to open commander/rebel menu or battle menu (y-menu) should no longer open these menus when player is in the arsenal or using Zeus
- Fix preventing AI from manning weapons at emplacements (#743)
> AI at HMG/AA/AT emplacements should now man their weapons again (Whoops!)
- Save vehicle customization for "parked" vehicles and statics (#738)
> Persistence for changes to a vehicle's paint scheme and customization made in the garage
- Prevent automatic rearm after surrender (#745)
> When playing with ACE medical, enemy units that dropped their weapon before being downed or surrendering should not pick their weapon back up after being revived
- More vehicle to emplacement changes and fixes (#744)
>  - Fixes persistence for rebel vehicles regardless of whether AI are allowed to man them.
>  - Fixes persistence for rebel vehicles at *all* rebel-held markers, not just HQ
>  - Adds persistence for manual changes to manning state. E.g. with AI allowed to man vehicles by default, a change to not allow a specific vehicle to be manned will persist on marker load/unload and server reload.
>  - Adds AI ability to man static mortars (in addition to all the other static weapon types)
- Fix min items calculation in AI arsenal (#752)
> Check for unlocked magazines when selecting primary and secondary muzzle loaded magazine in the AI arsenal should no longer error out.

# Arms Dealer:
N/A

# Changes:
N/A

# Parameters:
N/A

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>