### PR TITLE
Allow helicopter based QRF supports spawn from millitary bases

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -255,6 +255,7 @@ class CfgFunctions
             class attackHQ {};
             class availableBasesAir {};
             class availableBasesLand {};
+            class availableBasesMixed {};
             class calculateMarkerArea {};
             class cargoSeats {};
             class civVEHinit {};

--- a/A3A/addons/core/functions/CREATE/fn_availableBasesMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_availableBasesMixed.sqf
@@ -1,0 +1,53 @@
+/*
+    File: fn_availableBasesMixed.sqf
+    Author: wersal
+
+    Description:
+        Select from distance-weighted list of available enemy bases (air + land) or return full list.
+        Combines fn_availableBasesAir and fn_availableBasesLand. Optionally filters outposts from land bases.
+
+    Parameter(s):
+        _side     - Side of enemy faction [SIDE]
+        _targPos  - Target position or marker name [POS2D or STRING]
+        _returnAll     - Optional, true to return all bases & weights (Default: false) [BOOL]
+        _filterOutposts - Optional, true to exclude outposts from land bases (Default: true) [BOOL]
+
+    Returns:
+        _marker - Marker name of selected base, or nil if none available [STRING]
+        or [_bases, _weights] if _returnAll is true [ARRAY]
+*/
+
+params ["_side", "_targPos", ["_returnAll", false], ["_filterOutposts", true]];
+
+// Retrieve air and land base lists with their weights
+private _airData = [_side, _targPos, true] call A3A_fnc_availableBasesAir;
+private _landData = [_side, _targPos, true] call A3A_fnc_availableBasesLand;
+
+private _landMarkers = _landData select 0;
+private _landWeights = _landData select 1;
+
+// Filter outposts if requested
+if (_filterOutposts) then {
+    private _filteredMarkers = [];
+    private _filteredWeights = [];
+    {
+        if !(_x in outposts) then {
+            _filteredMarkers pushBack _x;
+            _filteredWeights pushBack (_landWeights select _forEachIndex);
+        };
+    } forEach _landMarkers;
+    _landMarkers = _filteredMarkers;
+    _landWeights = _filteredWeights;
+};
+
+// Combine markers and weights from both sources
+private _allBases = (_airData select 0) + _landMarkers;
+private _allWeights = (_airData select 1) + _landWeights;
+
+if (_returnAll) exitWith { [_allBases, _allWeights] };
+
+// If no bases are available, return nil (not possbile with air bases?)
+if (_allBases isEqualTo []) exitWith { nil };
+
+// Weighted random selection from combined pool
+_allBases selectRandomWeighted _allWeights;

--- a/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createAttackForceMixed.sqf
@@ -114,7 +114,12 @@ if (_airBase != "") then            // uh, is that a thing
     ServerDebug_3("Attempting to spawn %1 air vehicles including %2 attack from %3", _airCount, _attackCount, _airbase);
     private _roll = round (random 100);
     if (allowFuturisticUnfairSupports && _roll <= 25 && {(Faction(_side) get "vehiclesDropPod") isNotEqualTo []}) then {
-        private _data = [_side, _airBase, _targPos, _resPool, _airCount, _attackCount, _tier, _troops] call A3A_fnc_createAttackForceOrbital;
+        // Ensure we have an actual air base for orbital drop; if current base is land, pick a new air base
+        private _orbitalBase = _airBase;
+        if !(_orbitalBase in airportsX) then {
+            _orbitalBase = [_side, _targPos] call A3A_fnc_availableBasesAir;
+        };
+        private _data = [_side, _orbitalBase, _targPos, _resPool, _airCount, _attackCount, _tier, _troops] call A3A_fnc_createAttackForceOrbital;
         _resourcesSpent = _resourcesSpent + _data#0;
         _vehicles append _data#1;
         _crewGroups append _data#2;

--- a/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_createVehicleQRFBehaviour.sqf
@@ -32,6 +32,10 @@ private _minClearance = 10 max (sizeOf _vehType);
 private _vtol = (getNumber (configOf _vehicle >> "vtol") > 0 && _vehType in FactionGet(all,"vehiclesTransportAir"));
 if (_vtol) then { _vehicle setVehicleRadar 1 };
 
+if (_vehType in FactionGet(all,"vehiclesTransportAir") && !(_markerOrigin in airportsX)) then { // && !_vtol  maybe? techicall they should land/take off anywhere
+    _markerOrigin = [side _crewGroup, _posDestination] call A3A_fnc_availableBasesAir; //should always be available since carrier always exists unless side is defeted
+};
+
 if (_vehicle isKindOf "Air" || _vehType in FactionGet(all, "vehiclesDropPod")) then
 {
     if (_vehType in FactionGet(all,"vehiclesHelisTransport") + FactionGet(all,"vehiclesHelisLight") + FactionGet(all, "vehiclesDropPod") || _vtol) exitWith

--- a/A3A/addons/core/functions/CREATE/fn_singleAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_singleAttack.sqf
@@ -26,10 +26,10 @@ private _targPos = markerPos _mrkDest;
 
 ServerInfo_1("Starting attack with parameters %1", _this);
 
-private _airbase = [_side, markerPos _mrkDest] call A3A_fnc_availableBasesAir;
+private _base = [_side, markerPos _mrkDest] call A3A_fnc_availableBasesMixed;
 
-//params ["_side", "_airbase", "_target", "_resPool", "_vehCount", "_delay", "_modifiers", "_attackType", "_reveal"];
-private _data = [_side, _airbase, _mrkDest, "defence", _vehCount, 0, [], "CounterAttack", _reveal] call A3A_fnc_createAttackForceMixed;
+//params ["_side", "_base", "_target", "_resPool", "_vehCount", "_delay", "_modifiers", "_attackType", "_reveal"];
+private _data = [_side, _base, _mrkDest, "defence", _vehCount, 0, [], "CounterAttack", _reveal] call A3A_fnc_createAttackForceMixed;
 _data params ["", "_vehicles", "_crewGroups", "_cargoGroups"];
 
 // Prepare despawn conditions

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
@@ -41,7 +41,7 @@ private _taskId = "CON" + str A3A_taskCount;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 private _delay = 30 + (round random 20);
 private _targPos = markerPos _markerX;
-private _airbase = [_oppositeside, markerPos _markerX] call A3A_fnc_availableBasesAir;
+private _base = [_oppositeside, markerPos _markerX] call A3A_fnc_availableBasesMixed;
 
 private _vehCount = if (_difficultX) then {
 	4;
@@ -52,7 +52,7 @@ if (_markerX in (airportsX + milbases)) then {
 	_vehCount = 6;
 };
 
-[_markerX, _airbase, _vehCount] spawn A3A_fnc_wavedAttack;
+[_markerX, _base, _vehCount] spawn A3A_fnc_wavedAttack;
 // Prepare despawn conditions
 private _endTime = time + 2700;
 

--- a/A3A/addons/core/functions/Supports/fn_SUP_QRFAir.sqf
+++ b/A3A/addons/core/functions/Supports/fn_SUP_QRFAir.sqf
@@ -25,8 +25,8 @@ params ["_suppName", "_side", "_resPool", "_maxSpend", "_target", "_targPos", "_
 // not 100% smart but we don't want it to be
 // Also no killzones, QRFs have resource spend limitations instead
 
-private _airbase = [_side, _targPos] call A3A_fnc_availableBasesAir;
-if (isNil "_airbase") exitWith { Info("QRF cancelled because no airbases available (how?)"); -1 };
+private _base = [_side, _targPos] call A3A_fnc_availableBasesMixed;
+if (isNil "_base") exitWith { Info("QRF cancelled because no airbases available (how?)"); -1 };
 
 private _vehCount = 3 min ceil (_maxSpend / A3A_balanceVehicleCost);        // will overshoot a bit (no 1.5x factor). This is preferable to sending tiny QRFs
 // TODO: bias a bit for tank/APC/static targets?
@@ -40,12 +40,12 @@ private _aggro = [aggressionOccupants, aggressionInvaders] select (_side == Inva
 if (_delay < 0) then { _delay = (0.5 + random 1) * (300 - 15*tierWar - 1*_aggro) };
 
 //Set idle times for marker, just so that stuff doesn't spawn on top? Carrier will ignore anyway
-//[_airbase, 5+_delay/60] call A3A_fnc_addTimeForIdle;
+//[_base, 5+_delay/60] call A3A_fnc_addTimeForIdle;
 
 // kinda epic but whatever
-[[_suppName, _side, _resPool, _delay, _targPos, _airbase, "AIR", _vehCount, _attackCount, _estResources], "A3A_fnc_SUP_QRFRoutine"] call A3A_fnc_scheduler;
+[[_suppName, _side, _resPool, _delay, _targPos, _base, "AIR", _vehCount, _attackCount, _estResources], "A3A_fnc_SUP_QRFRoutine"] call A3A_fnc_scheduler;
 
-private _approxTime = _delay + (markerPos _airbase distance2D _targPos) / (200 / 3.6);      // estimated travel time
+private _approxTime = _delay + (markerPos _base distance2D _targPos) / (200 / 3.6);      // estimated travel time
 [_reveal, _side, "QRFAIR", _targPos, _approxTime] spawn A3A_fnc_showInterceptedSetupCall;
 
 _estResources;            // *estimated* resource cost of QRF

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -91,8 +91,6 @@ A3A_supportMarkerTypes = [];     // format [markerName, markerType, hasRadio, de
 
 // Build arrays of markers that have defence bonuses
 { A3A_supportMarkerTypes pushBack [_x, "Airport", false, 1.0] } forEach airportsX;
-{ A3A_supportMarkerTypes pushBack [_x, "Airport", false, 1.0] } forEach airportsX;
-{ A3A_supportMarkerTypes pushBack [_x, "MilitaryBase", false, 0.8] } forEach milbases;
 { A3A_supportMarkerTypes pushBack [_x, "MilitaryBase", false, 0.8] } forEach milbases;
 { A3A_supportMarkerTypes pushBack [_x, "Seaport", false, 0.6] } forEach seaports;
 { A3A_supportMarkerTypes pushBack [_x, "Outpost", false, 0.6] } forEach outposts;

--- a/A3A/addons/core/functions/Supports/fn_initSupports.sqf
+++ b/A3A/addons/core/functions/Supports/fn_initSupports.sqf
@@ -40,7 +40,7 @@ private _initData = [
     ["CASDIVE",       "TARGET", 0.8, 0.3,   0, 100,  "", "vehiclesPlanesCAS"],
     ["QRFLAND",       "TROOPS", 1.0, 1.4,   0,   0,  "", ""],
     ["QRFAIR",        "TROOPS", 0.5, 0.1,   0,   0,  "", ""],
-    ["QRFVEHAIRDROP", "TROOPS", 0.3, 0.1,   0,   0,  "", "vehiclesPlanesTransport"],
+    ["QRFVEHAIRDROP", "TROOPS", 0.3, 0.1,   0,   0,  "", "vehiclesPlanesTransport"],   //maybe replace it with vehiclesAirborne ?
     ["QRFORBITAL",        "TROOPS", 0.2, 0.1,   0,   0,  "fu", "vehiclesDropPod"],     ///needs to be balanced
     ["CARPETBOMBS",     "AREA", 0.5, 0.1, 200,   0, "u", ""],                            // balanced against airstrikes
     ["GUNSHIP",         "AREA", 0.2, 0.1, 0, 80, "", "vehiclesPlanesGunship"],                   //u      // uh. Does AREA work for this? Only lasts 5 minutes so maybe...


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

Added ability for supports to spawn on military bases through new function fn_availableBasesMixed. 

fn_availableBasesMixed calls A3A_fnc_availableBasesAir and A3A_fnc_availableBasesLand (genius, right?) and select available bases from both lists. Also it has an optional parameter to exclude outposts that were added by A3A_fnc_availableBasesLand, true by default (not sure what it can be used for, but I added it just in case)
+ fn_singleAttack now uses availableBasesMixed
+ fn_CON_Outpost_Compet misson now also uses availableBasesMixed
+ fn_createAttackForceMixed now checks if base is land before calling orbital QRF
+ fn_createVehicleQRFBehaviour checks if vehicle is Planetransport and if base provided is land, if so, it selects a new air bases for that call.

**How can your changes be tested, or reproduced?**

+ call QRFAIR and check if it spawns on milbases and airports, but not on outposts
+ counterattacks should also spawn air from milbases

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

I also deleted duplicate build array lines in fn_initSupports

</details>