### PR TITLE
don't break resourceCheck with no miladmins

### DIFF
--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -108,7 +108,7 @@ while {true} do {
 			[_city] call A3A_fnc_mrkUpdate;
 
 			private _closestAdminMarker = [milAdministrationsX, _city] call BIS_fnc_nearestPosition;
-			if ((getMarkerPos _closestAdminMarker) distance2D (getMarkerPos _city) < 800) then {
+			if (_closestAdminMarker isEqualType "" && {(getMarkerPos _closestAdminMarker) distance2D (getMarkerPos _city) < 800}) then {
 				private _milAdministration = [A3A_milAdministrations, _closestAdminMarker] call BIS_fnc_nearestPosition;
 				[_milAdministration, "SILENT"] call SCRT_fnc_location_removeMilAdmin;
 			};


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> `BIS_fnc_nearestPosition` returns a position (`[0,0,0]`) when none found instead of a marker name (string), which causes this check to throw a type error.

**How can your changes be tested, or reproduced?**

> Load Anizay (or another map with no mil admins) and verify resourceCheck doesn't choke on this line and stop doing all the things it does every 10min.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

Should probably / may add new mil admin positions to maps including Anizay because those are broken and don't populate due to the building class name not being included in the mil admin types. Should also probably put mil admin types in config or a global var or something so they're easier to update.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>