### PR TITLE
Fix: Swapping to loadGame breaking params

### DIFF
--- a/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
+++ b/A3A/addons/gui/functions/SetupGUI/fn_setupLoadgameTab.sqf
@@ -103,12 +103,18 @@ switch (_mode) do
         private _params = _saveData get "params";
         if (isNil "_params") then { _params = [] };               // getOrDefault doesn't work because input code may set nils
         if ((_sameMap and !cbChecked _newGameCtrl) or cbChecked _copyGameCtrl or cbChecked _oldParamsCtrl) then {
-            if (count _params > 0 and _params isNotEqualTo (_display getVariable "savedParams")) then { _display setVariable ["savedParams", _params] };
+            if (count _params > 0 and _params isNotEqualTo (_display getVariable "savedParams")) then { 
+                _display setVariable ["savedParams", _params];
+                ["fillParams"] call A3A_fnc_setupParamsTab;
+            };
         } else {
-            if (cbChecked _newGameCtrl && {!(_display getVariable ["paramsChangedSinceReset", false])}) then { _display setVariable ["savedParams", []] };
+            if (cbChecked _newGameCtrl && {!(_display getVariable ["paramsChangedSinceReset", false])}) then { 
+                _display setVariable ["savedParams", []];
+                ["fillParams"] call A3A_fnc_setupParamsTab;
+            };
         };
-        ["clearLBSelection", [[_display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_SIZE, _display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_DIFF, _display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_CSTM]]] call A3A_fnc_setupParamsTab;
-        ["fillParams"] call A3A_fnc_setupParamsTab;
+        // ["clearLBSelection", [[_display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_SIZE, _display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_DIFF, _display displayCtrl A3A_IDC_SETUP_PARAMSPRESETS_CSTM]]] call A3A_fnc_setupParamsTab;
+        // ["fillParams"] call A3A_fnc_setupParamsTab;
     };
 
     case ("setSaveData"):


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Fixes params being reset when swapping back to the load game tab
> Couldn't tell you if this has any unintended consequences, I can't remember what clearLBSelection does (@jwoodruff40)?

**How can your changes be tested, or reproduced?**

> Create new game box, change params, go back to load game tab, go back to params tab. See if reset

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...