### PR TITLE
Don't add AI manning options to drop pods

### DIFF
--- a/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_AIVEHinit.sqf
@@ -111,7 +111,7 @@ if (_veh isKindOf "Car" or{ _veh isKindOf "Tank"}) then {
 	};
 };
 
-if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship")) then {
+if ((_veh isKindOf  "LandVehicle") || (_veh isKindOf  "Ship") && {!(_veh in FactionGet(all, "vehiclesDropPod"))}) then {
 	private _staticVehInit = {
 		waitUntil { sleep 0.1; !isNil "serverInitDone" };
 		params ["_veh", "_flagAction"];


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Title. Intended to fix [this](https://discord.com/channels/817005365740044289/1016041276912705646/1485362628044787774)

**How can your changes be tested, or reproduced?**

> Spawn orbital QRF on rebel-controlled zone. Ensure drop pods are not manned by AI and do not get the actions to allow or prevent AI from manning them.
>
> Untested at this point - not downloading OPTRE on hotel wifi lol

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

> ...

</details>