### PR TITLE
Give SMGs to every tier of Aegis NATO troops

### DIFF
--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Arid.sqf
@@ -345,6 +345,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
 ["GL_XM25_F", "", "", "", ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_snd_F", "Aegis_muzzle_snds_460_sand", "", "optic_Holosight_smg", [], [], ""]
+]];
 _sfLoadoutData set ["machineGuns", [
 ["LMG_03_snd_F", "muzzle_snds_m_snd_F", "acc_pointer_IR", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
 ["LMG_03_snd_F", "muzzle_snds_m_snd_F", "acc_pointer_IR", "optic_NVS", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -444,6 +448,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_LoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_snd_F", "", "", "optic_Holosight_smg", [], [], ""]
+]];
 
 private _mgs = [
     ["LMG_Mk200_plain_F", "muzzle_mzls_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_01_F_blk"],
@@ -535,8 +543,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_snd_F", "", "acc_pointer_IR", "optic_Holosight", ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_snd_F", "", "", "optic_Holosight_smg", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""]
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_snd_F", "", "", "optic_Holosight_smg", [], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -622,6 +630,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_plain_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_F", "", "acc_flashlight", "optic_Holosight", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_snd_F", "", "", "optic_Holosight_smg", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Temperate.sqf
@@ -345,6 +345,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
 ["GL_XM25_F", "", "", "", ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "Aegis_muzzle_snds_460_khaki", "", "optic_Holosight_smg_khk_F", [], [], ""]
+]];
 _sfLoadoutData set ["machineGuns", [
 ["LMG_03_khk_F", "muzzle_snds_m_khk_F", "acc_pointer_IR", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
 ["LMG_03_khk_F", "muzzle_snds_m_khk_F", "acc_pointer_IR", "optic_NVS", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -441,6 +445,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_eliteLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
+]];
 
 private _mgs = [
     ["LMG_Mk200_black_F", "muzzle_mzls_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_01_F_blk"],
@@ -531,8 +539,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_snd_F", "", "acc_pointer_IR", "optic_Holosight_khk_F", ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_khk_F", "", "", "optic_Holosight_smg", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""]
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -618,6 +626,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_black_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_black_F", "", "acc_flashlight", "", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_black_F", "", "acc_flashlight", "optic_Holosight_khk_F", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_AUKUS_Tropical.sqf
@@ -344,6 +344,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["designatedGrenadeLaunchers", [
 ["GL_XM25_F", "", "", "", ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ["5Rnd_25x40mm_HE", "5Rnd_25x40mm_HE", "5Rnd_25x40mm_airburst"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "Aegis_muzzle_snds_460_khaki", "", "optic_Holosight_smg_khk_F", [], [], ""]
+]];
 _sfLoadoutData set ["machineGuns", [
 ["LMG_03_khk_F", "muzzle_snds_m_khk_F", "acc_pointer_IR", "optic_Hamr", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
 ["LMG_03_khk_F", "muzzle_snds_m_khk_F", "acc_pointer_IR", "optic_NVS", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -440,6 +444,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SPAR_01_GL_blk_F", "", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_red", "30Rnd_556x45_Stanag_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_eliteLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
+]];
 
 private _mgs = [
     ["LMG_Mk200_black_F", "muzzle_mzls_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Red", "200Rnd_65x39_cased_Box_Tracer_Red"], [], "bipod_01_F_blk"],
@@ -530,8 +538,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_khk_F", "", "acc_pointer_IR", "optic_Holosight_khk_F", ["30Rnd_65x39_caseless_khaki_mag", "30Rnd_65x39_caseless_khaki_mag", "30Rnd_65x39_caseless_khaki_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_khk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F", "40Rnd_460x30_Mag_F"], [], ""]
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],
@@ -617,6 +625,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["arifle_Mk20_GL_black_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_black_F", "", "acc_flashlight", "", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_AUG_GL_black_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_F", "30Rnd_556x45_AUG_Mag_Tracer_F"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_LoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_khk_F", "", "", "optic_Holosight_smg_khk_F", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_MRCO", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
@@ -408,8 +408,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -553,12 +553,12 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_F", "", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "acc_pointer_IR", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "acc_pointer_IR", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_F", "acc_pointer_IR", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "acc_pointer_IR", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "acc_pointer_IR", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "acc_pointer_IR", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -685,10 +685,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
@@ -408,8 +408,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -553,8 +553,8 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_F", "", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -685,8 +685,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag", "30Rnd_65x39_caseless_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
@@ -814,8 +814,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_sand_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
@@ -410,10 +410,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -555,10 +555,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 _eliteLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -687,10 +687,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 _militaryLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_Mk200_plain_F", "", "acc_flashlight", "", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_01_F_snd"],
@@ -816,10 +816,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_snd_F", "", "acc_flashlight", "optic_Holosight", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Arid.sqf
@@ -407,6 +407,14 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+]];
 
 private _mgs = [
 ["arifle_SPAR_02_blk_F", "muzzle_snds_M", "acc_pointer_IR", "optic_ERCO_blk_F", ["150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_Tracer_F"], [], "bipod_01_F_blk"],
@@ -543,6 +551,14 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_F", "", "acc_pointer_IR", "optic_Holosight", ["30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_F", "", "acc_pointer_IR", "optic_Hamr", ["30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_F", "", "acc_pointer_IR", "optic_MRCO", ["30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand", "30Rnd_556x45_Stanag_Sand_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_eliteLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "acc_pointer_IR", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "acc_pointer_IR", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "acc_pointer_IR", "", "optic_Holosight", [], [], ""],
+["SMG_01_F", "acc_pointer_IR", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "acc_pointer_IR", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "acc_pointer_IR", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -796,6 +812,14 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_sand_F", "", "acc_flashlight", "optic_Holosight", ["30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_sand_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_sand_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_red", "30Rnd_556x45_Stanag_Sand_Tracer_Red"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_snd_F", "", "acc_flashlight", "optic_Holosight", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
@@ -407,8 +407,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -552,8 +552,8 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -676,8 +676,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_Black_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
@@ -806,8 +806,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
@@ -407,8 +407,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -552,12 +552,12 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -676,10 +676,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_Black_F", "", "acc_flashlight", "optic_Hamr", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_F", "", "", "optic_Holosight_blk_F", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
@@ -409,10 +409,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -554,10 +554,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 _eliteLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_black_F", "", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_black_F", "", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -678,10 +678,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 _militaryLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_Mk200_black_F", "", "acc_flashlight", "", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_01_F_blk"],
@@ -808,10 +808,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Temperate.sqf
@@ -406,6 +406,14 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+]];
 
 private _mgs = [
 ["arifle_SPAR_02_blk_F", "muzzle_snds_M", "acc_pointer_IR", "optic_ERCO_blk_F", ["150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_Tracer_F"], [], "bipod_01_F_blk"],
@@ -542,6 +550,14 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_Hamr", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_eliteLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -788,6 +804,14 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
@@ -406,8 +406,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -551,8 +551,8 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
 ["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -692,8 +692,8 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_Black_F", "", "acc_flashlight", "optic_Aco", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
@@ -837,8 +837,8 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_khaki_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
 ["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
@@ -406,8 +406,8 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _sfLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
 ["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
@@ -551,12 +551,12 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _eliteLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -692,10 +692,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 ["arifle_MX_GL_Black_F", "", "acc_flashlight", "optic_Aco", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militaryLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_F", "", "", "optic_Holosight_blk_F", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];
@@ -837,10 +837,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_khaki_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
 _militiaLoadoutData set ["SMGs", [
-["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
-["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
 ["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
@@ -408,10 +408,10 @@ _sfLoadoutData set ["grenadeLaunchers", [
 _sfLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "muzzle_snds_460", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -553,10 +553,10 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 _eliteLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""],
-["SMG_01_black_F", "", "", "optic_Holosight", [], [], ""],
-["SMG_01_black_F", "", "", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+["SMG_01_black_F", "", "", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_black_F", "", "", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_pointer_IR", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 
 private _mgs = [
@@ -694,10 +694,10 @@ _militaryLoadoutData set ["grenadeLaunchers", [
 _militaryLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight_blk_F", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militaryLoadoutData set ["machineGuns", [
 ["LMG_Mk200_black_F", "", "acc_flashlight", "", ["200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box", "200Rnd_65x39_cased_Box_Tracer"], [], "bipod_01_F_blk"],
@@ -839,10 +839,10 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 _militiaLoadoutData set ["SMGs", [
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Holosight_smg_blk_F", [], [], ""],
 ["SMG_04_blk_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", [], [], ""],
-["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
-["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Holosight", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_01_F", "", "acc_flashlight_smg_01", "optic_Aco_smg", ["30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01", "30Rnd_45ACP_Mag_SMG_01_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", ["30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02", "30Rnd_9x21_Mag_SMG_02_Tracer_Yellow"], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_khk_F", "", "acc_flashlight", "optic_Holosight_khk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],

--- a/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Aegis/Aegis_AI_NATO_Tropical.sqf
@@ -405,6 +405,14 @@ _sfLoadoutData set ["grenadeLaunchers", [
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_Hamr", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SA80_GL_blk_F", "muzzle_snds_H", "acc_pointer_IR", "optic_ERCO_blk_F", ["30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag", "30Rnd_65x39_caseless_black_mag_Tracer"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
 ]];
+_sfLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
+]];
 
 private _mgs = [
 ["arifle_SPAR_02_blk_F", "muzzle_snds_M", "acc_pointer_IR", "optic_ERCO_blk_F", ["150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_F", "150Rnd_556x45_Drum_Mag_Tracer_F"], [], "bipod_01_F_blk"],
@@ -541,6 +549,14 @@ _eliteLoadoutData set ["grenadeLaunchers", [
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_Holosight_blk_F", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_Hamr", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""],
 ["arifle_SCAR_GL_black_F", "", "acc_pointer_IR", "optic_MRCO", [], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_HEDP_Grenade_shell", "1Rnd_Pellet_Grenade_shell_lxWS", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_eliteLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "muzzle_snds_460", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Holosight", [], [], ""],
+["SMG_01_black_F", "muzzle_mzls_smg_01", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "muzzle_snds_L", "acc_pointer_IR", "optic_Aco_smg", [], [], ""]
 ]];
 
 private _mgs = [
@@ -819,6 +835,14 @@ _militiaLoadoutData set ["grenadeLaunchers", [
 ["Aegis_arifle_M4A1_GL_khaki_F", "", "acc_flashlight", "optic_Holosight_khk_F", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_khaki_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""],
 ["Aegis_arifle_M4A1_GL_khaki_F", "", "acc_flashlight", "", ["30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag", "30Rnd_556x45_Stanag_Tracer_Yellow"], ["1Rnd_HE_Grenade_shell", "1Rnd_HE_Grenade_shell", "1Rnd_Smoke_Grenade_shell"], ""]
+]];
+_militiaLoadoutData set ["SMGs", [
+["SMG_04_blk_F", "", "", "optic_Holosight_smg_blk_F", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_04_blk_F", "", "", "optic_Aco_smg", ["40Rnd_460x30_Mag_F"], [], ""],
+["SMG_01_F", "", "", "optic_Holosight", [], [], ""],
+["SMG_01_F", "", "", "optic_Aco_smg", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Holosight_blk_F", [], [], ""],
+["SMG_02_F", "", "acc_flashlight", "optic_Aco_smg", [], [], ""]
 ]];
 _militiaLoadoutData set ["machineGuns", [
 ["LMG_03_khk_F", "", "acc_flashlight", "optic_Holosight_khk_F", ["200Rnd_556x45_Box_F", "200Rnd_556x45_Box_F", "200Rnd_556x45_Box_Tracer_F"], [], ""],


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [x] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Went into the various Aegis NATO templates and gave every tier of troop SMGs, resolving the issue where troops in tiers aside from military and police would occasionally spawn without a primary.

**How can your changes be tested, or reproduced?**

> Use this handy teleport script to move between strongholds `openMap true;
onMapSingleClick {
onMapSingleClick {};
{_x setPos _pos;} forEach units group player;
hint '';
openMap false;
};` and open spectator mode to look for units wielding SMGs. Use `tierWar = 10;` before loading in a stronghold to test for elite troops.

> For spec ops, use `[["_markerX"],"A3A_fnc_AS_specOP"] remoteExec ["A3A_fnc_scheduler",2];` to create a spec ops assassination mission where _markerX is any given map marker ID.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #717.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>