### PR TITLE
Add more events to Antistasi's Events system

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_randomWeapon.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_randomWeapon.sqf
@@ -21,7 +21,7 @@
         Scheduled, any machine
     
     Usage:
-        [_unit, "MachineGuns", 150] call A3A_fnc_equipRebel;
+        [_unit, "MachineGuns", 150] call A3A_fnc_randomWeapon;
     
     Return:
         Nothing

--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -13,7 +13,7 @@ while {true} do
     publicVariable "A3A_activePlayerCount";
 
     //Sleep if no player is online
-    if (A3A_activePlayerCount == 0) then { sleep 60; continue };
+    if (A3A_activePlayerCount == 0) then { ["aggressionUpdateLoopComplete", []] call EFUNC(Events,triggerEvent); sleep 60; continue };
 
     waitUntil {!prestigeIsChanging};
     prestigeIsChanging = true;
@@ -109,6 +109,8 @@ while {true} do
         };
     };
 
+    ["aggressionUpdateLoopComplete", []] call EFUNC(Events,triggerEvent);
+    
     sleep 60;
 };
 

--- a/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
+++ b/A3A/addons/core/functions/Base/fn_aggressionUpdateLoop.sqf
@@ -13,7 +13,7 @@ while {true} do
     publicVariable "A3A_activePlayerCount";
 
     //Sleep if no player is online
-    if (A3A_activePlayerCount == 0) then { ["aggressionUpdateLoopComplete", []] call EFUNC(Events,triggerEvent); sleep 60; continue };
+    if (A3A_activePlayerCount == 0) then { ["aggressionUpdateLoopComplete", []] spawn EFUNC(Events,triggerEvent); sleep 60; continue };
 
     waitUntil {!prestigeIsChanging};
     prestigeIsChanging = true;
@@ -109,7 +109,7 @@ while {true} do
         };
     };
 
-    ["aggressionUpdateLoopComplete", []] call EFUNC(Events,triggerEvent);
+    ["aggressionUpdateLoopComplete", []] spawn EFUNC(Events,triggerEvent);
     
     sleep 60;
 };

--- a/A3A/addons/core/functions/Base/fn_buildHQ.sqf
+++ b/A3A/addons/core/functions/Base/fn_buildHQ.sqf
@@ -19,4 +19,4 @@ petros setBehaviour "SAFE";
 [getPos petros, false] remoteExec ["A3A_fnc_relocateHQObjects", 2];
 
 sleep 5;
-["HQPlaced", [getPos petros]] call EFUNC(Events,triggerEvent);
+["HQPlaced", [getPos petros]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
@@ -85,4 +85,4 @@ if (isClass (configFile/"CfgPatches"/"rhsgref_main")) then {//ToDo: these should
 missionNamespace setVariable ["A3A_lastGarbageCleanTime",serverTime,true];
 Info("Garbage clean completed");
 
-["garbageCleanerComplete", []] call EFUNC(Events,triggerEvent);
+["garbageCleanerComplete", []] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
+++ b/A3A/addons/core/functions/Base/fn_garbageCleaner.sqf
@@ -84,3 +84,5 @@ if (isClass (configFile/"CfgPatches"/"rhsgref_main")) then {//ToDo: these should
 [localize "STR_antistasi_dialogs_open_clean_garbage_title", format [localize "STR_antistasi_dialogs_open_clean_garbage_success", _timeSinceLastGC]] remoteExec ["A3A_fnc_customHint", 0];
 missionNamespace setVariable ["A3A_lastGarbageCleanTime",serverTime,true];
 Info("Garbage clean completed");
+
+["garbageCleanerComplete", []] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -399,7 +399,7 @@ else
 };
 
 markersChanging = markersChanging - [_markerX];
-["markerChange", [_markerX, _winner]] call EFUNC(Events,triggerEvent);
+["markerChange", [_markerX, _winner]] spawn EFUNC(Events,triggerEvent);
 
 if (_winner == teamPlayer) then {
 	[_loser] remoteExecCall ["SCRT_fnc_common_defeatFactionIfPossible", 2];

--- a/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
+++ b/A3A/addons/core/functions/Base/fn_vehicleBoxRestore.sqf
@@ -110,7 +110,7 @@ private _finalStringVariant = [
 
 private _finalString = format [_finalStringVariant, _finalAdditiveString];
 
-["vehicleBoxRestore", [_posHQ]] call EFUNC(Events,triggerEvent);
+["vehicleBoxRestore", [_posHQ]] spawn EFUNC(Events,triggerEvent);
 [localize "STR_A3A_base_vehicleBoxRestore_restoration_title", _finalString] call A3A_fnc_customHint;
 
 [] remoteExec ["SCRT_fnc_common_updateArsenal", 2];

--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -288,5 +288,5 @@ if (_side != teamPlayer) then {///might need to change that, tho I'm not sure
 };
 
 if (!isNull _veh) then {
-    ["AIVehInit", [_veh, _side]] call EFUNC(Events,triggerEvent);
+    ["AIVehInit", [_veh, _side]] spawn EFUNC(Events,triggerEvent);
 };

--- a/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_NATOinit.sqf
@@ -275,4 +275,4 @@ if (_unit == gunner objectParent _unit or {(secondaryWeapon _unit) in allAA}) th
         if (!isNull driver _x) then { _unit reveal [_x, 1.5] };
     } forEach (_unit nearEntities ["Air", distanceSPWN*1]);
 };
-["AIInit", [_unit, _side, _marker, _unit getVariable "spawner"]] call EFUNC(Events,triggerEvent);
+["AIInit", [_unit, _side, _marker, _unit getVariable "spawner"]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_civVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_civVEHinit.sqf
@@ -25,4 +25,4 @@ if (count _vehCrew == 0) then { //and {("vanilla" in A3A_factionEquipFlags)}
 		if (!simulationEnabled _veh) then {[_veh,true] remoteExec ["enableSimulationGlobal",2]};
 	}];
 };
-["civVehInit", [_veh]] call EFUNC(Events,triggerEvent);
+["civVehInit", [_veh]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -583,7 +583,7 @@ if (random 100 < (20 + tierWar * 3)) then {
 
 { _x setVariable ["originalPos", getPosATL _x] } forEach _vehiclesX;
 
-["locationSpawned", [_markerX, "Airport", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Airport", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
@@ -610,4 +610,4 @@ if (!isNil "_ammoBox") then {
 	private _lootCD = 120*16 / ([_markerX] call A3A_fnc_garrisonSize);
 	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
 };
-["locationSpawned", [_markerX, "Airport", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Airport", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAICities.sqf
@@ -49,11 +49,11 @@ private _roadPositions = (_positionX nearRoads round(_patrolSize / 2));
 private _civNonHuman = Faction(civilian) getOrDefault ["attributeCivNonHuman", false];
 
 if (_civNonHuman && {(selectRandom [1,2,3]) isEqualTo 2}) exitWith {
-	["locationSpawned", [_markerX, "City", true]] call EFUNC(Events,triggerEvent);
+	["locationSpawned", [_markerX, "City", true]] spawn EFUNC(Events,triggerEvent);
 
 	waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
-	["locationSpawned", [_markerX, "City", false]] call EFUNC(Events,triggerEvent);
+	["locationSpawned", [_markerX, "City", false]] spawn EFUNC(Events,triggerEvent);
 };
 
 while {(spawner getVariable _markerX != 2) and (_countX < _num)} do {
@@ -89,7 +89,7 @@ while {(spawner getVariable _markerX != 2) and (_countX < _num)} do {
 	_countX = _countX + 1;
 };
 
-["locationSpawned", [_markerX, "City", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "City", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 
@@ -97,4 +97,4 @@ waitUntil {sleep 1;(spawner getVariable _markerX == 2)};
 {deleteVehicle _x} forEach _dogs;
 { deleteGroup _x } forEach _groups;
 
-["locationSpawned", [_markerX, "City", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "City", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIMilAdmin.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIMilAdmin.sqf
@@ -292,4 +292,4 @@ if (!isNil "_grpPOW") then {
 	[_grpPOW] spawn A3A_fnc_groupDespawner;
 };
 
-["locationSpawned", [_marker, "MilAdmin", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_marker, "MilAdmin", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIMilbase.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIMilbase.sqf
@@ -474,7 +474,7 @@ if (random 100 < (30 + tierWar * 6)) then {
 	_heavyVehicle setVariable ["originalPos", getPosATL _heavyVehicle];
 };
 
-["locationSpawned", [_markerX, "Milbase", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Milbase", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
@@ -510,4 +510,4 @@ if (!isNil "_ammoBox2") then {
 	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
 };
 
-["locationSpawned", [_markerX, "Milbase", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Milbase", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIOutposts.sqf
@@ -341,7 +341,7 @@ for "_i" from 0 to (count _array - 1) do {
 		[_groupX, "Patrol_Defend", 0, 100, -1, true, _positionX, false] call A3A_fnc_patrolLoop;
 	};
 };
-["locationSpawned", [_markerX, "Outpost", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Outpost", true]] spawn EFUNC(Events,triggerEvent);
 
 {
 	if (_x isKindOf "Static" || _x isKindOf "StaticWeapon") then {continue};
@@ -374,4 +374,4 @@ if (!isNil "_ammoBox") then {
 	private _lootCD = 120*16 / ([_markerX] call A3A_fnc_garrisonSize);
 	garrison setVariable [_markerX + "_lootCD", _lootCD, true];
 };
-["locationSpawned", [_markerX, "Outpost", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Outpost", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIResources.sqf
@@ -191,7 +191,7 @@ for "_i" from 0 to (count _array - 1) do {
 	};
 };
 
-["locationSpawned", [_markerX, "Resource", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Resource", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
@@ -211,4 +211,4 @@ deleteMarker _mrk;
 		else { if !(_x isKindOf "StaticWeapon") then { [_x] spawn A3A_fnc_VEHdespawner } };
 	};
 } forEach _vehiclesX;
-["locationSpawned", [_markerX, "Resource", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Resource", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIcontrols.sqf
@@ -285,7 +285,7 @@ while {(spawner getVariable _markerX != 2) and ({[_x,_markerX] call A3A_fnc_canC
     sleep 3;
 };
 
-["locationSpawned", [_markerX, "Control", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Control", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1;((spawner getVariable _markerX == 2))  or ({[_x,_markerX] call A3A_fnc_canConquer} count _soldiers == 0)};
 
@@ -384,4 +384,4 @@ if (_conquered) then
             };
     };
 };
-["locationSpawned", [_markerX, "Control", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "Control", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/CREATE/fn_createSDKgarrisons.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createSDKgarrisons.sqf
@@ -168,7 +168,7 @@ for "_i" from 0 to (count _groups) - 1 do {
 	};
 };
 
-["locationSpawned", [_markerX, "RebelOutpost", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelOutpost", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {sleep 1; (spawner getVariable _markerX == 2)};
 
@@ -180,4 +180,4 @@ deleteGroup _groupStatics;
 deleteGroup _groupMortars;
 
 {if (!(_x in staticsToSave)) then {deleteVehicle _x}} forEach _vehiclesX;
-["locationSpawned", [_markerX, "RebelOutpost", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelOutpost", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
@@ -101,3 +101,5 @@ if (player == leader _unit) then {
 		_victim setVariable ["spawner",nil,true];
 	}];
 };
+
+["FIAinit", [_unit, _preserveIdentity]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
+++ b/A3A/addons/core/functions/REINF/fn_FIAinit.sqf
@@ -102,4 +102,4 @@ if (player == leader _unit) then {
 	}];
 };
 
-["FIAinit", [_unit, _preserveIdentity]] call EFUNC(Events,triggerEvent);
+["FIAinit", [_unit, _preserveIdentity]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -326,3 +326,5 @@ if (backpackItems _unit isEqualTo []) then { removeBackpack _unit };
 Verbose_3("Class %1, type %2, loadout %3", _unitType, _recruitType, str (getUnitLoadout _unit));
 
 if (_recruitType isEqualTo 0) then { _unit setVariable ["orgLoadout", getUnitLoadout _unit, true] };
+
+["rebelUnitEquipped", [_unit, _recruitType, _forceClass]] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
+++ b/A3A/addons/core/functions/REINF/fn_equipRebel.sqf
@@ -327,4 +327,4 @@ Verbose_3("Class %1, type %2, loadout %3", _unitType, _recruitType, str (getUnit
 
 if (_recruitType isEqualTo 0) then { _unit setVariable ["orgLoadout", getUnitLoadout _unit, true] };
 
-["rebelUnitEquipped", [_unit, _recruitType, _forceClass]] call EFUNC(Events,triggerEvent);
+["rebelUnitEquipped", [_unit, _recruitType, _forceClass]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
+++ b/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
@@ -169,4 +169,6 @@ if ((_sideX != side (group _medic)) and ((_sideX == Occupants) or (_sideX == Inv
 };
 _cured setVariable ["incapacitated",false,true];        // why is this applied later? check
 
+["unitRevived", [_cured, _medic]] call EFUNC(Events,triggerEvent);
+
 true;

--- a/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
+++ b/A3A/addons/core/functions/Revive/fn_actionRevive.sqf
@@ -169,6 +169,6 @@ if ((_sideX != side (group _medic)) and ((_sideX == Occupants) or (_sideX == Inv
 };
 _cured setVariable ["incapacitated",false,true];        // why is this applied later? check
 
-["unitRevived", [_cured, _medic]] call EFUNC(Events,triggerEvent);
+["unitRevived", [_cured, _medic]] spawn EFUNC(Events,triggerEvent);
 
 true;

--- a/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
@@ -79,6 +79,8 @@ private _makeUnconscious =
 	if (isPlayer _unit) then {_unit allowDamage false};
 	private _fromside = if (!isNull _injurer) then {side group _injurer} else {sideUnknown};
 	[_unit,_fromside] spawn A3A_fnc_unconscious;
+
+	["unitDowned", [_unit]] call EFUNC(Events,triggerEvent);
 };
 
 if (_part == "") then

--- a/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamage.sqf
@@ -80,7 +80,7 @@ private _makeUnconscious =
 	private _fromside = if (!isNull _injurer) then {side group _injurer} else {sideUnknown};
 	[_unit,_fromside] spawn A3A_fnc_unconscious;
 
-	["unitDowned", [_unit]] call EFUNC(Events,triggerEvent);
+	["unitDowned", [_unit]] spawn EFUNC(Events,triggerEvent);
 };
 
 if (_part == "") then

--- a/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
@@ -88,7 +88,7 @@ private _makeUnconscious =
 
 	[_unit,_injurer] spawn A3A_fnc_unconsciousAAF;
 
-	["unitDowned", [_unit]] call EFUNC(Events,triggerEvent);
+	["unitDowned", [_unit]] spawn EFUNC(Events,triggerEvent);
 };
 
 if (side _injurer == teamPlayer) then

--- a/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
+++ b/A3A/addons/core/functions/Revive/fn_handleDamageAAF.sqf
@@ -87,6 +87,8 @@ private _makeUnconscious =
 	[_unit, group _unit, _injurer] spawn A3A_fnc_AIreactOnKill;
 
 	[_unit,_injurer] spawn A3A_fnc_unconsciousAAF;
+
+	["unitDowned", [_unit]] call EFUNC(Events,triggerEvent);
 };
 
 if (side _injurer == teamPlayer) then

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -492,3 +492,5 @@ _saveHintText = [
 ] joinString "";
 [localize "STR_A3A_save_persisent_save",_saveHintText] remoteExecCall ["A3A_fnc_customHint",0,false];
 Info("Persistent Save Completed");
+
+["saveLoopComplete", []] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -493,4 +493,4 @@ _saveHintText = [
 [localize "STR_A3A_save_persisent_save",_saveHintText] remoteExecCall ["A3A_fnc_customHint",0,false];
 Info("Persistent Save Completed");
 
-["saveLoopComplete", []] call EFUNC(Events,triggerEvent);
+["saveLoopComplete", []] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/Supports/fn_createSupport.sqf
+++ b/A3A/addons/core/functions/Supports/fn_createSupport.sqf
@@ -71,6 +71,8 @@ try {
         private _spendTarg = [_targPos, _target] select (_target isEqualType objNull and {_target isKindOf "Air"});
         A3A_supportSpends pushBack [_side, _caller, _spendTarg, _resourceCost, time];
     };
+
+    ["supportCalled", [_type, _side]] call EFUNC(Events,triggerEvent);
 } catch {
     _supportName = "";
 

--- a/A3A/addons/core/functions/Supports/fn_createSupport.sqf
+++ b/A3A/addons/core/functions/Supports/fn_createSupport.sqf
@@ -72,7 +72,7 @@ try {
         A3A_supportSpends pushBack [_side, _caller, _spendTarg, _resourceCost, time];
     };
 
-    ["supportCalled", [_type, _side]] call EFUNC(Events,triggerEvent);
+    ["supportCalled", [_type, _side]] spawn EFUNC(Events,triggerEvent);
 } catch {
     _supportName = "";
 

--- a/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
+++ b/A3A/addons/core/functions/Undercover/fn_goUndercover.sqf
@@ -77,7 +77,7 @@ private _secureBases = (
 
 private _lastBaseInside = "";
 private _reason = "";
-["Undercover", [""]] call EFUNC(Events,triggerEvent);
+["Undercover", [""]] spawn EFUNC(Events,triggerEvent);
 
 while {_reason == ""} do
 {
@@ -332,4 +332,4 @@ switch (_reason) do
         ["Undercover", "STR_A3A_fn_undercover_goUn_Error"] call A3A_fnc_customHint;
     };
 };
-["Undercover", [_reason]] call EFUNC(Events,triggerEvent);
+["Undercover", [_reason]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -651,7 +651,7 @@ if (saveZeusBuildings) then {
 
 initClientDone = true;
 Info("initClient completed");
-["initClientComplete", []] call EFUNC(Events,triggerEvent);
+["initClientComplete", []] spawn EFUNC(Events,triggerEvent);
 
 if (!isMultiplayer) then {
 	["noSingleplayer",false,1,false,false] call BIS_fnc_endMission;

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -651,6 +651,7 @@ if (saveZeusBuildings) then {
 
 initClientDone = true;
 Info("initClient completed");
+["initClientComplete", []] call EFUNC(Events,triggerEvent);
 
 if (!isMultiplayer) then {
 	["noSingleplayer",false,1,false,false] call BIS_fnc_endMission;

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -309,7 +309,6 @@ addMissionEventHandler ["EntityKilled", {
 serverInitDone = true; publicVariable "serverInitDone";
 Info("Setting serverInitDone as true");
 A3A_startupState = "completed"; publicVariable "A3A_startupState";
-["initServerComplete", []] call EFUNC(Events,triggerEvent);
 
 
 // ********************* Initialize loops *******************************************
@@ -409,3 +408,4 @@ if (enableSpectrumDevice) then {
 };
 
 Info("initServer completed");
+["initServerComplete", []] call EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -408,4 +408,4 @@ if (enableSpectrumDevice) then {
 };
 
 Info("initServer completed");
-["initServerComplete", []] call EFUNC(Events,triggerEvent);
+["initServerComplete", []] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -309,6 +309,7 @@ addMissionEventHandler ["EntityKilled", {
 serverInitDone = true; publicVariable "serverInitDone";
 Info("Setting serverInitDone as true");
 A3A_startupState = "completed"; publicVariable "A3A_startupState";
+["initServerComplete", []] call EFUNC(Events,triggerEvent);
 
 
 // ********************* Initialize loops *******************************************

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -367,7 +367,7 @@ Info("Reading templates");
     private _type = ["Occ", "Inv", "Reb", "Civ", "Riv"] # _forEachIndex;
     missionNamespace setVariable ["A3A_"+_type+"_template", _x, true];			// don't actually need this atm, but whatever
 
-	["factionLoaded", [_side, _type]] call EFUNC(Events,triggerEvent);
+	["factionLoaded", [_side, _type]] spawn EFUNC(Events,triggerEvent);
 } forEach (_saveData get "factions");
 
 {

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -367,7 +367,7 @@ Info("Reading templates");
     private _type = ["Occ", "Inv", "Reb", "Civ", "Riv"] # _forEachIndex;
     missionNamespace setVariable ["A3A_"+_type+"_template", _x, true];			// don't actually need this atm, but whatever
 
-	["factionLoaded", [_side]] call EFUNC(Events,triggerEvent);
+	["factionLoaded", [_side, _type]] call EFUNC(Events,triggerEvent);
 } forEach (_saveData get "factions");
 
 {

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -366,6 +366,8 @@ Info("Reading templates");
 
     private _type = ["Occ", "Inv", "Reb", "Civ", "Riv"] # _forEachIndex;
     missionNamespace setVariable ["A3A_"+_type+"_template", _x, true];			// don't actually need this atm, but whatever
+
+	["factionLoaded", [_side]] call EFUNC(Events,triggerEvent);
 } forEach (_saveData get "factions");
 
 {

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -322,5 +322,5 @@ while {true} do {
 		publicVariable "unlockedVehicleTypes";
 	};
 
-	["resourceCheckComplete", []] call EFUNC(Events,triggerEvent);
+	["resourceCheckComplete", []] spawn EFUNC(Events,triggerEvent);
 };

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -321,4 +321,6 @@ while {true} do {
 		
 		publicVariable "unlockedVehicleTypes";
 	};
+
+	["resourceCheckComplete", []] call EFUNC(Events,triggerEvent);
 };

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -153,6 +153,16 @@ class Events {
     class saveLoopComplete {
         isLocal = 1;
     };
+    class factionLoaded {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Side of the faction loaded"; // One of: ["Occ", "Inv", "Reb", "Civ", "Riv"]
+                types[] = {"STRING"};
+                optional = 0;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -163,6 +163,26 @@ class Events {
             };
         };
     };
+    class rebelUnitEquipped {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Unit that was equipped";
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+            class _1 {
+                description = "Rebel recruit type"; // type of recruit; 0 = player or player's squad, 1 = high command unit, 2 = garrison unit
+                types[] = {"SCALAR"};
+                optional = 0;
+            };
+            class _2 {
+                description = "Unit class used to equip the unit"; // e.g. "unitUnarmed", "unitRifleman", etc.
+                types[] = {"STRING"};
+                optional = 1;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -157,13 +157,18 @@ class Events {
         isLocal = 1;
         class params {
             class _0 {
-                description = "Side of the faction loaded"; // One of: ["Occ", "Inv", "Reb", "Civ", "Riv"]
+                description = "Side of the faction loaded"; // One of: [west, east, resistance, civilian, opfor]
+                types[] = {"SIDE"};
+                optional = 0;
+            };
+            class _1 {
+                description = "Type of the faction loaded"; // One of: ["Occ", "Inv", "Reb", "Civ", "Riv"]
                 types[] = {"STRING"};
                 optional = 0;
             };
         };
     };
-    class rebelUnitEquipped {
+    class FIAinit {
         isLocal = 1;
         class params {
             class _0 {

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -153,6 +153,15 @@ class Events {
     class saveLoopComplete {
         isLocal = 1;
     };
+    class resourceCheckComplete {
+        isLocal = 1;
+    };
+    class aggressionUpdateLoopComplete {
+        isLocal = 1;
+    };
+    class garbageCleanerComplete {
+        isLocal = 1;
+    };
     class factionLoaded {
         isLocal = 1;
         class params {

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -218,6 +218,16 @@ class Events {
             };
         };
     };
+    class unitDowned {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Unit that was downed"; // same event for both downed rebels and enemies
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -228,6 +228,21 @@ class Events {
             };
         };
     };
+    class unitRevived {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Unit that was revived";
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+            class _1 {
+                description = "Medic unit that performed the revive";
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -144,6 +144,12 @@ class Events {
             };
         };
     };
+    class initServerComplete {
+        isLocal = 1;
+    };
+    class saveLoopComplete {
+        isLocal = 1;
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -144,6 +144,9 @@ class Events {
             };
         };
     };
+    class initClientComplete {
+        isLocal = 1;
+    };
     class initServerComplete {
         isLocal = 1;
     };

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -168,7 +168,7 @@ class Events {
             };
         };
     };
-    class FIAinit {
+    class rebelUnitEquipped {
         isLocal = 1;
         class params {
             class _0 {
@@ -184,6 +184,21 @@ class Events {
             class _2 {
                 description = "Unit class used to equip the unit"; // e.g. "unitUnarmed", "unitRifleman", etc.
                 types[] = {"STRING"};
+                optional = 1;
+            };
+        };
+    };
+    class FIAinit {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Unit being initialized";
+                types[] = {"OBJECT"};
+                optional = 0;
+            };
+            class _1 {
+                description = "Preserve Identity flag";
+                types[] = {"BOOL"};
                 optional = 1;
             };
         };

--- a/A3A/addons/events/Events.hpp
+++ b/A3A/addons/events/Events.hpp
@@ -203,6 +203,21 @@ class Events {
             };
         };
     };
+    class supportCalled {
+        isLocal = 1;
+        class params {
+            class _0 {
+                description = "Type of support called";
+                types[] = {"STRING"};
+                optional = 0;
+            };
+            class _1 {
+                description = "Side calling the support";
+                types[] = {"SIDE"};
+                optional = 0;
+            };
+        };
+    };
 /*
     class Example {
         isLocal = 1;

--- a/A3A/addons/patcom/functions/Civilian/fn_civilianInitEH.sqf
+++ b/A3A/addons/patcom/functions/Civilian/fn_civilianInitEH.sqf
@@ -55,7 +55,7 @@ if (_civNotHuman) exitWith
         params ["_victim", "_killer"];
         [_victim] spawn A3A_fnc_postmortem;
     }];
-    ["civInit", [_unit]] call EFUNC(Events,triggerEvent);
+    ["civInit", [_unit]] spawn EFUNC(Events,triggerEvent);
 };
 
 _unit addEventHandler["FiredNear", {
@@ -102,4 +102,4 @@ _unit addEventHandler ["Killed", {
     [_victim] spawn A3A_fnc_postmortem;
 }];
 
-["civInit", [_unit]] call EFUNC(Events,triggerEvent);
+["civInit", [_unit]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
@@ -80,7 +80,7 @@ switch (true) do {
 		garrison setVariable [_marker,_garrison,true];
 		staticPositions setVariable [_marker, [_position, _direction], true];
 		[_taskId, "outpostTask", "SUCCEEDED"] call A3A_fnc_taskSetState;
-		["RebelControlCreated", [_marker, "aaemplacement"]] call EFUNC(Events,triggerEvent);
+		["RebelControlCreated", [_marker, "aaemplacement"]] spawn EFUNC(Events,triggerEvent);
 	};
 	default {
 		[_taskId, "outpostTask", "FAILED"] call A3A_fnc_taskSetState;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAaDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAaDistance.sqf
@@ -61,7 +61,7 @@ _groupX setCombatMode "YELLOW";
 
 [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 
-["locationSpawned", [_markerX, "RebelAaEmpl", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelAaEmpl", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {
 	sleep 1; 
@@ -93,4 +93,4 @@ deleteGroup _groupX;
 	deleteVehicle _x;
 } forEach _props;
 
-["locationSpawned", [_markerX, "RebelAaEmpl", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelAaEmpl", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
@@ -81,7 +81,7 @@ switch (true) do {
 		garrison setVariable [_marker,_garrison,true];
 		staticPositions setVariable [_marker, [_position, _direction], true];
 		[_taskId, "outpostTask", "SUCCEEDED"] call A3A_fnc_taskSetState;
-		["RebelControlCreated", [_marker, "atemplacement"]] call EFUNC(Events,triggerEvent);
+		["RebelControlCreated", [_marker, "atemplacement"]] spawn EFUNC(Events,triggerEvent);
 	};
 	default {
 		[_taskId, "outpostTask", "FAILED"] call A3A_fnc_taskSetState;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAtDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAtDistance.sqf
@@ -63,7 +63,7 @@ _groupX setCombatMode "YELLOW";
 
 [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 
-["locationSpawned", [_markerX, "RebelAtEmpl", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelAtEmpl", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {
 	sleep 1; 
@@ -95,4 +95,4 @@ deleteGroup _groupX;
 	deleteVehicle _x;
 } forEach _props;
 
-["locationSpawned", [_markerX, "RebelAtEmpl", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelAtEmpl", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
@@ -80,7 +80,7 @@ switch (true) do {
 		garrison setVariable [_marker,_garrison,true];
 		staticPositions setVariable [_marker, [_position, _direction], true];
 		[_taskId, "outpostTask", "SUCCEEDED"] call A3A_fnc_taskSetState;
-		["RebelControlCreated", [_marker, "hmgemplacement"]] call EFUNC(Events,triggerEvent);
+		["RebelControlCreated", [_marker, "hmgemplacement"]] spawn EFUNC(Events,triggerEvent);
 	};
 	default {
 		[_taskId, "outpostTask", "FAILED"] call A3A_fnc_taskSetState;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createHmgDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createHmgDistance.sqf
@@ -64,7 +64,7 @@ _groupX setCombatMode "YELLOW";
 
 [_veh, teamPlayer] call A3A_fnc_AIVEHinit;
 
-["locationSpawned", [_markerX, "RebelHmgEmpl", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelHmgEmpl", true]] spawn EFUNC(Events,triggerEvent);
 
 
 waitUntil {
@@ -97,4 +97,4 @@ deleteGroup _groupX;
 	deleteVehicle _x;
 } forEach _props;
 
-["locationSpawned", [_markerX, "RebelHmgEmpl", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelHmgEmpl", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
@@ -82,7 +82,7 @@ switch (true) do {
 		_garrison = [_riflemanType] + _squadType;
 		garrison setVariable [_marker,_garrison,true];
 		[_taskId, "outpostTask", "SUCCEEDED"] call A3A_fnc_taskSetState;
-		["RebelControlCreated", [_marker, "roadblock"]] call EFUNC(Events,triggerEvent);
+		["RebelControlCreated", [_marker, "roadblock"]] spawn EFUNC(Events,triggerEvent);
 	};
 	default {
 		[_taskId, "outpostTask", "FAILED"] call A3A_fnc_taskSetState;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createRoadblockDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createRoadblockDistance.sqf
@@ -59,7 +59,7 @@ if (_crewManIndex != -1) then {
     _crewMan lookAt (_crewMan getRelPos [100, _dirveh]);
 };
 
-["locationSpawned", [_markerX, "RebelRoadblock", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelRoadblock", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {
 	sleep 1; 
@@ -89,4 +89,4 @@ if (!isNull _veh) then {
 } forEach units _groupX;
 deleteGroup _groupX;
 
-["locationSpawned", [_markerX, "RebelRoadblock", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelRoadblock", false]] spawn EFUNC(Events,triggerEvent);

--- a/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
@@ -77,7 +77,7 @@ switch (true) do {
 		_marker setMarkerColor colorTeamPlayer;
 		_marker setMarkerText _textX;
 		[_taskId, "outpostTask", "SUCCEEDED"] call A3A_fnc_taskSetState;
-		["RebelControlCreated", [_marker, "watchpost"]] call EFUNC(Events,triggerEvent);
+		["RebelControlCreated", [_marker, "watchpost"]] spawn EFUNC(Events,triggerEvent);
 	};
 	default {
 		[_taskId, "outpostTask", "FAILED"] call A3A_fnc_taskSetState;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createWatchpostDistance.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createWatchpostDistance.sqf
@@ -29,7 +29,7 @@ _props pushBack _tent;
 	_x setVectorUp surfaceNormal position _x;
 } forEach _props;
 
-["locationSpawned", [_markerX, "RebelWatchpost", true]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelWatchpost", true]] spawn EFUNC(Events,triggerEvent);
 
 waitUntil {
 	sleep 1; 
@@ -57,4 +57,4 @@ deleteGroup _groupX;
 	deleteVehicle _x;
 } forEach _props;
 
-["locationSpawned", [_markerX, "RebelWatchpost", false]] call EFUNC(Events,triggerEvent);
+["locationSpawned", [_markerX, "RebelWatchpost", false]] spawn EFUNC(Events,triggerEvent);


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [x] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [x] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> This PR adds more events that other mods, or Antistasi itself, can listen to. Mostly useful for extenders to enable them to run their own code when certain events happen instead of overwriting our functions (and breaking when we update).
>
> Newly-Added Events:
> EventName | Triggered
> --- | ---
> initClientComplete | After completion of fn_initClient
> initServerComplete | After completion of fn_initServer
> saveLoopComplete | After completion of Antistasi save routing (loops based on param value or when manually called)
> resourceCheckComplete | After completion of resource check (loops every 10min)
> aggressionUpdateLoopComplete | After completion of aggressionUpdate (loops every 1min)
> garbageCleanerComplete | After completion of garbageCleaner routine
> factionLoaded | After loading faction template and storing it in missionNamespace (e.g. `A3A_faction_Reb`)
> FIAinit | After initializing a rebel AI unit
> rebelUnitEquipped | After equipping a rebel AI unit
> supportCalled | After enemy calls a support (e.g. mortar, ASF, etc)
> unitDowned | After a unit (rebel or enemy) is downed / made unconscious by Antistasi system (*NOT ACE*)
>
> Open to feedback on more functions / events we should add.

**How can your changes be tested, or reproduced?**

> Create an extender that adds event listener(s) for the events you added. Verify the event is triggered and the callback in your extender runs when the event is triggered.
>
> I have a test extender at [jwoodruff40/A3UE-Events-Testing](https://github.com/jwoodruff40/A3UE-Events-Testing)
>
> The only events I have actually tested at this point are `initServerComplete` and `saveLoopComplete`.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [x] Needs further changes.
- [ ] Needs to be converted to a draft.

> - Needs testing on DS
> - Should have more events added

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #716

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>