### PR TITLE
Fix Params.hpp loot crate generation parameters display and backend values

### DIFF
--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -2661,7 +2661,7 @@ class Params
     {
         title = $STR_params_crateExplosiveTypeMax;
         tooltip = $STR_params_crateExplosiveTypeMax_desc;
-        values[] = {0,1,3,5,7,10};[]
+        values[] = {0,1,3,5,7,10};
         texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
         default = 3;
     };
@@ -2691,7 +2691,7 @@ class Params
         tooltip = $STR_params_crateAttachmentTypeMax_desc;
         values[] = {0,1,3,5,7,10,15,20};
         texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
-        default = 6;
+        default = 7;
     };
     class crateAttachmentNumMax: CrateParams
     {
@@ -2803,7 +2803,7 @@ class Params
         tooltip = $STR_params_crateDeviceTypeMax_desc;
         values[] = {0,1,3,5,7,10};
         texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
-        default = 2;
+        default = 3;
     };
     class crateDeviceNumMax: CrateParams
     {

--- a/A3A/addons/core/Params.hpp
+++ b/A3A/addons/core/Params.hpp
@@ -2577,16 +2577,16 @@ class Params
     {
         title = $STR_params_crateWepTypeMax;
         tooltip = $STR_params_crateWepTypeMax_desc;
-        values[] = {0,2,4,6,8,12,16};
-        texts[] = {"1","3","5","7","9","13","17"};
-        default = 8;
+        values[] = {0,1,3,5,7,10,15,20};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
+        default = 7;
     };
     class crateWepNumMax: CrateParams
     {
         title = $STR_params_crateWepNumMax;
         tooltip = $STR_params_crateWepNumMax_desc;
-        values[] = {0,1,3,5,8,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","8","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
@@ -2599,22 +2599,22 @@ class Params
             class medium : solo {};
             class large : solo {};
         };
-        default = 8;
+        default = 10;
     };
     class crateItemTypeMax: CrateParams
     {
         title = $STR_params_crateItemTypeMax;
         tooltip = $STR_params_crateItemTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
-        default = 4;
+        values[] = {0,1,3,5,7,10,15,20};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
+        default = 5;
     };
     class crateItemNumMax: CrateParams
     {
         title = $STR_params_crateItemNumMax;
         tooltip = $STR_params_crateItemNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
@@ -2633,16 +2633,16 @@ class Params
     {
         title = $STR_params_crateAmmoTypeMax;
         tooltip = $STR_params_crateAmmoTypeMax_desc;
-        values[] = {0,2,4,6,9,14,19};
-        texts[] = {"1","3","5","7","10","15","20"};
-        default = 6;
+        values[] = {0,1,3,5,7,10,15,20};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
+        default = 5;
     };
     class crateAmmoNumMax: CrateParams
     {
         title = $STR_params_crateAmmoNumMax;
         tooltip = $STR_params_crateAmmoNumMax_desc;
-        values[] = {0,1,3,5,10,15,20,25,30};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","25","30"};
+        values[] = {0,2,5,10,15,20,30,50};
+        texts[] = {$STR_params_civ_traffic_none,"2","5","10","15","20","30","50"};
         class difficulty
         {
             class solo
@@ -2661,16 +2661,16 @@ class Params
     {
         title = $STR_params_crateExplosiveTypeMax;
         tooltip = $STR_params_crateExplosiveTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
-        default = 4;
+        values[] = {0,1,3,5,7,10};[]
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
+        default = 3;
     };
     class crateExplosiveNumMax: CrateParams
     {
         title = $STR_params_crateExplosiveNumMax;
         tooltip = $STR_params_crateExplosiveNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,7,10,15,20};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
         class difficulty
         {
             class solo
@@ -2689,21 +2689,21 @@ class Params
     {
         title = $STR_params_crateAttachmentTypeMax;
         tooltip = $STR_params_crateAttachmentTypeMax_desc;
-        values[] = {0,2,4,6,9,14,19};
-        texts[] = {"1","3","5","7","10","15","20"};
+        values[] = {0,1,3,5,7,10,15,20};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10","15","20"};
         default = 6;
     };
     class crateAttachmentNumMax: CrateParams
     {
         title = $STR_params_crateAttachmentNumMax;
         tooltip = $STR_params_crateAttachmentNumMax_desc;
-        values[] = {0,1,3,5,10,15,20,25,30};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","25","30"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
             {
-                easy = 25;
+                easy = 30;
                 medium = 15;
                 hard = 5;
             };
@@ -2717,16 +2717,16 @@ class Params
     {
         title = $STR_params_crateBackpackTypeMax;
         tooltip = $STR_params_crateBackpackTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
+        values[] = {0,1,3,5,7,10};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
         default = 0;
     };
     class crateBackpackNumMax: CrateParams
     {
         title = $STR_params_crateBackpackNumMax;
         tooltip = $STR_params_crateBackpackNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
@@ -2745,16 +2745,16 @@ class Params
     {
         title = $STR_params_crateVestTypeMax;
         tooltip = $STR_params_crateVestTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
+        values[] = {0,1,3,5,7,10};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
         default = 0;
     };
     class crateVestNumMax: CrateParams
     {
         title = $STR_params_crateVestNumMax;
         tooltip = $STR_params_crateVestNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
@@ -2773,16 +2773,16 @@ class Params
     {
         title = $STR_params_crateHelmetTypeMax;
         tooltip = $STR_params_crateHelmetTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
+        values[] = {0,1,3,5,7,10};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
         default = 0;
     };
     class crateHelmetNumMax: CrateParams
     {
         title = $STR_params_crateHelmetNumMax;
         tooltip = $STR_params_crateHelmetNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo
@@ -2801,16 +2801,16 @@ class Params
     {
         title = $STR_params_crateDeviceTypeMax;
         tooltip = $STR_params_crateDeviceTypeMax_desc;
-        values[] = {0,2,4,9};
-        texts[] = {"1","3","5","10"};
+        values[] = {0,1,3,5,7,10};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","7","10"};
         default = 2;
     };
     class crateDeviceNumMax: CrateParams
     {
         title = $STR_params_crateDeviceNumMax;
         tooltip = $STR_params_crateDeviceNumMax_desc;
-        values[] = {0,1,3,5,10,15};
-        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15"};
+        values[] = {0,1,3,5,10,15,20,30};
+        texts[] = {$STR_params_civ_traffic_none,"1","3","5","10","15","20","30"};
         class difficulty
         {
             class solo


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

Fixed multiple loot crate item spawning parameters showing the wrong number when setting up the save.
Also mostly standardized the choices across loot crate parameters.

Previously, multiple item max number and item max type numbers were offset by one, so setting maximum type or number to 1 at setup would actually result in no loot crate spawning of that particular category.

**How can your changes be tested, or reproduced?**
1. Create or modify a save file, start the game, and check the .rpt for correct parameter numbers.
2. Check loot crates for correct type and number of items spawned.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
>This PR closes #XYZ.

## Notes

> ...