### PR TITLE
v11.9.11

### DIFF
--- a/A3A/addons/core/Includes/script_version.hpp
+++ b/A3A/addons/core/Includes/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 11
 #define MINOR 9
-#define PATCHLVL 10
+#define PATCHLVL 11
 #define BUILD 0

--- a/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
+++ b/A3A/addons/core/functions/Templates/fn_compileMissionAssets.sqf
@@ -127,8 +127,8 @@ setVar("staticMGs", OccAndInv("staticMGs") + Riv("staticLowWeapons") + Reb("stat
 setVar("vehiclesAirborne", OccAndInv("vehiclesAirborne"));
 setVar("vehiclesLightTanks", OccAndInv("vehiclesLightTanks"));
 
-setVar("vehicleRadars", OccAndInv("vehicleRadar"));
-setVar("vehicleSams", OccAndInv("vehicleSam"));
+setVar("vehicleRadars", [OccAndInv("vehicleRadar")]); // The following 2 NEED to be an array. Do not remove
+setVar("vehicleSams", [OccAndInv("vehicleSam")]); 
 setVar("staticHowitzers", OccAndInv("staticHowitzers"));
 
 [A3A_faction_inv, "animations"] call _fnc_setHashmap;


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> #938 

> Creates a new issue, but the game starts now:

```sqf
16:55:09 2026-06-24 15:55:09:580 | Antistasi | Error | File: A3A_fnc_initVehClassToCrew | VehicleClassNotString | A vehicle was not a classname but was instead '["B_SAM_System_03_F","O_SAM_System_04_F"]'. Please fix this. | Called By: A3A_fnc_initVarServer
16:55:09 Error in expression <oteExec ["A3A_fnc_localLog", 2]; };} };
assert false;
} else {
_vehClassToCrew s>
16:55:09   Error position: <assert false;
} else {
_vehClassToCrew s>
16:55:09   Error Assertation failed
16:55:09 File x\A3A\addons\core\functions\init\fn_initVehClassToCrew.sqf..., line 68
```

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [ ] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [ ] These changes are my own, or I have written permission to use them. `*`
- [ ] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...