### PR TITLE
Garage parity update AU 11.9 / Community 3.11

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -82,10 +82,6 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 	};
 } else {
 	switch (true) do {
-		case (unitIsUAV _veh && {_side isEqualTo teamPlayer}): {
-			if (crew _veh isNotEqualTo []) then { deleteVehicleCrew _veh };
-			[_side, _veh] call A3A_fnc_createVehicleCrew;
-		};
 		case (_typeX in (FactionGet(all,"vehiclesFixedWing") + FactionGet(all,"vehiclesHelis"))): {
 			_veh addEventHandler ["GetIn", {
 				if (_this select 1 != "driver") exitWith {};

--- a/A3A/addons/garage/CfgDefines.inc
+++ b/A3A/addons/garage/CfgDefines.inc
@@ -60,7 +60,8 @@
 #define HR_GRG_IDC_ExtraPylonsMirrorCheckbox 1700154
 #define HR_GRG_IDC_ExtraPylonsMirrorLabel 1700155
 #define HR_GRG_IDC_ExtraPylonsPresetsCombo 1700156
-#define HR_GRG_IDC_ExtraPylons 1700157 // Controlsgroup containing all the actual pylons
+#define HR_GRG_IDC_ExtraPylonsNewSysWarning 1700157
+#define HR_GRG_IDC_ExtraPylons 1700158 // Controlsgroup containing all the actual pylons
 #define HR_GRG_IDC_PylonsFirstIDC 1715300
 #define checkboxTextures [tolower gettext (configfile >> "RscCheckBox" >> "textureUnchecked"),tolower gettext (configfile >> "RscCheckBox" >> "textureChecked")]
 

--- a/A3A/addons/garage/CfgFunctions.hpp
+++ b/A3A/addons/garage/CfgFunctions.hpp
@@ -67,6 +67,7 @@ class CfgFunctions
             class getAmmoCargo {};
             class getAmmoData {};
             class getDamage {};
+            class getDefaultMags {};
             class getFuel {};
             class getState {};
             class prepPylons {};

--- a/A3A/addons/garage/CfgFunctions.hpp
+++ b/A3A/addons/garage/CfgFunctions.hpp
@@ -17,7 +17,8 @@ class CfgFunctions
             class getLockCount {};
             class onLoad {};
             class onUnload {};
-            class reciveBroadcast {};
+            class receiveBroadcast {};
+            class receiveVehicles {};
             class releaseAllVehicles {};
             class reloadCategory {};
             class reloadPreview {};
@@ -82,7 +83,7 @@ class CfgFunctions
             class broadcastStateUpdate {};
             class getTotalFuelCargo {};
             class prefix {};
-            class reciveStateUpdate {};
+            class receiveStateUpdate {};
             class refuelVehicleFromSources {};
         };
 

--- a/A3A/addons/garage/Core/fn_addUser.sqf
+++ b/A3A/addons/garage/Core/fn_addUser.sqf
@@ -31,6 +31,5 @@ if (
 if (isNil "HR_GRG_Users") then {HR_GRG_Users = []};
 Trace_1("Adding user: %1", _client);
 HR_GRG_Users pushBack _client;
-_client publicVariableClient "HR_GRG_Vehicles";
-_client publicVariableClient "HR_GRG_Sources";
+[HR_GRG_Vehicles, HR_GRG_Sources] remoteExecCall ["HR_GRG_fnc_receiveVehicles", _client];
 true

--- a/A3A/addons/garage/Core/fn_broadcast.sqf
+++ b/A3A/addons/garage/Core/fn_broadcast.sqf
@@ -23,9 +23,9 @@
 
     License: APL-ND
 */
+#include "defines.inc"
+FIX_LINE_NUMBERS()
 if !(isServer) exitWith {false};
-HR_GRG_Event = _this;
-{
-    _x publicVariableClient "HR_GRG_Event";
-} forEach HR_GRG_Users;
+Trace_2("Broadcasting %1 to users %2",_this,HR_GRG_Users);
+_this remoteExecCall ["HR_GRG_fnc_receiveBroadcast", HR_GRG_Users];
 true

--- a/A3A/addons/garage/Core/fn_confirmPlacement.sqf
+++ b/A3A/addons/garage/Core/fn_confirmPlacement.sqf
@@ -302,7 +302,17 @@ HR_GRG_EH_keyDown = findDisplay 46 displayAddEventHandler ["KeyDown", {
                 _veh setPylonLoadout [_pylonIndex, _mag, _forced, _turret]
             } forEach HR_GRG_CP_pylons;
         };
-        _veh spawn {sleep 0.5;_this allowDamage true;_this enableSimulation true; { _x allowDamage true; } forEach (attachedObjects _this); };
+        _veh spawn {
+            sleep 0.5;
+            _this allowDamage true;
+            _this enableSimulation true; 
+            { _x allowDamage true; } forEach (attachedObjects _this);
+            if (unitIsUAV _this) then {
+                private _group = createGroup side player;
+                createVehicleCrew _this;
+                crew _this joinSilent _group;
+            };
+        };
         ([_veh] + HR_GRG_CP_callBackArgs) call HR_GRG_CP_callbackPlace;
     };
 

--- a/A3A/addons/garage/Core/fn_onLoad.sqf
+++ b/A3A/addons/garage/Core/fn_onLoad.sqf
@@ -106,15 +106,17 @@ if (HR_GRG_disableSellButton) then {
     _disp displayCtrl HR_GRG_IDC_SellVeh ctrlEnable false;
 };
 
-//extras list init
-if (
-    !HR_GRG_Pylons_Enabled //Pylon editing disabled
-    || {!HR_GRG_hasAmmoSource} //or ammo source not registered
-) then {
+private _pylonsDisabled = switch (true) do {
+    case HR_GRG_useNewPylonSys: {"newSys"};
+    case !HR_GRG_Pylons_Enabled: {"setting"};
+    case !HR_GRG_hasAmmoSource: {"noAmmo"};
+    default {""};
+};
+if (_pylonsDisabled isNotEqualTo "") then {
     private _pylonBttn = _disp displayCtrl HR_GRG_IDC_BttnPylons;
     _pylonBttn ctrlEnable false;
     _pylonBttn ctrlSetTextColor [0.7,0,0,1];
-    _pylonBttn ctrlSetTooltip localize "STR_HR_GRG_Generic_PylonDisabled";
+    _pylonBttn ctrlSetTooltip localize format ["STR_HR_GRG_Generic_PylonDisabled_%1", _pylonsDisabled];
 };
 [false] call HR_GRG_fnc_reloadExtras;
 

--- a/A3A/addons/garage/Core/fn_onLoad.sqf
+++ b/A3A/addons/garage/Core/fn_onLoad.sqf
@@ -75,18 +75,7 @@ _disp displayAddEventHandler ["MouseButtonUp", "if ((_this#1) isEqualTo 1) then 
 _disp displayAddEventHandler ["MouseMoving", "if (HR_GRG_RMouseBtnDown) then {_this call HR_GRG_fnc_updateCamPos};"];
 _disp displayAddEventHandler ["MouseZChanged","if !(HR_GRG_RMouseBtnDown) exitWith {}; HR_GRG_camDist = 0.9 max (HR_GRG_camDist - (_this#1)*0.1) min 2; [nil,0,0] call HR_GRG_fnc_updateCamPos; HR_GRG_previewLight setLightBrightness 1.1 * HR_GRG_camDist;"];
 
-//add veh pool modified EH
-"HR_GRG_Event" addPublicVariableEventHandler {
-    if (isNil "HR_GRG_Vehicles") exitWith {};
-    (_this#1) call HR_GRG_fnc_reciveBroadcast;
-};
-"HR_GRG_Vehicles" addPublicVariableEventHandler {
-    call HR_GRG_fnc_updateVehicleCount;
-    private _disp = findDisplay HR_GRG_IDD_Garage;
-    private _index = HR_GRG_Cats findIf {ctrlShown _x};
-    private _ctrl = HR_GRG_Cats#_index;
-    [_ctrl, _index] call HR_GRG_fnc_reloadCategory;
-};
+
 //add player to broadcast recipient list
 [clientOwner] remoteExecCall ["HR_GRG_fnc_addUser", 2]; //add to recipient
 waitUntil {!isNil "HR_GRG_Vehicles"};//wait for server response

--- a/A3A/addons/garage/Core/fn_onUnload.sqf
+++ b/A3A/addons/garage/Core/fn_onUnload.sqf
@@ -27,8 +27,6 @@ Trace("Closing Garage");
 [] call HR_GRG_onCloseEvent;
 
 [clientOwner] remoteExecCall ["HR_GRG_fnc_removeUser",2];
-"HR_GRG_Event" addPublicVariableEventHandler {};
-"HR_GRG_Vehicles" addPublicVariableEventHandler {};
 HR_GRG_SelectedVehicles = [-1, -1, ''];
 removeMissionEventHandler ["EachFrame", HR_GRG_EachFrame];
 

--- a/A3A/addons/garage/Core/fn_receiveBroadcast.sqf
+++ b/A3A/addons/garage/Core/fn_receiveBroadcast.sqf
@@ -19,13 +19,14 @@
     Public: [No]
     Dependencies:
 
-    Example: (_this#1) call HR_GRG_fnc_reciveBroadcast;
+    Example: (_this#1) call HR_GRG_fnc_receiveBroadcast;
 
     License: APL-ND
 */
 #include "defines.inc"
 FIX_LINE_NUMBERS()
-Trace_1("Reciving broadcast: %1",_this);
+if (isNil "HR_GRG_Vehicles") exitWith {};       // might be sent shortly after garage is unloaded on client
+Trace_1("Receiving broadcast: %1",_this);
 params ["_lockUID", "_checkoutUID", "_catIndex", "_vehUID", "_player", "_switch", "_time"];
 
 private _cat = HR_GRG_Vehicles#_catIndex;

--- a/A3A/addons/garage/Core/fn_receiveVehicles.sqf
+++ b/A3A/addons/garage/Core/fn_receiveVehicles.sqf
@@ -1,0 +1,32 @@
+/*
+Author: John Jordan
+Description:
+    Handles client receiving initial list of vehicles from server
+
+Arguments:
+0. <Array> Vehicles array
+1. <Array> Sources array
+
+Return Value: <nil>
+
+Scope: Clients
+Environment: unscheduled
+Public: No
+Dependencies:
+
+License: APL-ND
+*/
+#include "defines.inc"
+FIX_LINE_NUMBERS()
+
+private _disp = findDisplay HR_GRG_IDD_Garage;
+if (isNull _disp) exitWith {};          // might be possible with slow network?
+
+params ["_vehicles", "_sources"];
+HR_GRG_Vehicles = _vehicles;
+HR_GRG_Sources = _sources;
+
+call HR_GRG_fnc_updateVehicleCount;
+private _index = HR_GRG_Cats findIf {ctrlShown _x};
+private _ctrl = HR_GRG_Cats#_index;
+[_ctrl, _index] call HR_GRG_fnc_reloadCategory;

--- a/A3A/addons/garage/Extras/fn_findMount.sqf
+++ b/A3A/addons/garage/Extras/fn_findMount.sqf
@@ -44,5 +44,5 @@ if !((_mount#3) in ["", _UID]) exitWith _failed; //Checked out by someone else
 
 //check out mount
 _mount set [3, _CheckedUID];
-[nil, _CheckedUID, 4, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
+[nil, _CheckedUID, HR_GRG_STATICINDEX, _vehUID, _player, false] call HR_GRG_fnc_broadcast;
 true;

--- a/A3A/addons/garage/Extras/fn_isAmmoSource.sqf
+++ b/A3A/addons/garage/Extras/fn_isAmmoSource.sqf
@@ -20,17 +20,26 @@
 */
 params [ ["_vehicle", objNull, [objNull,""]] ];
 
+private _vehCfg = if (_vehicle isEqualType objNull) then {
+    configOf _vehicle
+} else {
+    configFile/"CfgVehicles"/_vehicle;
+};
+
 if (_vehicle isEqualType objNull) then {
     if (isNull _vehicle) exitWith {false};
-    if (getAmmoCargo _vehicle > 0) exitWith {true};                                     // vanilla
-    if (_vehicle getVariable ["ace_rearm_currentSupply", 0] < 0) exitWith {false};          // ACE but used up
-    if (_vehicle getVariable ["ace_rearm_isSupplyVehicle", false]) exitWith {true};
-    if (getNumber (configOf _vehicle/"ace_rearm_defaultSupply") > 0) exitWith {true};
+    if (HR_GRG_useNewRearmSys) exitWith {
+        if ([_vehicle, "rearm"] call HR_GRG_getResourceCargo < 1) exitWith {false}; // antistasi
+        if (getNumber (_vehCfg/"transportAmmo") > 0) exitWith {true};               // vanilla
+        false;
+    };
+    if (_vehicle getVariable ["ace_rearm_currentSupply", 0] < 0) exitWith {false};  // ACE but used up
+    if (getAmmoCargo _vehicle > 0) exitWith {true};                                 // vanilla
+    if (getNumber (_vehCfg/"ace_rearm_defaultSupply") > 0) exitWith {true};         // ace
     false;
 } else {
-    private _vehCfg = configFile/"CfgVehicles"/_vehicle;
     if (!isClass _vehCfg) exitWith {false}; //invalid class string passed
-    if (getNumber (_vehCfg/"transportAmmo") > 0) exitWith {true};                       // vanilla
-    if (getNumber (_vehCfg/"ace_rearm_defaultSupply") > 0) exitWith {true};
+    if (getNumber (_vehCfg/"ace_rearm_defaultSupply") > 0) exitWith {true}; // ace
+    if (getNumber (_vehCfg/"transportAmmo") > 0) exitWith {true};           // vanilla
     false;
 };

--- a/A3A/addons/garage/Extras/fn_reloadExtras.sqf
+++ b/A3A/addons/garage/Extras/fn_reloadExtras.sqf
@@ -115,12 +115,12 @@ HR_GRG_curAnims = _customisation#1;
 [HR_GRG_previewVeh, HR_GRG_curTexture, HR_GRG_curAnims] call BIS_fnc_initVehicle;
 
 //update source panel
-_ctrlSourcePanelAmmo ctrlSetStructuredText composeText ["   ", image RearmIcon, " ", image (checkboxTextures select (HR_GRG_hasAmmoSource && !HR_GRG_ServiceDisabled_Rearm))];
+_ctrlSourcePanelAmmo ctrlSetStructuredText composeText ["   ", image RearmIcon, " ", image (checkboxTextures select (HR_GRG_hasAmmoSource && !(HR_GRG_ServiceDisabled_Rearm || HR_GRG_useNewRearmSys)))];
 _ctrlSourcePanelAmmo ctrlSetTooltip ([
     localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Unavailable"
     , localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Available"
     , localize "STR_HR_GRG_SourcePanel_toolTip_Ammo_Disabled"
-] select (if (HR_GRG_ServiceDisabled_Rearm) then {2} else {HR_GRG_hasAmmoSource}));
+] select (if (HR_GRG_ServiceDisabled_Rearm || HR_GRG_useNewRearmSys) then {2} else {HR_GRG_hasAmmoSource}));
 
 _ctrlSourcePanelFuel ctrlSetStructuredText composeText ["   ", image RefuelIcon, " ", image (checkboxTextures select (HR_GRG_hasFuelSource && !HR_GRG_ServiceDisabled_Refuel))];
 _ctrlSourcePanelFuel ctrlSetTooltip ([

--- a/A3A/addons/garage/Extras/fn_reloadExtras.sqf
+++ b/A3A/addons/garage/Extras/fn_reloadExtras.sqf
@@ -184,6 +184,7 @@ _sellPrice = [localize "STR_HR_GRG_InfoPanel_salePrice",_sellPrice] joinString "
 
 //state indicator
 private _getPercentageAmmo = {
+    if (_this isEqualType 0) exitWith {_this};
     if (count _this isEqualTo 0) exitWith {0};
     private _sumPercent = 0;
     private _weaponsWithAmmo = 0;
@@ -204,8 +205,8 @@ private _getPercentageAmmo = {
 
 private _hasAmmo = (HR_GRG_previewVehState#2) isNotEqualTo [];//Preview state >> Ammo data
 private _avgAmmo = (HR_GRG_previewVehState#2) call _getPercentageAmmo; //Preview state >> Ammo data
-private _avgFuel = HR_GRG_previewVehState#0#0; //Preview state >> Fuel data >> Fuel
-private _avgDmg = 1 - (HR_GRG_previewVehState#1#0); //Preview state >> Damage data >> Damage
+private _avgFuel = fuel HR_GRG_previewVeh;      //HR_GRG_previewVehState#0#0; //Preview state >> Fuel data >> Fuel
+private _avgDmg = 1 - damage HR_GRG_previewVeh; //(HR_GRG_previewVehState#1#0); //Preview state >> Damage data >> Damage
 private _selectStateColor = {
     switch true do {
         case (_this > 0.5): {"#ffffff"}; // white

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -173,3 +173,23 @@ HR_GRG_getVehicleSellPrice = {
     params ["_veh"];
     [_veh] call A3A_fnc_getVehicleSellPrice;
 };
+
+
+// antistasi resource cargo
+
+HR_GRG_useNewPylonSys = true; // new rearm system, blocks pylons entirely. turn off for old behavior
+HR_GRG_useNewRearmSys = true; // new rearm system
+HR_GRG_useNewRepairSys = false; // new repair system
+HR_GRG_useNewRefuelSys = false; // new refuel system
+
+HR_GRG_getResourceCargo = {
+    params ["_veh", "_search"];
+    [_veh, _search, false] call A3A_fnc_getResourceCargo;
+};
+
+HR_GRG_setResourceCargo = {
+    params ["_veh", "_search", "_value"];
+    private _searchVar = format ["A3A_%1Cargo", _search];
+    _veh setVariable [_searchVar, _value, true];
+};
+

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -181,6 +181,7 @@ HR_GRG_useNewPylonSys = true; // new rearm system, blocks pylons entirely. turn 
 HR_GRG_useNewRearmSys = true; // new rearm system
 HR_GRG_useNewRepairSys = false; // new repair system
 HR_GRG_useNewRefuelSys = false; // new refuel system
+HR_GRG_reduceState = true;      // Compress stored state (not fully backwards compatible)
 
 HR_GRG_getResourceCargo = {
     params ["_veh", "_search"];

--- a/A3A/addons/garage/Public/config.inc
+++ b/A3A/addons/garage/Public/config.inc
@@ -156,15 +156,6 @@ HR_GRG_addResources = {
     [0,_money] call A3A_fnc_resourcesFIA;
 };
 
-HR_GRG_fnc_addVehicleUAVCompat = {
-    private _veh = _this select 0;
-    if (unitisUAV _veh && {crew _veh isNotEqualTo []}) then {
-        private _moveOutCrewHandle = [_this select 3, _this select 0] spawn A3A_fnc_moveOutCrew;
-        waitUntil { sleep 0.1; scriptDone _moveOutCrewHandle };
-    };
-    _this call HR_GRG_fnc_addVehicle;
-};
-
 HR_GRG_canSell = {_this isEqualTo theBoss};
 
 HR_GRG_getVehicleSellPrice = {
@@ -175,13 +166,16 @@ HR_GRG_getVehicleSellPrice = {
 };
 
 
+// ! The below ported from Official Antistasi Community as part of APL-ND ports,
+// ! set to false to preserve legacy behavior as some required code for this functionality (outside of garage addon) was not ported
+// ! (for multiple reasons)
 // antistasi resource cargo
 
-HR_GRG_useNewPylonSys = true; // new rearm system, blocks pylons entirely. turn off for old behavior
-HR_GRG_useNewRearmSys = true; // new rearm system
+HR_GRG_useNewPylonSys = false; // new rearm system, blocks pylons entirely. turn off for old behavior
+HR_GRG_useNewRearmSys = false; // new rearm system
 HR_GRG_useNewRepairSys = false; // new repair system
 HR_GRG_useNewRefuelSys = false; // new refuel system
-HR_GRG_reduceState = true;      // Compress stored state (not fully backwards compatible)
+HR_GRG_reduceState = false;      // Compress stored state (not fully backwards compatible)
 
 HR_GRG_getResourceCargo = {
     params ["_veh", "_search"];

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -103,7 +103,8 @@ if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith
 private _exit = false;
 if ( ( {alive _x} count (crew _vehicle) ) > 0) then { _exit = true };
 { if ( ( {alive _x} count (crew _x) ) > 0) exitWith {_exit = true} } forEach attachedObjects _vehicle;
-if (_exit) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_exit && (!_isUAV)) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side _player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     // valid vehicle for garage
 if (_vehicle == vehicleBox) exitWith { ["STR_HR_GRG_Feedback_addVehicle_GenericFail"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };

--- a/A3A/addons/garage/Public/fn_addVehicle.sqf
+++ b/A3A/addons/garage/Public/fn_addVehicle.sqf
@@ -100,11 +100,12 @@ if (_vehicle getVariable ['A3A_canGarage', false]) exitwith { [_vehicle] call _u
 if !((_vehicle getVariable ["SA_Tow_Ropes",objNull]) isEqualTo objNull) exitWith {["STR_HR_GRG_Feedback_addVehicle_SATow"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     //crewed
+private _isUAV = unitIsUAV _vehicle;
 private _exit = false;
 if ( ( {alive _x} count (crew _vehicle) ) > 0) then { _exit = true };
 { if ( ( {alive _x} count (crew _x) ) > 0) exitWith {_exit = true} } forEach attachedObjects _vehicle;
 if (_exit && (!_isUAV)) exitWith { ["STR_HR_GRG_Feedback_addVehicle_Crewed"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
-if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side _player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
+if (_isUAV && (crew _vehicle isNotEqualTo [] && {side _vehicle isNotEqualTo side player})) exitWith {  ["STR_HR_GRG_Feedback_addVehicle_HostileUAV"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
 
     // valid vehicle for garage
 if (_vehicle == vehicleBox) exitWith { ["STR_HR_GRG_Feedback_addVehicle_GenericFail"] remoteExec ["HR_GRG_fnc_Hint", _client]; false };
@@ -200,6 +201,8 @@ private _catsRequiringUpdate = [];
     if (typeOf _x in ["ACE_Wheel", "ACE_Track"]) then { continue };
     [_x, _vehicle] call ace_cargo_fnc_unloadItem;
 } forEach (_vehicle getVariable ["ace_cargo_loaded", []]);
+
+if (_isUAV) then {{deleteVehicle _x} forEach (crew _vehicle)};
 
 // Can only deal correctly with static weapons here. Drop everything else where it is.
 {

--- a/A3A/addons/garage/Public/fn_initServer.sqf
+++ b/A3A/addons/garage/Public/fn_initServer.sqf
@@ -23,6 +23,9 @@ if !(isClass (missionConfigFile/"A3A")) exitWith {};//not A3 Antistasi mission
 #include "config.inc"
 #include "defines.inc"
 FIX_LINE_NUMBERS()
+
+HR_GRG_defaultMags = createHashMap;
+
 if (!isServer) exitWith {};
 
 Trace("Running server init");

--- a/A3A/addons/garage/Pylons/fn_getPylonTurret.sqf
+++ b/A3A/addons/garage/Pylons/fn_getPylonTurret.sqf
@@ -7,7 +7,7 @@
  * 1: Pylon Index (starting at 0) <NUMBER>
  *
  * Return Value:
- * * Turret index (either [-1] or [0]) <ARRAY>
+ * * Turret index (either [] or [0]) <ARRAY>
  *
  * Scope: Any
  * Environment: Any
@@ -19,36 +19,8 @@
 
 params ["_vehicle", "_pylonIndex"];
 
-// See if index is in ace_pylonTurrets setVar on vehicle
-private _pylonTurrets = _vehicle getVariable ["ace_pylonTurrets", []];
-private _returnValue = _pylonTurrets param [_pylonIndex, []];
-
-if (_returnValue isEqualTo []) then {
-    // Attempt to determine turret owner based on magazines in the vehicle
-    private _pyMags = getPylonMagazines _vehicle;
-    private _pylonConfigs = configProperties [configFile >> "CfgVehicles" >> typeOf _vehicle >> "Components" >> "TransportPylonsComponent" >> "Pylons", "isClass _x"];
-    if (_pylonIndex >= (count _pyMags)) exitWith {};
-    if (_pylonIndex >= (count _pylonConfigs)) exitWith {};
-
-    private _targetMag = _pyMags select _pylonIndex;
-    private _inPilot = _targetMag in (_vehicle magazinesTurret [-1]);
-    private _inGunner = _targetMag in (_vehicle magazinesTurret [0]);
-
-    if (_inPilot) then {
-        if !(_inGunner) then {
-            _returnValue = [];
-        };
-    } else {
-        if (_inGunner) then {
-            _returnValue = [0];
-        };
-    };
-
-    if (_returnValue isEqualTo []) then { // If not sure, just use config value
-        _returnValue = getArray ((_pylonConfigs select _pylonIndex) >> "turret");
-    };
-} else {
-    if (_returnValue isEqualTo [-1]) then { _returnValue = [] };
-};
-
-_returnValue
+// This is trivial with getAllPylonsInfo
+private _pylonInfo = getAllPylonsInfo _vehicle;
+if (_pylonIndex >= count _pylonInfo) exitWith { [] };       // shouldn't happen but whatever
+private _turret = _pylonInfo#_pylonIndex#2;
+[_turret, []] select (_turret isEqualTo [-1]);           // translate to dumbass pylon command driver turret format

--- a/A3A/addons/garage/Pylons/fn_reloadPylons.sqf
+++ b/A3A/addons/garage/Pylons/fn_reloadPylons.sqf
@@ -68,7 +68,7 @@ private _presetComboCtrl = _disp displayCtrl HR_GRG_IDC_ExtraPylonsPresetsCombo;
 lbClear _presetComboCtrl;
 private _index = _presetComboCtrl lbAdd localize "STR_HR_GRG_Pylons_CustomPreset";
 _presetComboCtrl lbSetData [_index, "[]"];
-HR_GRG_DefaultMags = [];
+HR_GRG_DefaultPylons = [];
 {
     private _displayName = getText (_x >> "displayName");
     private _attachement = getArray (_x >> "attachment");
@@ -77,7 +77,7 @@ HR_GRG_DefaultMags = [];
 
     //get all mags used by default presets
     _loadoutMags = _attachement apply { getText (configFile >> "CfgMagazines" >> _x >> "pylonWeapon") };
-    {HR_GRG_DefaultMags pushBackUnique _x} forEach _loadoutMags;
+    {HR_GRG_DefaultPylons pushBackUnique _x} forEach _loadoutMags;
 
 } forEach (configProperties [(_pylonsCfg >> "Presets")]);
 

--- a/A3A/addons/garage/Refuel/fn_broadcastStateUpdate.sqf
+++ b/A3A/addons/garage/Refuel/fn_broadcastStateUpdate.sqf
@@ -25,6 +25,5 @@ if (isNil "_vUID" || isNil "_state") exitWith {false};
 if (HR_GRG_Users isNotEqualTo []) then {
     private _recipiants = +HR_GRG_Users;
     _recipiants pushBackUnique 2;
-    [_vUID, _stateIndex, _state] remoteExecCall ["HR_GRG_fnc_reciveStateUpdate", _recipiants];
-    {_x publicVariableClient "HR_GRG_Sources"} forEach _recipiants;
+    [_vUID, _stateIndex, _state, HR_GRG_Sources] remoteExecCall ["HR_GRG_fnc_receiveStateUpdate", _recipiants];
 };

--- a/A3A/addons/garage/Refuel/fn_receiveStateUpdate.sqf
+++ b/A3A/addons/garage/Refuel/fn_receiveStateUpdate.sqf
@@ -7,11 +7,12 @@ Arguments:
 0. <UID> Vehicle UID
 1. <Int> The index of the state data being updated
 2. <Struct> The state data to update to (see getState for more deatails on struct)
+3. <Array> New sources data
 
 Return Value: <nil>
 
 Scope: Any
-Environment: Scheduled
+Environment: Unscheduled
 Public: No
 Dependencies:
 
@@ -19,10 +20,12 @@ Example:
 
 License: APL-ND
 */
-params ["_vUID","_stateIndex", "_state"];
+params ["_vUID","_stateIndex", "_state", "_sources"];
 
 private "_vehData";
 { _vehData = _x get _vUID; if (!isNil "_vehdata") exitWith {}; } forEach HR_GRG_Vehicles;
 
 //#4 == state preservation data
 (_vehData#4) set [_stateIndex, _state];
+
+HR_GRG_Sources = _sources;

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
@@ -8,7 +8,7 @@
 
     Return Value:
     <Array>
-        <Int> Vanilla ammo cargo
+        <Int> Vanilla ammo cargo OR Antistasi ammo cargo
         <Int> ACE ammo cargo
     ] Ammo cargo data
 
@@ -23,7 +23,11 @@
 */
 params [["_veh", objNull, [objNull]]];
 
-private _baseAmmoCargo = getAmmoCargo _veh;
+private _baseAmmoCargo = if (HR_GRG_useNewRearmSys) then {
+    [_veh, "rearm"] call HR_GRG_getResourceCargo;
+} else {
+    getAmmoCargo _veh;
+};
 private _currentACEAmmoCargo = if (A3A_hasAce) then { [_veh] call ace_rearm_fnc_getSupplyCount } else { -1 };
 
 [_baseAmmoCargo,_currentACEAmmoCargo];

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoCargo.sqf
@@ -23,6 +23,9 @@
 */
 params [["_veh", objNull, [objNull]]];
 
+// This one was new anyway, so returning an empty array or nil is fully backwards compatible
+if (getNumber (configOf _veh/"ace_rearm_defaultSupply") <= 0 and getNumber (configOf _veh/"transportAmmo") <= 0) exitWith {[]};
+
 private _baseAmmoCargo = if (HR_GRG_useNewRearmSys) then {
     [_veh, "rearm"] call HR_GRG_getResourceCargo;
 } else {

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -27,6 +27,8 @@
                 <Int> Magazine ammo count
             ] Pylon data
         ]
+        or
+        <Int> Scalar vehicle ammo
     ] Ammo Data
 
     Scope: Any
@@ -40,9 +42,29 @@
 */
 params [["_veh", objNull, [objNull]]];
 
+private _pylonsCfg = (configOf _veh >> "Components" >> "TransportPylonsComponent");
+
+scopeName "main";
+if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
+    private _blacklistMags = ["FakeWeapon", "FakeMagazine"];
+    private _originalMags = (typeOf _veh call HR_GRG_fnc_getDefaultMags) select {!(_x#0 in _blacklistMags)};
+    if (count _originalMags == 0) then { [] breakOut "main" };        // may as well keep this one
+
+    private _curMags = magazinesAllTurrets _veh select {!(_x#0 in _blacklistMags)};
+    private _totalRounds = 0;
+    { _totalRounds = _totalRounds + _x#2 } forEach _curMags;
+    private _maxRounds = 0;
+    { _maxRounds = _maxRounds + _x#2 } forEach _originalMags;
+
+    // If the ammo can be set with setVehicleAmmo (no pylons, [0, 1] or all same magazine), just return scalar
+    private _magName = _originalMags#0#0;
+    if (_totalRounds in [0, _maxRounds] or _originalMags findIf {_magName != _x#0} == -1) then {
+        _totalRounds / (_maxRounds max 1) breakOut "main";
+    };
+};
+
 private _nonPylon = magazinesAllTurrets _veh select {!("pylon" in toLower (_x#0))} apply { [false, [_x#0,_x#1,_x#2]] }; //[is Pylon, [magName, path, ammo]]
 
-private _pylonsCfg = (configFile >> "CfgVehicles" >> typeOf _veh >> "Components" >> "TransportPylonsComponent");
 private _pylonAmmo = [];
 private _magName = getPylonMagazines _veh;
 {

--- a/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getAmmoData.sqf
@@ -63,22 +63,12 @@ if (!isClass _pylonsCfg and HR_GRG_reduceState) then {
     };
 };
 
-private _nonPylon = magazinesAllTurrets _veh select {!("pylon" in toLower (_x#0))} apply { [false, [_x#0,_x#1,_x#2]] }; //[is Pylon, [magName, path, ammo]]
+// Ok do this properly for a change
+private _pylonMags = getAllPylonsInfo _veh select {_x#3 != ""} apply {[_x#3, _x#2, _x#4]};      // [magName, path, ammo]
+private _allMags = magazinesAllTurrets _veh apply {_x select [0,3]};        // matched formats
+_pylonMags apply {_allMags deleteAt (_allMags find _x)};
+private _nonPylon = _allMags apply {[false, _x]};       // [isPylon, [magname, path, ammo]]
 
-private _pylonAmmo = [];
-private _magName = getPylonMagazines _veh;
-{
-    private _pylonIndex = _forEachIndex + 1;
-    _pylonAmmo pushBack [
-        true
-        , [
-            _pylonIndex
-            , configName _x
-            , [_veh, _forEachIndex] call HR_GRG_fnc_getPylonTurret
-            , _magName#_forEachIndex
-            , _veh ammoOnPylon _pylonIndex
-        ]
-    ];
-} forEach ("true" configClasses (_pylonsCfg >> "Pylons"));
-
+private _pylonAmmo = getAllPylonsInfo _veh apply {[true, _x select [0, 5]]};            // lol code reduction
+{ if (_x#1#2 isEqualTo [-1]) then {_x#1 set [2, []]} } forEach _pylonAmmo;                  // maintain previous behaviour, but it doesn't seem to matter now
 _nonPylon + _pylonAmmo

--- a/A3A/addons/garage/StatePreservation/fn_getDamage.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getDamage.sqf
@@ -9,9 +9,11 @@
     Return Value:
         <Array> [
             <Scalar> Overall damage
-            <Array> Hitpoint damage
+            <Array> Optional: Hitpoint damage
             <Scalar> Repair cargo
         ] Damage state
+        or 
+        <Scalar> Overall damage
 
     Scope: Any
     Environment: Any
@@ -23,11 +25,19 @@
     License: APL-ND
 */
 params ["_vehicle"];
-private _dmg = damage _vehicle min 0.89;
-private _hitPointDamage = getAllHitPointsDamage _vehicle;
-if !(_hitPointDamage isEqualTo []) then { //ensure it has hitpoints
-    _hitPointDamage = _hitPointDamage#2
-};
-private _repairCargo = getRepairCargo _vehicle;
+private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
 
-[_dmg, _hitPointDamage, _repairCargo];
+private _output = [damage _vehicle min 0.89];
+private _hitPointDamage = getAllHitPointsDamage _vehicle;
+if (_hitPointDamage isNotEqualTo []) then { //ensure it has hitpoints
+    // Skip storing hitpoints if damage is low or we can repair it
+    if (HR_GRG_reduceState and (selectMax (_hitPointDamage#2) < 0.15 or _restoreState == 1)) exitWith {};
+    _output pushBack _hitPointDamage#2;
+};
+
+// Set repair cargo only if it exists
+if (getNumber (configOf _vehicle/"transportRepair") > 0) then { _output set [2, getRepairCargo _vehicle] };
+
+// If we only have overall damage, just return that
+if (count _output == 1) exitWith { _output#0 };
+_output;

--- a/A3A/addons/garage/StatePreservation/fn_getDefaultMags.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getDefaultMags.sqf
@@ -1,0 +1,47 @@
+/*
+    Author: [John Jordan]
+    Description:
+        Returns cached array of default non-pylon magazines for a vehicle
+
+    Arguments:
+    0. <String> Vehicle classname
+
+    Return Value:
+    <Array>
+        <Struct> [
+            <String> Magazine classname
+            <Array> Turret path ([-1] for driver)
+            <Number> Number of bullets in magazine
+        ]
+    ]
+
+    Scope: Any
+    Environment: Any
+    Public: Yes
+    Dependencies: HR_GRG_defaultMags, created by initServer at postInit
+
+    Example: [typeof cursorObject] call HR_GRG_fnc_getDefaultMags;
+
+    License: APL-ND
+*/
+
+params ["_vehClass"];
+
+if (_vehClass in HR_GRG_defaultMags) exitWith { HR_GRG_defaultMags get _vehClass };
+
+private _driverMags = getArray (configFile >> "CfgVehicles" >> _vehClass >> "magazines");
+private _output = _driverMags apply { [_x, [-1]] };
+
+private _turrets = _vehClass call BIS_fnc_allTurrets;         // need to use config because setVehicleAmmo deletes mags
+{
+    private _path = _x;
+    private _mags = getArray ([_vehClass, _path] call BIS_fnc_turretConfig >> "magazines");
+    _output append (_mags apply { [_x, _path] });
+} forEach _turrets;
+
+{
+    _x pushBack getNumber (configFile >> "CfgMagazines" >> _x#0 >> "count");
+} forEach _output;
+
+HR_GRG_defaultMags set [_vehClass, _output];
+_output;

--- a/A3A/addons/garage/StatePreservation/fn_getFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getFuel.sqf
@@ -12,6 +12,8 @@
             <Int> Fuel cargo
             <Int> Ace Fuel cargo
         ] Fuel state
+        or
+        <Int> Fuel if it doesn't have cargo
 
     Scope: Any
     Environment: Any
@@ -23,6 +25,8 @@
     License: APL-ND
 */
 params [["_vehicle", objNull, [objNull]]];
-private _fuelCargo = getFuelCargo _vehicle;
+
+private _maxFuelCargo = getNumber (configOf _vehicle/"transportFuel");
 private _maxAceFuelCargo = getNumber (configOf _vehicle/"ace_refuel_fuelCargo");
-[fuel _vehicle, _fuelCargo, if (A3A_hasAce) then { _vehicle getVariable ["ace_refuel_currentFuelCargo",_maxAceFuelCargo] } else {nil} ];
+if (HR_GRG_reduceState and (_maxFuelCargo <= 0 and _maxAceFuelCargo <= 0)) exitWith { fuel _vehicle };
+[fuel _vehicle, getFuelCargo _vehicle, _vehicle getVariable ["ace_refuel_currentFuelCargo", _maxAceFuelCargo]];

--- a/A3A/addons/garage/StatePreservation/fn_getState.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_getState.sqf
@@ -44,7 +44,7 @@
             ] Ammo Data
 
             <Array>
-                <Int> Vanilla ammo cargo
+                <Int> Vanilla ammo cargo OR Antistasi ammo cargo
                 <Int> ACE ammo cargo
             ] Ammo cargo data
 

--- a/A3A/addons/garage/StatePreservation/fn_setAmmoCargo.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setAmmoCargo.sqf
@@ -6,7 +6,7 @@
     Arguments:
     0. <Object> Vehicle to restore ammo cargostate
     1. <Array>
-        <Int> Vanilla ammo cargo
+        <Int> Vanilla ammo cargo OR Antistasi ammo cargo
         <Int> ACE ammo cargo
     ] Ammo cargo data
 
@@ -26,9 +26,14 @@
 
 params ["_vehicle", "_ammoCargoData"];
 if !(local _vehicle) exitWith {};
-
 if (_ammoCargoData isNotEqualTo []) then { // may be the case on older saves
-    _vehicle setAmmoCargo _ammoCargoData#0; // no effect if not ammo vic
+    if (HR_GRG_useNewRearmSys) then {
+        [_vehicle, "rearm", _ammoCargoData#0] call HR_GRG_setResourceCargo;
+        _vehicle setAmmoCargo 0;
+    } else {
+        _vehicle setAmmoCargo _ammoCargoData#0; // no effect if not ammo vic
+    };
+    
     if (A3A_hasACE && (_ammoCargoData#1 > -1)) then {
         [_vehicle, _ammoCargoData#1] call ace_rearm_fnc_setSupplyCount;
     };

--- a/A3A/addons/garage/StatePreservation/fn_setAmmoData.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setAmmoData.sqf
@@ -26,6 +26,8 @@
             ] Pylon data
         ]
     ] Ammo Data
+    or
+    <Scalar> Total vehicle ammo
 
     Return Value:
     <Nil>
@@ -42,7 +44,10 @@
 params ["_vehicle", "_ammoData"];
 if !(local _vehicle) exitWith {};
 if (_ammoData isEqualTo []) exitWith {};
-if (HR_GRG_hasAmmoSource && !HR_GRG_ServiceDisabled_Rearm) exitWith {};
+if (HR_GRG_hasAmmoSource && !(HR_GRG_ServiceDisabled_Rearm || HR_GRG_useNewRearmSys)) exitWith {};
+
+if (_ammoData isEqualType 0) exitWith { _vehicle setVehicleAmmo _ammoData };
+
 private _weaponData = _ammoData select {!(_x#0)};
 private _pylonData = _ammoData - _weaponData;
 

--- a/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setDamage.sqf
@@ -10,6 +10,8 @@
             <Array> Hitpoint damage
             <Scalar> Repair cargo
         ] Damage state
+        or
+        <Scalar> Overall damage
 
     Return Value: <nil>
 
@@ -24,8 +26,11 @@
 */
 params ["_vehicle", "_dmgStats"];
 if !(local _vehicle) exitWith {};
-_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
+
 private _restoreState = [0,1] select (HR_GRG_hasRepairSource && !HR_GRG_ServiceDisabled_Repair);
+if (_dmgStats isEqualType 0) exitWith { _vehicle setDamage ([_dmgStats, 0] # _restoreState) };
+
+_dmgStats params [["_dmg",0,[0]], ["_hitDmg", [], [[]]], ["_repairCargo", -1, [0]]];
 _vehicle setDamage ([_dmg, 0] # _restoreState);
 
 if (_hitDmg#0 isEqualTo []) then {_hitDmg = _hitDmg#1}; //temp compat while testing, old had selection names we no longer care about those

--- a/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setFuel.sqf
@@ -10,6 +10,8 @@
             <Int> Fuel cargo
             <Int> Ace Fuel cargo
         ] Fuel state
+        or
+        <Scalar> Fuel
 
     Return Value: <nil>
 
@@ -24,6 +26,8 @@
 */
 params ["_vehicle", "_fuelStats"];
 if !(local _vehicle) exitWith {};
+if (_fuelStats isEqualType 0) exitWith {_vehicle setFuel _fuelStats};
+
 _fuelStats params [["_fuel",1, [0]], ["_fuelCargo",-1,[0]], "_aceFuel"];
 _vehicle setFuel _fuel;
 _vehicle setFuelCargo _fuelCargo;

--- a/A3A/addons/garage/StatePreservation/fn_setState.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setState.sqf
@@ -61,7 +61,7 @@
 */
 params [["_vehicle", objNull, [objNull]], ["_state", [], [[]]]];
 if (isNull _vehicle) exitWith {};
-_state params [["_fuelStats", [], [[]]], ["_dmgStats", [], [[]]], ["_ammoStats", [], [[]]], ["_ammoCargo", [], [[]]]];
+_state params [["_fuelStats", 1, [[],0]], ["_dmgStats", 0, [[],0]], ["_ammoStats", [], [[],0]], ["_ammoCargo", [], [[]]]];
 
 [_vehicle, _fuelStats] call HR_GRG_fnc_setFuel;
 [_vehicle, _dmgStats] call HR_GRG_fnc_setDamage;

--- a/A3A/addons/garage/StatePreservation/fn_setState.sqf
+++ b/A3A/addons/garage/StatePreservation/fn_setState.sqf
@@ -42,7 +42,7 @@
             ] Ammo Data
 
             <Array>
-                <Int> Vanilla ammo cargo
+                <Int> Vanilla ammo cargo OR Antistasi ammo cargo
                 <Int> ACE ammo cargo
             ] Ammo cargo data
 

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -248,7 +248,7 @@
                 <Polish>Pylony</Polish>
                 <Turkish>Silahlandır</Turkish>
             </Key>
-            <Key ID="STR_HR_GRG_Generic_PylonDisabled">
+            <Key ID="STR_HR_GRG_Generic_PylonDisabled_noAmmo">
                 <Original>Pylons require an ammo source to edit</Original>
                 <French>Les pylônes nécessitent une source de munitions pour être modifiés</French>
                 <Russian>Для редактирования пилонов необходим источник боеприпасов</Russian>
@@ -259,6 +259,12 @@
                 <Italian>Per editare gli equipaggiamenti dinamici hai bisogno di una fonte di munizioni</Italian>
                 <Polish>Pylony wymagają źródła amunicji do edycji</Polish>
                 <Turkish>Silah askılarını düzenlemek için bir mühimmat kaynağı gerekir</Turkish>
+            </Key>
+            <Key ID="STR_HR_GRG_Generic_PylonDisabled_setting">
+                <Original>Pylon editing is disabled on this server</Original>
+            </Key>
+            <Key ID="STR_HR_GRG_Generic_PylonDisabled_newSys">
+                <Original>Pylon editing is now done through the battle menu.\n\nLook at a vehicle and use the RRR button to change pylons</Original>
             </Key>
             <Key ID="STR_HR_GRG_Generic_full">
                 <Original>Full</Original>

--- a/A3A/addons/garage/Stringtable.xml
+++ b/A3A/addons/garage/Stringtable.xml
@@ -723,6 +723,9 @@
                 <Polish>Przechowywany przedmiot</Polish>
                 <Turkish>Öğe depolandı</Turkish>
             </Key>
+            <Key ID="STR_HR_GRG_Feedback_addVehicle_HostileUAV">
+                <Original>You can't garage a drone that doesnt belong to your side. Hack this drone before trying to garage it.</Original>
+            </Key>
             <Key ID="STR_HR_GRG_Feedback_addVehicle_Ammo_sold">
                 <Original>Ammo crate sold</Original>
                 <Turkish>Mühimmat sandığı satıldı</Turkish>

--- a/A3A/addons/scrt/UILayouts/menu.hpp
+++ b/A3A/addons/scrt/UILayouts/menu.hpp
@@ -355,7 +355,7 @@ class radioComm: SimpleMenuBigger
 			x = 0.257187 * safezoneW + safezoneX;
 			y = 0.486 * safezoneH + safezoneY;
 			tooltip = $STR_antistasi_dialogs_put_garage_tooltip;
-			action = "closeDialog 0; _target = cursorObject; if (isNull _target) then { _target = cursorTarget; }; [_target, clientOwner, call HR_GRG_dLock, player] remoteExec ['HR_GRG_fnc_addVehicleUAVCompat', 2];";
+			action = "closeDialog 0; _target = cursorObject; if (isNull _target) then { _target = cursorTarget; }; [_target, clientOwner, call HR_GRG_dLock, player] remoteExec ['HR_GRG_fnc_addVehicle', 2];";
 		};
 
 		class l4Button: SimpleButton


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Garage parity update + MIT fixes for Ultimate
> - more detailed changelog for each included PR to be included in release changelog

**How can your changes be tested, or reproduced?**

> - Ensure garage functions still work as normal.
> - Ensure UAV garaging and auto-manning (when pulled from garage or bought from arms dealer) work as expected.
> - Ensure garage doesn't eat mounted statics on DS

**Does this PR include changes not authored by you?**

- [ ] No
- [x] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [x] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> Ports garage-related parts of #3815, #3800, #3818, #3824, #3823, and #3838 for garage APL-ND compliance. Written permission received from @Tiny-DM and @jaj22 for ports; however, some MIT parts were changed (config.inc and the MIT portion of addVehicle) for Ultimate compat.
>
> Cherry-picking was done where feasible. Where it was not, *authorship* but not *full commit history* was preserved via `git checkout -p hash_of_pr_merge_commit -- .\A3A\addons\relevant_files` and `git commit --amend author="PR_author"`.
>
> New ammo and pylon functionality, and compressed garage state is explicitly disabled as not all parts of those PRs were ported from community, just the garage APL-ND parts (thanks Tiny / John for making those easily disableable)


</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>