### PR TITLE
Unused variables cleanup and fallbacks in fn_resourcecheck

### DIFF
--- a/A3A/addons/core/functions/Base/fn_checkLossCondition.sqf
+++ b/A3A/addons/core/functions/Base/fn_checkLossCondition.sqf
@@ -6,6 +6,7 @@ private _hr = server getVariable ["hr",0];
 private _victoryZones = airportsX + milbases + outposts + resourcesX + factories + seaports;
 private _victoryZonesLogistical = airportsX + milbases + seaports;
 private _popTotal = 0;
+private _popKilled = 0;
 private _missingMoney = ((2000000 - _factionMoney) call BIS_fnc_numberText) splitString " " joinString ",";
 private _popReb = 0;
 private _popGov = 0;
@@ -17,6 +18,7 @@ private _popMajority = 0;
     _cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
 
     _popTotal = _popTotal + _numCiv;
+    if (_city in destroyedSites) then { _popKilled = _popKilled + _numCiv; continue };
 
     _popReb = _popReb + (_numCiv * (_supportReb / 100));
     _popGov = _popGov + (_numCiv * (_supportGov / 100));

--- a/A3A/addons/core/functions/Base/fn_checkLossCondition.sqf
+++ b/A3A/addons/core/functions/Base/fn_checkLossCondition.sqf
@@ -6,7 +6,6 @@ private _hr = server getVariable ["hr",0];
 private _victoryZones = airportsX + milbases + outposts + resourcesX + factories + seaports;
 private _victoryZonesLogistical = airportsX + milbases + seaports;
 private _popTotal = 0;
-private _popKilled = 0;
 private _missingMoney = ((2000000 - _factionMoney) call BIS_fnc_numberText) splitString " " joinString ",";
 private _popReb = 0;
 private _popGov = 0;
@@ -18,7 +17,6 @@ private _popMajority = 0;
     _cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
 
     _popTotal = _popTotal + _numCiv;
-    if (_city in destroyedSites) then { _popKilled = _popKilled + _numCiv; continue };
 
     _popReb = _popReb + (_numCiv * (_supportReb / 100));
     _popGov = _popGov + (_numCiv * (_supportGov / 100));

--- a/A3A/addons/core/functions/Base/fn_checkWinCondition.sqf
+++ b/A3A/addons/core/functions/Base/fn_checkWinCondition.sqf
@@ -6,7 +6,6 @@ private _hr = server getVariable ["hr",0];
 private _victoryZones = airportsX + milbases + outposts + resourcesX + factories + seaports;
 private _victoryZonesLogistical = airportsX + milbases + seaports;
 private _popTotal = 0;
-private _popKilled = 0;
 private _popReb = 0;
 private _popGov = 0;
 private _popMajority = 0;
@@ -20,7 +19,6 @@ private _missingMoney = ((_economicCalculation - _factionMoney) call BIS_fnc_num
     _cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
 
     _popTotal = _popTotal + _numCiv;
-    if (_city in destroyedSites) then { _popKilled = _popKilled + _numCiv; continue };
 
     _popReb = _popReb + (_numCiv * (_supportReb / 100));
     _popGov = _popGov + (_numCiv * (_supportGov / 100));

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -7,8 +7,6 @@ if (!isServer) exitWith {
 //declaring variables outside of the loop increases performance
 private _resAdd = nil;
 private _hrAdd = nil;
-private _popReb = nil;
-private _popTotal = nil;
 private _suppBoost = nil;
 private _resBoost = nil;
 

--- a/A3A/addons/core/functions/init/fn_resourcecheck.sqf
+++ b/A3A/addons/core/functions/init/fn_resourcecheck.sqf
@@ -8,8 +8,6 @@ if (!isServer) exitWith {
 private _resAdd = nil;
 private _hrAdd = nil;
 private _popReb = nil;
-private _popGov = nil;
-private _popKilled = nil;
 private _popTotal = nil;
 private _suppBoost = nil;
 private _resBoost = nil;
@@ -56,12 +54,12 @@ while {true} do {
 	waitUntil {sleep 15; time >= nextTick};
     waitUntil {sleep 10; A3A_activePlayerCount > 0};
 
+	if (isNil "factories") then { factories = []; };
+	if (isNil "seaports") then { seaports = []; };
+	if (isNil "destroyedSites") then { destroyedSites = []; };
+
 	_resAdd = 25;
 	_hrAdd = 0;
-	_popReb = 0;
-	_popGov = 0;
-	_popKilled = 0;
-	_popTotal = 0;
 
 	_suppBoost = 0.5 * (1+ ({sidesX getVariable [_x,sideUnknown] == teamPlayer} count seaports));
 	_resBoost = 1 + (0.25*({(sidesX getVariable [_x,sideUnknown] == teamPlayer) and !(_x in destroyedSites)} count factories));
@@ -70,14 +68,8 @@ while {true} do {
 		private _city = _x;
 		private _resAddCity = 0;
 		private _hrAddCity = 0;
-		private _cityData = server getVariable _city;
-		_cityData params ["_numCiv", "_numVeh", "_supportGov", "_supportReb"];
-
-		_popTotal = _popTotal + _numCiv;
-		if (_city in destroyedSites) then { _popKilled = _popKilled + _numCiv; continue };
-
-		_popReb = _popReb + (_numCiv * (_supportReb / 100));
-		_popGov = _popGov + (_numCiv * (_supportGov / 100));
+		private _cityData = server getVariable [_city, [0,0,0,0]];
+		_cityData params [["_numCiv",0], ["_numVeh",0], ["_supportGov",0], ["_supportReb",0]];
 
 		private _radioTowerSide = [_city] call A3A_fnc_getSideRadioTowerInfluence;
 		switch (_radioTowerSide) do
@@ -87,7 +79,8 @@ while {true} do {
 			case Invaders: {[-1,-1,_city,false,true] spawn A3A_fnc_citySupportChange};
 		};
 
-		_resAddCity = _numCiv * (_supportReb / 100) / 3;
+		_resAddCity = (_numCiv * (_supportReb / 100)) / 3;
+		if (!finite _resAddCity) then { _resAddCity = 0; };
 		_hrAddCity = _numCiv * (_supportReb / 10000);
 
 		if (sidesX getVariable [_city,sideUnknown] == Occupants) then
@@ -142,11 +135,16 @@ while {true} do {
 	} forEach resourcesX;
 
 	_resAdd = [_resAdd] call SCRT_fnc_common_rebelSalary;
+	if (isNil "_resAdd" || {!finite _resAdd}) then {
+    	_resAdd = 25000;
+	};
 
-	_hrAdd = ceil _hrAdd;
-	_resAdd = ceil _resAdd;
-	server setVariable ["hr", _hrAdd + (server getVariable "hr"), true];
-	server setVariable ["resourcesFIA", _resAdd + (server getVariable "resourcesFIA"), true];
+	_hrAdd = round _hrAdd;
+	_resAdd = round _resAdd;
+	if (!finite _resAdd) then { _resAdd = 25000; }; //either number is too large or something is broken
+	if (!finite _hrAdd) then { _hrAdd = 30; };
+	server setVariable ["hr", _hrAdd + (server getVariable ["hr", 0]), true];
+	server setVariable ["resourcesFIA", _resAdd + (server getVariable ["resourcesFIA", 0]), true];
 
 	private _rebAirportsQuantity = {sidesX getVariable [_x,sideUnknown] == teamPlayer} count airportsX;
 	bombRuns = bombRuns + 0.25 * _rebAirportsQuantity;

--- a/A3A/addons/scrt/Common/fn_common_rebelSalary.sqf
+++ b/A3A/addons/scrt/Common/fn_common_rebelSalary.sqf
@@ -23,6 +23,11 @@ params ["_resAdd"];
 
 private _rebels = call SCRT_fnc_misc_getRebelPlayers;
 
+if (isNil "_resAdd" || {!finite _resAdd}) then {
+    Warning("_resAdd is invalid, returning 25000");
+    _resAdd = 25000;
+};
+
 if(_rebels isEqualTo []) exitWith {
 	Warning("No salary as no active rebels found.");
 	_resAdd;
@@ -34,6 +39,7 @@ private _totalSalary = _resAdd / 4;
 _nul = [_totalSalary, _rebelsCount, _rebels] spawn {
 	params ["_totalSalary", "_rebelsCount", "_rebels"];
 	private _incomePerPlayer = round(_totalSalary / _rebelsCount);
+	if (!finite _incomePerPlayer) then { _incomePerPlayer = 300; };
 	
 	{
 		private _playerMoney = round (((_x getVariable ["moneyX", 0]) + _incomePerPlayer) max 0);


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

Removed unused local variables (_popReb, _popGov, _popKilled, _popTotal) to clean up the code.

Added fallback values ([0,0,0,0] and params with defaults) when reading city data.

Added finite checks after salary calculation and before updating server variables, replacing invalid values with defaults.

Ensured global arrays (factories, seaports, destroyedSites) are never nil at loop start.

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>