### PR TITLE
Additional debug and better handling for empty arrays in loadout builder

### DIFF
--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -36,7 +36,7 @@ private _fnc_magClassToEntry = {
 // - Array of choices and weights (e.g. ["M16", 1, "AKM", 2])
 private _fnc_parseItemArray = {
     params [["_attachment", ""], ["_paramName", "unknown"]];
-    diag_log format ["[DEBUG] Parsing: %1 | Value: %2", _paramName, _attachment];
+    Debug_2("[DEBUG] Parsing: %1 | Value: %2", _paramName, _attachment);
     private _choice = "";
     if ((typeName _attachment) == "ARRAY") then {
         if (count _attachment > 1) then {

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -18,6 +18,9 @@
     Example(s):
         [parameter] call vn_fnc_myFunction
 */
+#include "..\..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+
 params ["_template", "_loadoutDataForTemplate"];
 
 private _finalLoadout = [] call A3A_fnc_loadout_createBase;

--- a/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
+++ b/A3A/addons/core/functions/Templates/Loadouts/fn_loadout_builder.sqf
@@ -2,7 +2,7 @@
     File: fn_loadout_build.sqf
     Author: Spoffy
     Date: 2020-11-27
-    Last Update: 2020-11-27
+    Last Update: 2026-04-12
     Public: No
 
     Description:
@@ -35,22 +35,23 @@ private _fnc_magClassToEntry = {
 // - Single classname (e.g. "holosight"), useful mostly for attachments within weapons
 // - Array of choices and weights (e.g. ["M16", 1, "AKM", 2])
 private _fnc_parseItemArray = {
-	params ["_attachment"]; 
-	private _choice = "";
-	if((typeName _attachment) == "ARRAY") then {
-		if(count _attachment > 1) then { 
-			if(typeName (_attachment select 1) == "SCALAR") then { //is it a weighted list?
-				_choice = selectRandomWeighted _attachment;
-			} else {
-				_choice = selectRandom _attachment;
-			};
-		} else {
-			_choice = _attachment select 0;
-		};
-	} else {
-		_choice = _attachment;
-	};
-	_choice;
+    params [["_attachment", ""], ["_paramName", "unknown"]];
+    diag_log format ["[DEBUG] Parsing: %1 | Value: %2", _paramName, _attachment];
+    private _choice = "";
+    if ((typeName _attachment) == "ARRAY") then {
+        if (count _attachment > 1) then {
+            if (typeName (_attachment select 1) == "SCALAR") then { //is it a weighted list?
+                _choice = selectRandomWeighted _attachment;
+            } else {
+                _choice = selectRandom _attachment;
+            };
+        } else {
+            _choice = if (_attachment isEqualTo []) then { "" } else { _attachment select 0 };
+        };
+    } else {
+        _choice = _attachment;
+    };
+    _choice;
 };
 
 // Converts a weapon array that's valid in the builder to a weapon array valid in a loadout, extracting data in the process.
@@ -122,7 +123,7 @@ private _fnc_parseWeaponFormat = {
 	//String - Literal mag name
 
 	[
-		[_class, ([_silencer] call _fnc_parseItemArray), ([_pointer] call _fnc_parseItemArray), ([_optic] call _fnc_parseItemArray), _magsToUse select 0 select 0, _magsToUse select 1 select 0, (_bipod call _fnc_parseItemArray)],
+		[_class, ([_silencer, "silencer"] call _fnc_parseItemArray), ([_pointer, "pointer"] call _fnc_parseItemArray), ([_optic, "optic"] call _fnc_parseItemArray), _magsToUse select 0 select 0, _magsToUse select 1 select 0, ([_bipod, "bipod"] call _fnc_parseItemArray)],
 		// Available primary mags
 		_magsToUse select 0 select 1,
 		// Available secondary mags
@@ -136,10 +137,10 @@ private _fnc_parseWeaponFormat = {
 
 //Adds a helmet to the loadout, selected at random from the category in loadout data.
 private _fnc_setHelmet = {
-	params ["_key"];
-	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
-	if (_data isEqualTo []) exitWith {};
-	private _helmet = ([_data] call _fnc_parseItemArray);
+    params ["_key"];
+    private _data = _loadoutDataForTemplate getOrDefault [_key, []];
+    if (_data isEqualTo []) exitWith {};
+	private _helmet = ([_data, "helmet"] call _fnc_parseItemArray);
 	[_finalLoadout, _helmet] call A3A_fnc_loadout_setHelmet;
 };
 
@@ -147,7 +148,7 @@ private _fnc_setFacewear = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _facewear = ([_data] call _fnc_parseItemArray);
+	private _facewear = ([_data, "facewear"] call _fnc_parseItemArray);
 	[_finalLoadout, _facewear] call A3A_fnc_loadout_setFacewear;
 };
 
@@ -156,7 +157,7 @@ private _fnc_setVest = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _vest = ([_data] call _fnc_parseItemArray);
+	private _vest = ([_data, "vest"] call _fnc_parseItemArray);
 	[_finalLoadout, _vest] call A3A_fnc_loadout_setVest
 };
 
@@ -165,7 +166,7 @@ private _fnc_setUniform = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _uniform = ([_data] call _fnc_parseItemArray);
+	private _uniform = ([_data, "uniform"] call _fnc_parseItemArray);
 	[_finalLoadout, _uniform] call A3A_fnc_loadout_setUniform
 };
 
@@ -174,7 +175,7 @@ private _fnc_setBackpack = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _backpack = ([_data] call _fnc_parseItemArray);
+	private _backpack = ([_data, "backpack"] call _fnc_parseItemArray);
 	[_finalLoadout, _backpack] call A3A_fnc_loadout_setBackpack
 };
 
@@ -186,7 +187,7 @@ private _fnc_setPrimary = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = ([_data] call _fnc_parseItemArray) call _fnc_parseWeaponFormat;
+	private _weaponData = ([_data, "primary_weapon"] call _fnc_parseItemArray) call _fnc_parseWeaponFormat;
 	_primaryPrimaryMags = _weaponData # 1;
 	_primarySecondaryMags = _weaponData # 2;
 	[_finalLoadout, "PRIMARY", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -200,7 +201,7 @@ private _fnc_setLauncher = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = (([_data] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
+	private _weaponData = (([_data, "launcher_weapon"] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
 	_launcherPrimaryMags = _weaponData # 1;
 	_launcherSecondaryMags = _weaponData # 2;
 	[_finalLoadout, "LAUNCHER", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -214,7 +215,7 @@ private _fnc_setHandgun = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _weaponData = (([_data] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
+	private _weaponData = (([_data, "handgun_weapon"] call _fnc_parseItemArray)) call _fnc_parseWeaponFormat;
 	_handgunPrimaryMags = _weaponData # 1;
 	_handgunSecondaryMags = _weaponData # 2;
 	[_finalLoadout, "HANDGUN", _weaponData # 0] call A3A_fnc_loadout_setWeapon;
@@ -277,7 +278,7 @@ private _fnc_addMap = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _map = ([_data] call _fnc_parseItemArray);
+	private _map = ([_data, "map"] call _fnc_parseItemArray);
 	_equipment pushBack ["MAP", _map];
 };
 
@@ -286,7 +287,7 @@ private _fnc_addWatch = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _watch = ([_data] call _fnc_parseItemArray);
+	private _watch = ([_data, "watch"] call _fnc_parseItemArray);
 	_equipment pushBack ["WATCH", _watch];
 };
 
@@ -295,7 +296,7 @@ private _fnc_addCompass = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _compass = ([_data] call _fnc_parseItemArray);
+	private _compass = ([_data, "compass"] call _fnc_parseItemArray);
 	_equipment pushBack ["COMPASS", _compass];
 };
 
@@ -304,7 +305,7 @@ private _fnc_addRadio = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _radio = ([_data] call _fnc_parseItemArray);
+	private _radio = ([_data, "radio"] call _fnc_parseItemArray);
 	_equipment pushBack ["RADIO", _radio];
 };
 
@@ -313,7 +314,7 @@ private _fnc_addGPS = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _gps = ([_data] call _fnc_parseItemArray);
+	private _gps = ([_data, "gps"] call _fnc_parseItemArray);
 	_equipment pushBack ["GPS", _gps];
 };
 
@@ -322,7 +323,7 @@ private _fnc_addBinoculars = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _binoculars = ([_data] call _fnc_parseItemArray);
+	private _binoculars = ([_data, "binoculars"] call _fnc_parseItemArray);
 	_equipment pushBack ["BINOCULARS", _binoculars];
 };
 
@@ -331,7 +332,7 @@ private _fnc_addNVGs = {
 	params ["_key"];
 	private _data = _loadoutDataForTemplate getOrDefault [_key, []];
 	if (_data isEqualTo []) exitWith {};
-	private _nvgs = ([_data] call _fnc_parseItemArray);
+	private _nvgs = ([_data, "nvgs"] call _fnc_parseItemArray);
 	_equipment pushBack ["NVG", _nvgs];
 };
 
@@ -375,8 +376,8 @@ private _slotMagInfo = createHashMapFromArray [
 
 	if (_weaponData isEqualTo []) then { continue };
 
-	private _primaryMagQuantity = _magazineCountForSlots getOrDefault [_weaponSlot, 0];
-	private _secondaryMagQuantity = _secondaryMagazineCountForSlots getOrDefault [_weaponSlot, 0];
+    private _primaryMagQuantity = _magazineCountForSlots getOrDefault [_weaponSlot, 0];
+    private _secondaryMagQuantity = _secondaryMagazineCountForSlots getOrDefault [_weaponSlot, 0];
 
 	// Loop through every primary mag type, check how many times it would be added given _primaryMagQuantity, then add that many mags.
 	{


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

<details><summary><i><b>
Sub-categories:
</b></i></summary>

- [ ] Template
- [ ] Map
- [ ] Config
- [x] Function
- [ ] Localization

</details>

## What have you changed, and why?

**Information:**

Added debug logging and improved error resilience in _fnc_parseItemArray to help identify problematic loadout template entries.

Changes:

+ Added a second parameter _paramName (default "unknown") to _fnc_parseItemArray for debug identification.

+ Added default value "" for _attachment to prevent Undefined variable errors when nil is passed.

+ Added diag_log output: "[DEBUG] Parsing: %1 | Value: %2" showing parameter name and value.

+ Added check for empty array to avoid index errors.

+ Updated all calls to _fnc_parseItemArray throughout the file to pass a descriptive name (e.g., "silencer", "helmet", "vest", "map", etc.).

The original code would crash with Undefined variable _attachment when certain loadout data fields were missing or nil, breaking the entire loadout builder and causing cascading errors.

With these changes, the function gracefully handles missing data, logs the exact parameter name and value, and allows the loadout builder to continue – making it much easier to debug broken faction templates (like the any values seen in logs for helmet, facewear, etc.).

No functional change to loadout generation when data is valid.

Adds helpful debug output for developers to quickly pinpoint missing or malformed entries in _loadoutDataForTemplate.

Prevents script termination when encountering unexpected nil values.
**How can your changes be tested, or reproduced?**

Emm, make a bad template on purpose?

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

<details><summary><i><b>
Further info:
</b></i></summary><br>

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

</details>

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [x] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

<hr><details><summary><i><b>
Notes:
</b></i></summary><br>

Diag_log should depend on the debug level parameter

This was originally made for my secret project, but I decided it would be nice to share it

</details>