### PR TITLE
Better radio detection

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_getRadio.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_getRadio.sqf
@@ -21,11 +21,5 @@ License: MIT License
 */
 params ["_unit"];
 
-private _items = assignedItems _unit;
-private _radioPosition = _items findIf { _x == "ItemRadio" || {"tf_" in _x || {"TFAR_" in _x || {"item_radio" in _x}}}};
-
-if (_radioPosition > -1) then {
-	_items # _radioPosition;
-} else {
-	"";
-};
+// https://community.bistudio.com/wiki/getSlotItemName
+_unit getSlotItemName 611;

--- a/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
@@ -20,5 +20,5 @@ Example: _unit call A3A_fnc_hasRadio;
 
 License: MIT License
 */
-assignedItems _this findIf { _x == "ItemRadio" || {"tf_" in _x} || {"TFAR" in _x} || {"item_radio" in _x} } > -1
+assignedItems _this findIf { getText(configFile >> "CfgWeapons" >> _x >> "simulation") isEqualTo "ItemRadio" } > -1
 || { backpack _this in allBackpacksRadio }

--- a/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_hasARadio.sqf
@@ -20,5 +20,4 @@ Example: _unit call A3A_fnc_hasRadio;
 
 License: MIT License
 */
-assignedItems _this findIf { getText(configFile >> "CfgWeapons" >> _x >> "simulation") isEqualTo "ItemRadio" } > -1
-|| { backpack _this in allBackpacksRadio }
+(_this getSlotItemName 611 isNotEqualTo "") || { backpack _this in allBackpacksRadio };


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Changed detection code for "does unit have a radio".
>
> Now works with anything that's a radio.

**How can your changes be tested, or reproduced?**

> Console: `player call A3A_fnc_hasARadio` should show `true` for radios like the "AN/PRC-152" (`rhsusf_radio_anprc152`), too.
>
> It won't, however, indicate (false?) positives on the MicroDAGR Radio Programmer (`tf_microdagr`), for example.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own.
- [X] These changes are ready for review.
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
