### PR TITLE
Fix tower's turret and civ traffic placements

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_milBuildings.sqf
@@ -92,7 +92,7 @@ for "_i" from 0 to (count _buildings) - 1 do
             private _type = selectRandom (_faction get "staticMGs");
             private _dir = (getDir _building) - 180;
             private _zpos = AGLToASL (_building buildingPos 1);
-            private _pos = _zpos getPos [1.5, _dir];			// zeroes Z value because BIS
+            private _pos = _zpos getPos [1.8, _dir];			// zeroes Z value because BIS /// I would like to move mg to the left a bit, but coudn't find a way to do it
             _pos = ASLToATL ([_pos select 0, _pos select 1, _zpos select 2]);
             [_type, _pos, _dir] call _fnc_spawnStatic;
         };

--- a/A3A/addons/patcom/functions/Civilian/fn_createAmbientCivTraffic.sqf
+++ b/A3A/addons/patcom/functions/Civilian/fn_createAmbientCivTraffic.sqf
@@ -93,13 +93,18 @@ while {(spawner getVariable _spawnKey != 2) and (_countParked < _numParked)} do 
                 _dirveh = _p1 getDir _p2;
             };
 
-            private _width = 3 max (getRoadInfo _road # 1 / 2 - 1);
+            private _width = 2.65 max (getRoadInfo _road # 1 / 2 - 1);
             _pos = [_p1, _width, _dirveh + 90] call BIS_Fnc_relPos;
             _typeVehX = selectRandomWeighted civVehiclesWeighted;
 
             private _veh = _typeVehX createVehicle _pos;
             _veh setDir _dirveh;
             _veh setFuel random [0.10, 0.30, 0.50];
+            _veh allowDamage false;
+			_veh enableSimulation false;
+			sleep 0.5;
+			_veh enableSimulation true;
+			_veh allowDamage true;
 
             // Magazine, Weapon, Item, Backpack, True = Clear
             [_veh, true, true, true, true] call A3A_fnc_clearVehicleCargo;
@@ -110,7 +115,7 @@ while {(spawner getVariable _spawnKey != 2) and (_countParked < _numParked)} do 
             };
         };
 
-    sleep 0.5;
+    sleep 0.3;
     _countParked = _countParked + 1;
 };
 


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

Moved turret placement on cargo turret towers to prevent different turrets from bugging out inside towers model and sloshing around, sometimes killing the gunner and destroying itself.

Moved civilian cars placed on the roads a little bit to the center to prevent them from spawning inside walls/building/fences thus exploding.
+ added a little bit of code (similar to plane placement inside hangars) in hopes to prevent vehicles from blowing up, if they still do manage to spawn inside something.

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

Carved out from #541 

</details>