### PR TITLE
JSON Saves

### DIFF
--- a/A3A/addons/core/functions/Save/fn_loadServer.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadServer.sqf
@@ -11,62 +11,81 @@ if (isServer) then {
 	} forEach (airportsX + resourcesX + factories + outposts + seaports + milbases);
 
 	A3A_saveVersion = 0;
-	["version"] call A3A_fnc_getStatVariable;
-	["mrkSDK"] call A3A_fnc_getStatVariable;
-	["mrkCSAT"] call A3A_fnc_getStatVariable;
-	["destroyedSites"] call A3A_fnc_getStatVariable;
-	["minesX"] call A3A_fnc_getStatVariable;
-	["antennas"] call A3A_fnc_getStatVariable;
-	["hr"] call A3A_fnc_getStatVariable;
-	["dateX"] call A3A_fnc_getStatVariable;
-	["weather"] call A3A_fnc_getStatVariable;
-	["prestigeOPFOR"] call A3A_fnc_getStatVariable;
-	["prestigeBLUFOR"] call A3A_fnc_getStatVariable;
-	["resourcesFIA"] call A3A_fnc_getStatVariable;
-	["garrison"] call A3A_fnc_getStatVariable;
-	["usesWurzelGarrison"] call A3A_fnc_getStatVariable;
-	["skillFIA"] call A3A_fnc_getStatVariable;
-	["membersX"] call A3A_fnc_getStatVariable;
-    ["HR_Garage"] call A3A_fnc_getStatVariable;
-    ["A3A_fuelAmountleftArray"] call A3A_fnc_getStatVariable;
-	["destroyedBuildings"] call A3A_fnc_getStatVariable;
-	["enemyResources"] call A3A_fnc_getStatVariable;
-	["HQKnowledge"] call A3A_fnc_getStatVariable;
+	{ [_x] call A3A_fnc_getStatVariable } forEach [
+		"version",
+		"mrkSDK",
+		"mrkCSAT",
+		"destroyedSites",
+		"minesX",
+		"antennas",
+		"hr",
+		"dateX",
+		"weather",
+		"prestigeOPFOR",
+		"prestigeBLUFOR",
+		"resourcesFIA",
+		"garrison",
+		"usesWurzelGarrison",
+		"skillFIA",
+		"membersX",
+		"HR_Garage",
+		"A3A_fuelAmountleftArray",
+		"destroyedBuildings",
+		"enemyResources",
+		"HQKnowledge",
+		"killZones",
+		"controlsSDK",
+		"bombRuns",
+		"jna_dataList",
+		"watchpostsFIA",
+		"roadblocksFIA",
+		"aapostsFIA",
+		"hmgpostsFIA",
+		"atpostsFIA",
+		"supportPoints",
+		"areOccupantsDefeated",
+		"areInvadersDefeated",
+		"isTraderQuestAssigned",
+		"isTraderQuestCompleted",
+		"traderPosition",
+		"traderDiscount",
+		"destroyedMilAdmins",
+		"rebelLoadouts",
+		"randomizeRebelLoadoutUniforms",
+		"areRivalsDiscovered",
+		"areRivalsDefeated",
+		"rivalsLocationsMap",
+		"rivalsExcludedLocations",
+		"nextRivalsLocationReveal",
+		"constructionsX",
+		"isRivalsDiscoveryQuestAssigned",
+		"revealedZones",
+		"unlockedVehicleTypes",
+		"occupantsRadioKeys",
+		"invaderRadioKeys",
+		"aggressionOccupants",
+		"aggressionInvaders",
+		"inactivityRivals",
+		"chopForest",
+		"posHQ",
+		"nextTick",
+		"staticsX",
+		"wurzelGarrison",
+		"testingTimerIsActive",
+		"tasks"
+	];
 
-	["killZones"] call A3A_fnc_getStatVariable;
-	["controlsSDK"] call A3A_fnc_getStatVariable;
-	["bombRuns"] call A3A_fnc_getStatVariable;
-	["jna_dataList"] call A3A_fnc_getStatVariable;
-
-	//Antistasi Plus variables
-	["watchpostsFIA"] call A3A_fnc_getStatVariable; publicVariable "watchpostsFIA";
-	["roadblocksFIA"] call A3A_fnc_getStatVariable; publicVariable "roadblocksFIA";
-	["aapostsFIA"] call A3A_fnc_getStatVariable; publicVariable "aapostsFIA";
-	["hmgpostsFIA"] call A3A_fnc_getStatVariable; publicVariable "hmgpostsFIA";
-	["atpostsFIA"] call A3A_fnc_getStatVariable; publicVariable "atpostsFIA";
-	["supportPoints"] call A3A_fnc_getStatVariable;
-	["areOccupantsDefeated"] call A3A_fnc_getStatVariable;
-	["areInvadersDefeated"] call A3A_fnc_getStatVariable;
-	["isTraderQuestAssigned"] call A3A_fnc_getStatVariable;
-	["isTraderQuestCompleted"] call A3A_fnc_getStatVariable;
-	["traderPosition"] call A3A_fnc_getStatVariable;
-	["traderDiscount"] call A3A_fnc_getStatVariable;
-	["destroyedMilAdmins"] call A3A_fnc_getStatVariable;
-	["rebelLoadouts"] call A3A_fnc_getStatVariable;
-	["randomizeRebelLoadoutUniforms"] call A3A_fnc_getStatVariable;
-	["areRivalsDiscovered"] call A3A_fnc_getStatVariable;
-	["areRivalsDefeated"] call A3A_fnc_getStatVariable;
-	["rivalsLocationsMap"] call A3A_fnc_getStatVariable;
-	["rivalsExcludedLocations"] call A3A_fnc_getStatVariable;
-	["nextRivalsLocationReveal"] call A3A_fnc_getStatVariable;
-	["constructionsX"] call A3A_fnc_getStatVariable;
-	["isRivalsDiscoveryQuestAssigned"] call A3A_fnc_getStatVariable;
-
-	//Antistasi Ultimate variables
-	["revealedZones"] call A3A_fnc_getStatVariable; publicVariable "revealedZones";
-	["unlockedVehicleTypes"] call A3A_fnc_getStatVariable; publicVariable "unlockedVehicleTypes";
-	["occupantsRadioKeys"] call A3A_fnc_getStatVariable; publicVariable "occupantsRadioKeys";
-	["invaderRadioKeys"] call A3A_fnc_getStatVariable; publicVariable "invaderRadioKeys";
+	{ publicVariable _x } forEach [
+		"watchpostsFIA",
+		"roadblocksFIA",
+		"aapostsFIA",
+		"hmgpostsFIA",
+		"atpostsFIA",
+		"revealedZones",
+		"unlockedVehicleTypes",
+		"occupantsRadioKeys",
+		"invaderRadioKeys"
+	];
 
 	//===========================================================================
 
@@ -103,30 +122,8 @@ if (isServer) then {
 		[_x] call A3A_fnc_mrkUpdate
 	} forEach (markersX - controlsX);
 
-	if (count watchpostsFIA > 0) then {
-		markersX = markersX + watchpostsFIA;
-		publicVariable "markersX";
-	};
-
-	if (count roadblocksFIA > 0) then {
-		markersX = markersX + roadblocksFIA;
-		publicVariable "markersX";
-	};
-
-	if (count aapostsFIA > 0) then {
-		markersX = markersX + aapostsFIA;
-		publicVariable "markersX";
-	};
-
-	if (count atpostsFIA > 0) then {
-		markersX = markersX + atpostsFIA;
-		publicVariable "markersX";
-	};
-
-	if (count hmgpostsFIA > 0) then {
-		markersX = markersX + hmgpostsFIA;
-		publicVariable "markersX";
-	};
+	markersX append (watchpostsFIA + roadblocksFIA + aapostsFIA + atpostsFIA + hmgpostsFIA);
+	publicVariable "markersX";
 
 	{
 		if (_x in destroyedSites) then {
@@ -136,18 +133,8 @@ if (isServer) then {
 	} forEach citiesX;
 
     //Load aggro stacks and level and calculate current level
-    ["aggressionOccupants"] call A3A_fnc_getStatVariable;
-	["aggressionInvaders"] call A3A_fnc_getStatVariable;
     [true] call A3A_fnc_calculateAggression;
-
-	["inactivityRivals"] call A3A_fnc_getStatVariable;
 	[true] call SCRT_fnc_rivals_calculateActivity;
-
-	["chopForest"] call A3A_fnc_getStatVariable;
-
-	["posHQ"] call A3A_fnc_getStatVariable;
-	["nextTick"] call A3A_fnc_getStatVariable;
-	["staticsX"] call A3A_fnc_getStatVariable;
 
 	{_x setPos getMarkerPos respawnTeamPlayer} forEach ((call A3A_fnc_playableUnits) select {side _x == teamPlayer});
 	_sites = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
@@ -171,16 +158,9 @@ if (isServer) then {
 		[outposts, "Outpost", [1,1,0]] spawn A3A_fnc_createGarrison;
 		[seaports, "Other", [1,0,0]] spawn A3A_fnc_createGarrison;
 
-	} else {
-		//Garrison save in wurzelformat, load it
-        Info("WurzelGarrison found, loading it!");
-		["wurzelGarrison"] call A3A_fnc_getStatVariable;
 	};
 
-    //Load state of testing timer
-    ["testingTimerIsActive"] call A3A_fnc_getStatVariable;
-
-	// Load all player data into A3A_playerSaveData hashmap. Works around issues with game copies
+    // Load all player data into A3A_playerSaveData hashmap. Works around issues with game copies
 	_savedPlayers = "savedPlayers" call A3A_fnc_returnSavedStat;
 	if (isNil "_savedPlayers") then { _savedPlayers = [] };
 	{
@@ -197,9 +177,6 @@ if (isServer) then {
     Info("Persistent Load Completed.");
 
 	["locationSpawned", QGVAR(crewLocationStatics), { call A3A_fnc_crewLocationStatics }] call EFUNC(Events,addEventListener);
-
-	// uh, why here?
-	["tasks"] call A3A_fnc_getStatVariable;
 
 	statsLoaded = 0; publicVariable "statsLoaded";
 	petros allowdamage true;

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -173,7 +173,12 @@ if (_varName in specialVarLoads) then {
         };
 
         case 'HR_Garage': {
-            [_varValue] call HR_GRG_fnc_loadSaveData;
+            _varValue params ["_garage", "_UID", "_sources"];
+            _garage = _garage apply {
+                (toArray _x) params ["_keys", "_values"];
+                (_keys apply {if (_x isEqualType "") then { parseNumber _x } else { _x }}) createHashMapFromArray _values
+            };
+            [[_garage, _UID, _sources]] call HR_GRG_fnc_loadSaveData;
         };
 
         case 'destroyedBuildings': {
@@ -198,12 +203,18 @@ if (_varName in specialVarLoads) then {
         };
 
         case 'minesX': {
-            for "_i" from 0 to (count _varvalue) - 1 do {
-                (_varvalue select _i) params ["_typeMine", "_posMine", "_detected", "_dirMine"];
+            {
+                _x params ["_typeMine", "_posMine", "_detected", "_dirMine"];
                 private _mineX = createVehicle [_typeMine, _posMine, [], 0, "CAN_COLLIDE"];
                 if !(isNil "_dirMine") then { _mineX setDir _dirMine };
+                _detected = _detected apply { switch (_x) do {
+                    case (0): { Invaders };
+                    case (1): { Occupants };
+                    case (2): { teamPlayer };
+                    default { _x }; // loading old variable data, already stored as a SIDE
+                }};
                 {_x revealMine _mineX} forEach _detected;
-            };
+            } forEach (_varValue);
         };
 
         case 'garrison': {

--- a/A3A/addons/core/functions/Save/fn_returnSavedStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_returnSavedStat.sqf
@@ -4,11 +4,17 @@ FIX_LINE_NUMBERS()
 params ["_varname"];
 A3A_saveTarget params ["_serverID", "_campaignID", "_map"];
 
+// JSON save (regardless of which namespace it's stored in)
+if (!isNil {A3A_saveDataHM} && {A3A_saveDataHM isEqualType createHashMap}) exitWith {
+	A3A_saveDataHM get _varname;
+};
+
 // Simple version for new missionProfileNamespace saves
 if (_serverID isEqualType false) exitWith {
 	missionProfileNamespace getVariable format ["%1%2", _varName, _campaignID];
 };
 
+// Legacy version for profileNamespace saves (very old or linux host saves)
 private _saveExt = format["%1%2Antistasi%3",_serverID,_campaignID,_map];
 
 private _varValue = profileNamespace getVariable (_varname + _saveExt);

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -18,6 +18,10 @@ private _saveToNewNamespace = _serverID isEqualType false;
 if (!_saveToNewNamespace) then { profileNamespace setVariable ["ss_serverID", _serverID] };			// backwards compatibility
 private _namespace = [profileNamespace, missionProfileNamespace] select _saveToNewNamespace;
 
+// Create a temporary hashmap to hold the saveData before JSON-serializing and storing it
+A3A_saveDataHM = createHashMap;
+A3A_saveDataHM set ["serverID", _serverID];
+A3A_saveDataHM set ["campaignID", _campaignID];
 
 // Save each player with global flag
 {
@@ -188,7 +192,14 @@ if (!isNil "isRallyPointPlaced" && {isRallyPointPlaced}) then {
 
 ["resourcesFIA", _resourcesBackground] call A3A_fnc_setStatVariable;
 ["hr", _hrBackground] call A3A_fnc_setStatVariable;
-["HR_Garage", [] call HR_GRG_fnc_getSaveData] call A3A_fnc_setStatVariable;
+
+// Convert garage data to JSON-serializable format
+([] call HR_GRG_fnc_getSaveData) params ["_garage", "_UID", "_sources"];
+_garage = _garage apply {
+	(toArray _x) params ["_keys", "_values"];
+	(_keys apply {str _x}) createHashMapFromArray _values
+};
+["HR_Garage", [_garage, _UID, _sources]] call A3A_fnc_setStatVariable;
 
 _arrayEst = [];
 
@@ -311,13 +322,13 @@ private _mineChance = 500 / (500 max count allMines);
 	_dirMine = getDir _x;
 	_detected = [];
 	if (_x mineDetectedBy teamPlayer) then {
-		_detected pushBack teamPlayer
+		_detected pushBack 2
 	};
 	if (_x mineDetectedBy Occupants) then {
-		_detected pushBack Occupants
+		_detected pushBack 1
 	};
 	if (_x mineDetectedBy Invaders) then {
-		_detected pushBack Invaders
+		_detected pushBack 0
 	};
 	_arrayMines pushBack [_typeMine,_posMine,_detected,_dirMine];
 } forEach allMines;
@@ -494,6 +505,10 @@ _fuelAmountleftArray = [];
 
 //Saving the state of the testing timer
 ["testingTimerIsActive", testingTimerIsActive] call A3A_fnc_setStatVariable;
+
+// JSON-serialize the save data and write to the selected namespace
+private _serializedData = toJson A3A_saveDataHM;
+["savedata", _serializedData, true] call A3A_fnc_setStatVariable;
 
 if (_saveToNewNamespace) then { saveMissionProfileNamespace } else { saveProfileNamespace };
 

--- a/A3A/addons/core/functions/Save/fn_setStatVariable.sqf
+++ b/A3A/addons/core/functions/Save/fn_setStatVariable.sqf
@@ -1,8 +1,13 @@
 
-params ["_varName", "_varValue"];
+params ["_varName", "_varValue", ["_final", false]];
 A3A_saveTarget params ["_serverID", "_campaignID", "_map"];
 
 if (isNil "_varValue") exitWith {};			// hmm...
+
+// Store data in temporary hashmap until we're done adding all the data, then the serialized data string will be stored in the appropriate namespace via following code sections
+if (!_final && {!isNil {A3A_saveDataHM} && {A3A_saveDataHM isEqualType createHashMap}}) exitWith {
+	A3A_saveDataHM set [_varName, _varValue];
+};
 
 // Simple version for new missionProfileNamespace saves
 if (_serverID isEqualType false) exitWith {

--- a/A3A/addons/core/functions/init/fn_initServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initServer.sqf
@@ -115,10 +115,17 @@ private _startType = A3A_saveData get "startType";
 if (_startType != "new") then
 {
     // Setup save info
-    A3A_saveTarget = [A3A_saveData get "serverID", A3A_saveData get "gameID", worldName];
-    // Sanity checks? hmm
+    private _serverID = A3A_saveData get "serverID";
+    private _campaignID = A3A_saveData get "gameID";
+    A3A_saveTarget = [_serverID, _campaignID, worldName];
 
-    Info_1("Loading campaign with ID %1", A3A_saveData get "gameID");
+    if (_serverID isEqualType false) then {
+        A3A_saveDataHM = fromJSON (missionProfileNamespace getVariable format ["savedata%1", _campaignID]);
+    } else {
+        A3A_saveDataHM = fromJSON (profileNamespace getVariable format["savedata%1%2%3%4",_serverID,_campaignID,"Antistasi",worldName]);
+    };
+
+    Info_1("Loading campaign with ID %1", _campaignID);
 
     // Do the actual game loading
     call A3A_fnc_loadServer;

--- a/A3A/addons/gui/functions/SetupGUI/fn_setupDialog.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupDialog.sqf
@@ -124,19 +124,24 @@ switch (_mode) do
         private _prettyMapHM = createHashMapFromArray [
             ["vt7", "Virolahti"]
             ,["sara", "Sahrani"]
-            ,["Cam_Lao_Nam", "Cam Lao Nam"]
+            ,["cam_lao_nam", "Cam Lao Nam"]
             ,["vn_khe_sanh", "Khe Sanh"]
             ,["chernarus_autumn", "Chernarus (A)"]
             ,["chernarus_summer", "Chernarus (S)"]
             ,["chernarus_winter", "Chernarus (W)"]
-            ,["Enoch", "Livonia"]
+            ,["enoch", "Livonia"]
             ,["tem_anizay", "Anizay"]
-            ,["cup_chernarus_A3", "Chernarus 2020"]
+            ,["cup_chernarus_a3", "Chernarus 2020"]
             ,["brf_sumava", "Šumava"]
+            ,["green_sea", "Green Sea"]
+            ,["tem_kujari", "Kujari"]
+            ,["gm_weferlingen_summer", "Weferlingen (S)"]
+            ,["gm_weferlingen_winter", "Weferlingen (W)"]
+            ,["takistan", "Takistan"]
         ];
         {
             private _realMap = _x get "map";
-            _x set ["mapStr", _prettyMapHM getOrDefault [_realMap, _realMap]];
+            _x set ["mapStr", _prettyMapHM getOrDefault [toLower _realMap, _realMap]];
             _x set ["fileStr", ["Old", "New"] select ((_x get "serverID") isEqualType false)];
             if (!isNil {_x get "ended"}) then { _x set ["timeStr", "Ended"]; continue };
             if (!isNil {_x get "saveTime"}) then {


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [x] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> This PR implements campaign saves stored as JSON strings.
>
> Currently implemented:
> - Save all save data as JSON string to appropriate namespace (missionProfileNamespace or profileNamespace)
> - Load all save data from JSON stored in either namespace
>
> Caveats:
> - There is no GUI indication that a save has been saved using the new system. Nor is old data removed from the namespace. Therefore, with an old save that gets saved with new system, the old data will remain and can be loaded in older versions of the mod, but will not have new data saved to it when this code is active. "New" (JSON) saves of course can only be loaded with this code.
>
> TODO:
> - GUI for copy-paste "exporting" / "importing" of saves
> - "Official"? extender for exporting / importing to/from file on disk ([A3UE-Py3A](https://github.com/jwoodruff40/A3UE-Py3A))
> - Change (create new) save ID when saving to JSON for the first time, so it's more obvious that only the data with the new ID is getting updated with the JSON system, while the old data remains loadable with older versions of the mod.
> - ???

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

Inspiration from https://github.com/official-antistasi-community/A3-Antistasi/pull/3652, no code re-use.

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [x] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>