### PR TITLE
Fix: Rival events happening on Reb vs Occ (and Inv)

### DIFF
--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
@@ -15,6 +15,12 @@ if (isNil "_player") exitWith {
     publicVariableServer "isEventInProgress";
 };
 
+if (gameMode == 3) exitWith {
+	Info("Reb vs Occ");
+	isEventInProgress = false;
+	publicVariableServer "isEventInProgress";
+};
+
 private _originPosition = position _player;
 Info_2("%1 will be used as center of the event at %2 position.", name _player, str _originPosition);
 

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_OccVsRivalsskirmish.sqf
@@ -15,8 +15,8 @@ if (isNil "_player") exitWith {
     publicVariableServer "isEventInProgress";
 };
 
-if (gameMode == 3) exitWith {
-	Info("Reb vs Occ");
+if (gameMode in [2, 3]) exitWith {
+	Info("Reb vs Occ/Reb vs Occ and Inv detected, aborting.");
 	isEventInProgress = false;
 	publicVariableServer "isEventInProgress";
 };

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_policeVsRivalsskirmish.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_policeVsRivalsskirmish.sqf
@@ -15,6 +15,12 @@ if (isNil "_player") exitWith {
     publicVariableServer "isEventInProgress";
 };
 
+if (gameMode == 3) exitWith {
+	Info("Reb vs Occ");
+	isEventInProgress = false;
+	publicVariableServer "isEventInProgress";
+};
+
 private _cities = citiesX select {sidesX getVariable [_x, sideUnknown] != teamPlayer && {spawner getVariable _x != 2} && {!(_x in destroyedSites)}};
 
 if (_cities isEqualTo []) exitWith {

--- a/A3A/addons/scrt/Rivals/fn_rivals_encounter_policeVsRivalsskirmish.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_encounter_policeVsRivalsskirmish.sqf
@@ -15,8 +15,8 @@ if (isNil "_player") exitWith {
     publicVariableServer "isEventInProgress";
 };
 
-if (gameMode == 3) exitWith {
-	Info("Reb vs Occ");
+if (gameMode in [2, 3]) exitWith {
+	Info("Reb vs Occ/Reb vs Occ and Inv detected, aborting.");
 	isEventInProgress = false;
 	publicVariableServer "isEventInProgress";
 };

--- a/A3A/addons/scrt/Rivals/fn_rivals_selectAndExecuteEvent.sqf
+++ b/A3A/addons/scrt/Rivals/fn_rivals_selectAndExecuteEvent.sqf
@@ -18,6 +18,8 @@ FIX_LINE_NUMBERS()
 params [["_excludeId", 0]];
 
 Info("Event condition has procced, selecting event...");
+
+if (gameMode == 3) exitWith {nil};
  
 isRivalEventInProgress = true;
 


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> *Should* stop rival events from occurring when they're not even allowed in Reb vs Occ, or Reb vs Occ and Inv

**How can your changes be tested, or reproduced?**

> Err. See if Rivals spawn with different gamemodes. This is a purely speculative fix

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...