### PR TITLE
Avoid game startup RPT spam about undefined variable `_revealedZones`

### DIFF
--- a/A3A/addons/ultimate/functions/init/fn_initZones.sqf
+++ b/A3A/addons/ultimate/functions/init/fn_initZones.sqf
@@ -17,11 +17,12 @@ markersImmune = markersX select {
 
 publicVariable "markersImmune";
 
-private _revealedZones = revealedZones;
-
 if (isNil "revealedZones") then {
     revealedZones = [];
+    publicVariable "revealedZones";
 };
+
+private _revealedZones = revealedZones;
 
 {
     private _markerSide = sidesX getVariable [_x, sideUnknown];


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Starting a game with enemy zones hidden creates nasty RPT spam about undeclared variable `_revealedZones`.

**How can your changes be tested, or reproduced?**

> Less of this in server RPTs:
>
> ```
> 11:49:23 Error in expression <tVariable [_x, sideUnknown];
> 
> if (_x in _revealedZones) then {
> [_x] call A3U_fnc>
> 11:49:23   Error position: <_revealedZones) then {
> [_x] call A3U_fnc>
> 11:49:23   Error Undefined variable in expression: _revealedzones
> 11:49:23 File x\A3A\addons\ultimate\functions\init\fn_initZones.sqf..., line 29
> ```

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

- [X] These changes are my own.
- [X] These changes are ready for review.
- [X] I have loaded the mission in LAN host.
- [X] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A