### PR TITLE
Prevent RPT whitespace mayhem when debug outputs trace messages

### DIFF
--- a/A3A/addons/core/functions/Events/fn_addEventHandler.sqf
+++ b/A3A/addons/core/functions/Events/fn_addEventHandler.sqf
@@ -28,7 +28,7 @@ Environment:
 Author:
     UnseenKill/gor3Splatter
 ---------------------------------------------------------------------------- */
-Trace_1(QFUNCMAIN(addEventHandler),_this);
+Trace_1(QFUNCMAIN(addEventHandler),_this#0);
 
 if !assert(params[
     ["_eventName", nil, [""]],


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [ ] Feature
- [X] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [ ] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

> Will stop RPT emptiness like that:
>
> <img width="1472" height="878" alt="image" src="https://github.com/user-attachments/assets/3ebdfde4-406e-4207-8cb3-b578295ea8de" />

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

- [X] These changes are my own.
- [X] These changes are ready for review.
- [X] I have loaded the mission in LAN host.
- [X] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
