### PR TITLE
Param values can't be floats

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -712,9 +712,9 @@ class Params
     {
         title = $STR_params_UAVSpawnChance;
         tooltip = $STR_params_UAVSpawnChance_desc;
-        values[] = {0, 0.1, 0.2, 0.3, 0.5, 1, 2};
+        values[] = {0, 10, 20, 30, 50, 100, 200};
         texts[] = {"0", "10%", "20%", "30%", "50%", "100%", "200%"};
-        default = 0.2;
+        default = 20;
     };
     class distanceMission: AIBalanceParams
     {

--- a/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAIAirplane.sqf
@@ -310,7 +310,7 @@ if (!_busy) then {
 				} forEach _vehiclesPlanesGunship;
 				{
 				    _vehPool pushBack _x;
-				    _vehPool pushBack ((A3A_UAVSpawnChance - 0.1) max 0);
+				    _vehPool pushBack ((A3A_UAVSpawnChance - 10) max 0);
 				} forEach _uavsAttack;
 				_typeVehX = selectRandomWeighted _vehPool;
 				if (!isNil "_typeVehX") then {

--- a/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CAS.sqf
@@ -26,7 +26,7 @@ if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _sup
 
 private _faction = Faction(_side);
 private _vehType = "";
-if (A3A_UAVSpawnChance < 0.2) then {
+if (A3A_UAVSpawnChance < 20) then {
     _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
 } else {
     _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS") + (_faction get "uavsAttack"));

--- a/A3A/addons/core/functions/Supports/fn_SUP_CASDive.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_CASDive.sqf
@@ -23,7 +23,7 @@ if (isNil "_airport") exitWith { Debug_1("No airport found for %1 support", _sup
 
 private _faction = Faction(_side);
 private _vehType = "";
-if (A3A_UAVSpawnChance < 0.2) then {
+if (A3A_UAVSpawnChance < 20) then {
     _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS"));
 } else {
     _vehType = selectRandom ((_faction get "vehiclesPlanesCAS") + (_faction get "vehiclesPlanesLargeCAS") + (_faction get "uavsAttack"));


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [x] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Due to the use of `lbValue` when getting configured param values, params can't (*shouldn't*) have float values. This is the only param using floats for value so at least there's that.

**How can your changes be tested, or reproduced?**

> Change param value to a fractional (somewhere between 0 and 100%, *not* inclusive). Verify value is set correctly in game and after saving game.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>