### PR TITLE
Logistics: Cargo can block turrets (turn out seats)

### DIFF
--- a/A3A/addons/logistics/Nodes/CUP.hpp
+++ b/A3A/addons/logistics/Nodes/CUP.hpp
@@ -690,16 +690,15 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_MG_p3d : TRIPLE
 {
     canLoadWeapon = 0;
     class Nodes
-   {
-       class Node1
-       {
-           offset[] = {0,-2.1,-1};
-       };
+    {
+        class Node1
+        {
+            offset[] = {0,-2.1,-1};
+        };
     };
 };
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_MG_p3d {};
 
-/* pending turn out seat fix
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -708,29 +707,27 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d : TRIPLES(
         class Node1
         {
             offset[] = {0,-2.8,-1.3};
-			seats[] = {0,1,3,4,5,6};
+			seats[] = {0,1};
+            turrets[] = {{2},{3},{4},{5}};
         };
     };
 };
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_hmg_p3d : CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d {};
-*/
 
-/* pending turn out seat fix
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP_bvp1 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0; 
-        class Nodes
+    canLoadWeapon = 0; 
+    class Nodes
     {
         class Node1
         {
             offset[] = {-0.6,-2.4,-1.3};
-			seats[] = {5,7};
+            seats[] = {5,7};
+			turrets[] = {{8},{9}};
         };
     };
 };
-*/
 
-/* pending turn out seat fix
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2 : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -740,12 +737,11 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2 : TRIPLES(ADDON,Node
         {
             offset[] = {-0.6,-2.3,-1.2};
 			seats[] = {8};
+            turrets[] = {{6}};
         };
     };
 };
-*/
 
-/* pending turret seat fix
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_ambulance : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 1;
@@ -754,16 +750,14 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_ambulance : TRIPLES(
         class Node1
         {
             offset[] = {0,-1.95,0.35};
-			seats[] = {};
         };
         class Node2
         {
             offset[] = {0,-2.75,0.35};
-			seats[] = {};
+			turrets[] = {{2}};
         };
     };
 };
-*/
 
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_HQ : TRIPLES(ADDON,Nodes,Base)
 {
@@ -827,7 +821,6 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_CUP_btr40_dskm : TRIPLES(ADD
     };
 };
 
-/* pending turn out seat fix
 class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 1;
@@ -837,6 +830,7 @@ class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,No
         {
             offset[] = {0,-1.4,-0.05};
 			seats[] = {1,4};
+            turrets[] = {{9}};
         };
 		class Node2
         {
@@ -845,7 +839,6 @@ class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,No
         };
     };
 };
-*/
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80_p3d : TRIPLES(ADDON,Nodes,Base)
 {
@@ -1014,7 +1007,6 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog_RWS : TR
 };
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog : CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog_RWS {};
 
-/* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -1023,13 +1015,11 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_p3d : TRIPLES(AD
         class Node1
         {
             offset[] = {0,-2.05,-0.45};
-			seats[] = {5,6,7};
+			seats[] = {1};
         };
     };
 };
-*/
 
-/* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_ambulance_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -1038,11 +1028,10 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_ambulance_p3d : 
         class Node1
         {
             offset[] = {0,-1.7,-0.02};
-			seats[] = {1,5};
+			seats[] = {0};
         };
     };
 };
-*/
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_FV510_CUP_FV510_BAF : TRIPLES(ADDON,Nodes,Base)
 {
@@ -1100,7 +1089,6 @@ class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d : TRIPL
 class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_LMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d {};
 class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_GMG_p3d : cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d {};
 
-/* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_AAV_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -1110,17 +1098,17 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_AAV_p3d : TRIPLES(ADDON,No
         {
             offset[] = {0,-2.3,-1.47};
 			seats[] = {4,9,12};
+            turrets[] = {{3},{6}};
         };
         class Node2
         {
             offset[] = {0,-3.1,-1.47};
 			seats[] = {5,6,7,10};
+            turrets[] = {{4},{7}};
         };
     };
 };
-*/
 
-/* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_aav_unarmed_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -1130,15 +1118,16 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_aav_unarmed_p3d : TRIPLES(
         {
             offset[] = {0,-2.3,-1.31};
 			seats[] = {4,9,12};
+            turrets[] = {{3},{6}};
         };
         class Node2
         {
             offset[] = {0,-3.1,-1.31};
 			seats[] = {5,6,7,10};
+            turrets[] = {{4},{7}};
         };
     };
 };
-*/
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_p3d : TRIPLES(ADDON,Nodes,Base)
 {
@@ -1204,7 +1193,6 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_mk19 : CUP_W
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1133_MEV : CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 {};
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1130_CV : CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 {};
 
-/* pending turn out seat fix
 class cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d : TRIPLES(ADDON,Nodes,Base)
 {
     canLoadWeapon = 0;
@@ -1213,12 +1201,12 @@ class cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d : TRIPLES(ADDO
         class Node1
         {
             offset[] = {0,-2.2,-1.5};
-			seats[] = {2,3,4,5};
+			seats[] = {2,3};
+            turrets[] = {{1},{2}};
         };
     };
 };
 class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav25m240_p3d : cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d {};
-*/
 
 class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav_hq_p3d : TRIPLES(ADDON,Nodes,Base)
 {

--- a/A3A/addons/logistics/Nodes/CUP.hpp
+++ b/A3A/addons/logistics/Nodes/CUP.hpp
@@ -387,7 +387,7 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_LR_model_LeftHand_CUP_LR_Special_p
 
 class cup_wheeledvehicles_cup_wheeledvehicles_wolfhound_CUP_wolfhound_GMG_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-	canLoadWeapon = 1;
+    canLoadWeapon = 1;
     class Nodes
     {
         class Node1
@@ -472,7 +472,7 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_NewM998_model_CUP_nM1038_4s_p3d : 
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-	canLoadWeapon = 0;
+    canLoadWeapon = 0;
     class Nodes
     {
         class Node1
@@ -487,8 +487,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_M1151_models_CUP_nM1151_ogpk_mk19_
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_HMMWV_model_CUP_m1151_m2_gpk_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -503,8 +503,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_hmmwv_model_cup_M998_crows : CUP_W
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_Deploy_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -517,8 +517,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_M1151_MK19_p3d : CUP_W
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_UpHMMWV_CUP_GMV_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -676,8 +676,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Ural_cup_Ural_open_p3d : TRIPLES(A
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_SUV_CUP_SUV_Armored_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-	   canLoadWeapon = 0;
-       class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
        class Node1
        {
@@ -688,8 +688,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_SUV_CUP_SUV_Armored_p3d : TRIPLES(
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_MG_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-	   canLoadWeapon = 0;
-       class Nodes
+    canLoadWeapon = 0;
+    class Nodes
    {
        class Node1
        {
@@ -702,8 +702,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Dingo_CUP_Dingo2a2_p3d : CUP_Wheel
 /* pending turn out seat fix
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Boxer_CUP_Boxer_gmg_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -733,8 +733,8 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP_bvp1 : TRIPLES(ADDON,Nodes
 /* pending turn out seat fix
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -748,8 +748,8 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2 : TRIPLES(ADDON,Node
 /* pending turret seat fix
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_ambulance : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -767,8 +767,8 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_ambulance : TRIPLES(
 
 class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_HQ : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -779,8 +779,8 @@ class cup_trackedvehicles_cup_trackedvehicles_bmp_BMP2_BMP2_HQ : TRIPLES(ADDON,N
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_BMP3_CUP_BMP3 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -791,8 +791,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_BMP3_CUP_BMP3 : TRIPLES(ADDON,Node
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BRDM2_CUP_BRDM2_HQ_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -803,8 +803,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BRDM2_CUP_BRDM2_HQ_p3d : TRIPLES(A
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_cup_btr40 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -816,8 +816,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_cup_btr40 : TRIPLES(ADDON,No
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_CUP_btr40_dskm : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -830,8 +830,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR40_CUP_btr40_dskm : TRIPLES(ADD
 /* pending turn out seat fix
 class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -849,8 +849,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_btr60_CUP_BTR60 : TRIPLES(ADDON,No
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -873,8 +873,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR80_CUP_BTR_80A_p3d : CUP_Wheele
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR90_CUP_BTR90_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -886,8 +886,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR90_CUP_BTR90_p3d : TRIPLES(ADDO
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_BTR90_CUP_BTR90_HQ : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -950,8 +950,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_Unarmed
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -964,8 +964,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_GMG_p3d
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_HMG_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1002,8 +1002,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Vodnik_CUP_GAZ39371_Vodnik_MedEvac
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog_RWS : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1017,8 +1017,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_bulldog : CUP_Tr
 /* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1032,8 +1032,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_p3d : TRIPLES(AD
 /* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_ambulance_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1046,8 +1046,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_Bulldog_CUP_fv432_ambulance_p3d : 
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_FV510_CUP_FV510_BAF : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1059,8 +1059,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_FV510_CUP_FV510_BAF : TRIPLES(ADDO
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_MCV80_CUP_MCV80_BAF : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1072,8 +1072,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_MCV80_CUP_MCV80_BAF : TRIPLES(ADDO
 
 class cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1087,8 +1087,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_Mastiff_CUP_Mastiff_GMG_p3d : cup_
 
 class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1103,8 +1103,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_ridgeback_CUP_ridgback_GMG_p3d : c
 /* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_AAV_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1123,8 +1123,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_AAV_p3d : TRIPLES(ADDON,No
 /* pending turn out seat fix
 class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_aav_unarmed_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1142,8 +1142,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_AAV_CUP_aav_unarmed_p3d : TRIPLES(
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1156,8 +1156,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_p3d : CUP_Track
 
 class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a3_mhq_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -1175,8 +1175,8 @@ class CUP_TrackedVehicles_CUP_TrackedVehicles_NewM113_CUP_m113a1_mhq_p3d : CUP_T
 
 class cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M2A2_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1190,8 +1190,8 @@ class cup_TrackedVehicles_CUP_TrackedVehicles_Bradley_CUP_M7_p3d : cup_TrackedVe
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1126_ICV_m2 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1207,8 +1207,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_Stryker_CUP_M1130_CV : CUP_Wheeled
 /* pending turn out seat fix
 class cup_wheeledvehicles_cup_wheeledvehicles_lav25_CUP_LAV25_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1222,8 +1222,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav25m240_p3d : cup_whee
 
 class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav_hq_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 1;
-        class Nodes
+    canLoadWeapon = 1;
+    class Nodes
     {
         class Node1
         {
@@ -1238,8 +1238,8 @@ class cup_wheeledvehicles_cup_wheeledvehicles_lav25_cup_lav_hq_p3d : TRIPLES(ADD
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1252,8 +1252,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_mk19 : CUP_WheeledVe
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50_GC : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1265,8 +1265,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_50_GC : TRIPLES(ADDO
 
 class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_MK5E_50 : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1283,8 +1283,8 @@ class CUP_WheeledVehicles_CUP_WheeledVehicles_RG31_CUP_RG31_MK5E_50 : TRIPLES(AD
 
 class cup_airvehicles_cup_airvehicles_mi6_int73_mi6a_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1347,8 +1347,8 @@ class cup_airvehicles_cup_airvehicles_mi6_int73_mi6a_p3d : TRIPLES(ADDON,Nodes,B
 
 class cup_airvehicles_cup_airvehicles_mi6_int73_mi6t_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1363,8 +1363,8 @@ class cup_airvehicles_cup_airvehicles_mi6_int73_mi6t_p3d : TRIPLES(ADDON,Nodes,B
 
 class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT_VIV : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1395,8 +1395,8 @@ class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT_VIV : TRIPLES(ADDON,
 
 class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8MT : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1434,8 +1434,8 @@ class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8MTV_3 : CUP_AirVehicles_
 
 class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1472,8 +1472,8 @@ class CUP_AirVehicles_CUP_AirVehicles_Mi8_model_CUP_Mi_8AMT : TRIPLES(ADDON,Node
 
 class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_viv_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1520,8 +1520,8 @@ class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_viv_p3d : TRIPLES(ADDON,
 
 class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1577,8 +1577,8 @@ class cup_airvehicles_cup_airvehicles_ch53e_usec_ch53_e_p3d : TRIPLES(ADDON,Node
 
 class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_VIV_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1625,8 +1625,8 @@ class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_VIV_p3d : TRIPLES(ADDON,No
 
 class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1682,8 +1682,8 @@ class CUP_AirVehicles_CUP_AirVehicles_CH47_CUP_CH_47F_p3d : TRIPLES(ADDON,Nodes,
 
 class CUP_AirVehicles_CUP_AirVehicles_MH47E_CUP_MH47E_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1694,8 +1694,8 @@ class CUP_AirVehicles_CUP_AirVehicles_MH47E_CUP_MH47E_p3d : TRIPLES(ADDON,Nodes,
 
 class cup_airvehicles_cup_airvehicles_mv22_CUP_MV22_VIV_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1734,8 +1734,8 @@ class cup_airvehicles_cup_airvehicles_mv22_CUP_MV22_VIV_p3d : TRIPLES(ADDON,Node
 
 class cup_airvehicles_cup_airvehicles_mv22_cup_mv22_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1783,8 +1783,8 @@ class cup_airvehicles_cup_airvehicles_mv22_CUP_MV22_RampGun_p3d : cup_airvehicle
 
 class CUP_AirVehicles_CUP_AirVehicles_C130J_CUP_c130j_Cargo_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {
@@ -1851,8 +1851,8 @@ class CUP_AirVehicles_CUP_AirVehicles_C130J_CUP_c130j_Cargo_p3d : TRIPLES(ADDON,
 
 class CUP_AirVehicles_CUP_AirVehicles_C130J_CUP_c130j_p3d : TRIPLES(ADDON,Nodes,Base)
 {
-		canLoadWeapon = 0;
-        class Nodes
+    canLoadWeapon = 0;
+    class Nodes
     {
         class Node1
         {

--- a/A3A/addons/logistics/Private/fn_canLoad.sqf
+++ b/A3A/addons/logistics/Private/fn_canLoad.sqf
@@ -104,7 +104,7 @@ while { isNil "_node" } do {
 
         private _thisNode = _nodes select(_sequenceStart + _n);
 
-        _thisNode params["_free","","","_canCouple"];
+        _thisNode params["_free","","","","_canCouple"];
 
         // Ocupando, break
         if (_free isNotEqualTo 1) then { break };
@@ -127,11 +127,13 @@ if (isNil "_node") exitWith {-8};
 //block loading if crew in node seats
 private _fullCrew = fullCrew _vehicle;
 private _seats = [];
+private _turrets = [];
 if ((_node#0) isEqualType []) then {
-    {_seats append (_x#2)} forEach _node;
+    {_seats append (_x#2); _turrets append (_x#3)} forEach _node;
 } else {
     _seats append (_node#2);
+    _turrets append (_node#3);
 };
-if !(_fullCrew findIf {_x#2 in _seats} isEqualTo -1) exitWith {-9};
+if !(_fullCrew findIf {_x#2 in _seats || {_x#3 in _turrets}} isEqualTo -1) exitWith {-9};
 
 [_object, _vehicle, _node, _weapon]

--- a/A3A/addons/logistics/Private/fn_getVehicleNodes.sqf
+++ b/A3A/addons/logistics/Private/fn_getVehicleNodes.sqf
@@ -27,6 +27,8 @@ configProperties [(_config/"Nodes"), "true", true] apply {[
     [_x >> "offset", "ARRAY", [0, 0, 0]] call CBA_fnc_getConfigEntry,
     // Cargo seat indices blocked if node is occupied
     [_x >> "seats", "ARRAY", []] call CBA_fnc_getConfigEntry,
+    // Turret indices blocked if node is occupied (optional)
+    [_x >> "turrets", "ARRAY", []] call CBA_fnc_getConfigEntry,
     // If node can be used for coupling (accomodating space for cargo-size > 1) with previous node
     [_x >> "canCouple", "NUMBER", 1] call CBA_fnc_getConfigEntry
 ]};

--- a/A3A/addons/logistics/Private/fn_load.sqf
+++ b/A3A/addons/logistics/Private/fn_load.sqf
@@ -46,6 +46,7 @@ _updateList = {
 //find node point and seats
 private _nodeOffset = [0,0,0];
 private _seats = [];
+private _turrets = [];
 
 if ((_node#0) isEqualType []) then {
     //offset
@@ -55,9 +56,10 @@ if ((_node#0) isEqualType []) then {
     private _diff = _offsetOne vectorDiff _offsetTwo;
     _nodeOffset = _offsetTwo vectorAdd [0,(_diff#1)/2,0];
 
-    //seats
+    //seats & turrets
     {
         _seats append (_x#2);
+        _turrets append (_x#3);
     } forEach _node;
 
     //update cargo list
@@ -69,6 +71,8 @@ if ((_node#0) isEqualType []) then {
     _nodeOffset = (_node#1);
     //seats
     _seats append (_node#2);
+    //turrets
+    _turrets append (_node#3);
     //update list
     [_vehicle , _node] call _updateList;
 };
@@ -89,9 +93,9 @@ private _yStart = _bbVehicle + _bbCargo - 0.1;
 private _yEnd = _location#1;
 _cargo setVariable ["AttachmentOffset", _location];
 
-//block seats
+//block seats & turrets
 [_cargo, true] remoteExec ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringCargo];
-[_vehicle, true, _seats] remoteExecCall ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
+[_vehicle, true, [_seats, _turrets]] remoteExecCall ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
 _cargo engineOn false;
 
 //break undercover

--- a/A3A/addons/logistics/Private/fn_toggleLock.sqf
+++ b/A3A/addons/logistics/Private/fn_toggleLock.sqf
@@ -1,12 +1,12 @@
 /*
     Author: [Håkon]
     [Description]
-        Refreshes lock with added/removed seats to lock
+        Refreshes lock with added/removed seats/turrets to lock
 
     Arguments:
-    0. <Object> Vehicle to lock seats of
-    1. <Bool>   Are the seats being locked
-    2. <Array>  Seat index's that are being locked/unlocked (optional - leave nil to lock/unlock all seats of the vehicle)
+    0. <Object> Vehicle to lock seats/turrets of
+    1. <Bool>   Are the seats/turrets being locked
+    2. <Array>  Seat indices / turret paths that are being locked/unlocked (optional - leave nil to lock/unlock all seats/turrets of the vehicle)
 
     Return Value:
     <Nil>
@@ -16,28 +16,41 @@
     Public: [No]
     Dependencies:
 
-    Example: [_vehicle, true, _seats] remoteExecCall ["A3A_Logistics_fnc_toggleLock", 0, _vehicle];
+    Example: [_vehicle, true, _seatsAndTurrets] remoteExecCall ["A3A_Logistics_fnc_toggleLock", 0, _vehicle];
 */
-params ["_vehicle", "_lock", "_seats"];
-//toggle lock of the propper seats
+params ["_vehicle", "_lock", "_seatsAndTurrets"];
+//toggle lock of the proper seats/turrets
 _vehicle lockCargo false;
-if !(isNil "_seats") then {//for vehicle loading cargo
+{_vehicle lockTurret [_x, false]} forEach (allTurrets _vehicle);
+if !(isNil "_seatsAndTurrets") then {//for vehicle loading cargo
+    _seatsAndTurrets params ["_seats", "_turrets"];
+    
     private _crew = crew _vehicle;
     private _crewCargoIndex = _crew apply {_vehicle getCargoIndex _x};
+    private _crewTurretPath = _crew apply {_vehicle unitTurret _x};
 
-    private _seatsToLock = _vehicle getVariable ["Logistics_occupiedSeats", []];
+    private _seatsAndTurretsToLock = _vehicle getVariable ["Logistics_occupiedSeatsAndTurrets", []];
     if (_lock) then {
-        _seatsToLock append _seats
+        _seatsAndTurretsToLock append _seats;
+        _seatsAndTurretsToLock append _turrets;
     } else {
-        _seatsToLock = _seatsToLock - _seats;
+        _seatsAndTurretsToLock = _seatsAndTurretsToLock - _seats;
+        _seatsAndTurretsToLock = _seatsAndTurretsToLock - _turrets;
     };
-    _vehicle setVariable ["Logistics_occupiedSeats", _seatsToLock, true];
+    _vehicle setVariable ["Logistics_occupiedSeatsAndTurrets", _seatsAndTurretsToLock, true];
     {
-        if (_x in _crewCargoIndex) then {
-            moveOut (_crew # (_crewCargoIndex find _x)); //incase someone got into the seat before it is locked in the loading process
-        };
-        _vehicle lockCargo [_x, true];
-    } forEach _seatsToLock;
+        if (_x isEqualType 0) then { // this is a seat index
+            if (_x in _crewCargoIndex) then {
+                moveOut (_crew # (_crewCargoIndex find _x)); //incase someone got into the seat before it is locked in the loading process
+            };
+            _vehicle lockCargo [_x, true];
+        } else { // this is a turret path
+            if (_x in _crewTurretPath) then {
+                moveOut (_crew # (_crewTurretPath find _x)); //incase someone got into the turret before it is locked in the loading process
+            };
+            _vehicle lockTurret [_x, true];
+        };        
+    } forEach _seatsAndTurretsToLock;
 } else {//for cargo, lock it fully and kick out any crew
     /* if (_vehicle isKindOf "StaticWeapon") exitWith {}; // dont lock statics, cant get out otherwise
     _vehicle lock _lock;

--- a/A3A/addons/logistics/Private/fn_unload.sqf
+++ b/A3A/addons/logistics/Private/fn_unload.sqf
@@ -57,6 +57,7 @@ _updateList = {
 //find node point and seats
 private _nodeOffset = [0,0,0];
 private _seats = [];
+private _turrets = [];
 
 if ((_node#0) isEqualType []) then {
     //type 2 cargo
@@ -67,9 +68,10 @@ if ((_node#0) isEqualType []) then {
     private _diff = _offsetOne vectorDiff _offsetTwo;
     _nodeOffset = _offsetTwo vectorAdd [0,(_diff#1)/2,0];
 
-    //seats
+    //seats & turrets
     {
         _seats append (_x#2);
+        _turrets append (_x#3);
     } forEach _node;
 
     //update cargo list
@@ -82,6 +84,8 @@ if ((_node#0) isEqualType []) then {
     _nodeOffset = (_node#1);
     //seats
     _seats append (_node#2);
+    //turrets
+    _turrets append (_node#3);
     //update list
     [_vehicle , _node] call _updateList;
 };
@@ -133,9 +137,9 @@ if !(_cargo isEqualTo objNull) then {//cargo not deleted
 } else {_keepUnloading = true};
 if (isNull _cargo || isNull _vehicle) exitWith {};//vehicle or cargo deleted
 
-//unlock seats
+//unlock seats & turrets
 [_cargo, false] remoteExec ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringCargo];
-[_vehicle, false, _seats] remoteExec ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
+[_vehicle, false, [_seats, _turrets]] remoteExec ["A3A_Logistics_fnc_toggleLock", 0, "A3A_Logistics_toggleLock" + _objStringVehicle];
 
 if (_isLootcrate) then {
     _nil = [_cargo] spawn {


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [x] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [x] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> This PR adds functionality for cargo to block turrets by turret path
>
> *Some*, but not *all* FFV/turn-out seats are cargo seats and turrets. Others are not cargo seats, but are a turret (cargoIndex is -1 but turret path is valid). This PR allows blocking those seats by setting the turret paths with turrets[] in the node config, similar to seats.
>
> In theory, this can be used to block *any* turret, including commander seats, main armament / gunner seat on armored vehicles with cargo on their roof, door guns in helis, etc

**How can your changes be tested, or reproduced?**

> CUP APCs added by #694 have been implemented in this PR for testing.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>