### PR TITLE
Fix: Add A3A unitTypes to units[]

### DIFF
--- a/A3A/addons/core/config.cpp
+++ b/A3A/addons/core/config.cpp
@@ -3,7 +3,26 @@
 class CfgPatches {
     class ADDON {
         name = COMPONENT_NAME;
-        units[] = {};
+        units[] = {
+            "a3a_unit_reb_unarmed",
+            "a3a_unit_reb",
+            "a3a_unit_reb_medic",
+            "a3a_unit_reb_sniper",
+            "a3a_unit_reb_marksman",
+            "a3a_unit_reb_lat",
+            "a3a_unit_reb_mg",
+            "a3a_unit_reb_exp",
+            "a3a_unit_reb_gl",
+            "a3a_unit_reb_sl",
+            "a3a_unit_reb_eng",
+            "a3a_unit_reb_at",
+            "a3a_unit_reb_aa",
+            "a3a_unit_reb_petros",
+            "a3a_unit_west",
+            "a3a_unit_east",
+            "a3a_unit_riv",
+            "a3a_unit_civ"
+        };
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"A3A_events"};


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> *May* prevent insufficient resource messages in zeus

**How can your changes be tested, or reproduced?**

> Can't remember the exact circumstances to replicate the message, but always happens moving an antistasi spawned unit in zeus (when it does happen)

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...