### PR TITLE
fix: refactor calls to BIS_fnc_taskCreate to localize description on clients

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -155,6 +155,7 @@ class CfgFunctions
             class arePositionsConnected {};
             class joinMultipleGroups {};
             class localizar {};
+            class localize_format_taskSetDescription {};
             class lockStatic {};
             class logPerformance {};
             class manageFlagAccess {};
@@ -860,7 +861,7 @@ class CfgFunctions
             class remainingFuel {};
             class rotateItem {};
         };
-        
+
         class reload_repack_turret_magazines {
             file = QPATHTOFOLDER(Scripts\RRTurretMagazines\scripts);
             //class postInit {};

--- a/A3A/addons/core/functions/Base/fn_localizar.sqf
+++ b/A3A/addons/core/functions/Base/fn_localizar.sqf
@@ -4,46 +4,46 @@ private _pos = getMarkerPos _siteX;
 private _textX = "";
 
 if (_siteX in citiesX) then {
-	_textX = format ["%1",_siteX];
+	_textX = format ["STR_CITY_%1",_siteX];
 } else {
-	private _city = [citiesX, _pos] call BIS_fnc_nearestPosition;
+	private _city = "STR_CITY_" + _siteX;
 
 	switch (true) do {
 		case (_siteX in airportsX): {
-			_textX = format [localize "STR_localizar_airbase",_city];
+			_textX = [ "STR_localizar_airbase",_city];
 		};
 		case (_siteX in milbases): {
-			_textX = format [localize "STR_localizar_milbase",_city];
+			_textX = [ "STR_localizar_milbase",_city];
 		};
 		case (_siteX in resourcesX): {
-			_textX = format [localize "STR_localizar_resource",_city];
+			_textX = [ "STR_localizar_resource",_city];
 		};
 		case (_siteX in factories): {
-			_textX = format [localize "STR_localizar_factory",_city];
+			_textX = [ "STR_localizar_factory",_city];
 		};
 		case (_siteX in outposts): {
-			_textX = format [localize "STR_localizar_outpost",_city];
+			_textX = [ "STR_localizar_outpost",_city];
 		};
 		case (_siteX in seaports): {
 			if (toLowerANSI worldName in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"]) then {
-				_textX = format [localize "STR_localizar_riverport",_city];
+				_textX = [ "STR_localizar_riverport",_city];
 			} else {
-				_textX = format [localize "STR_localizar_seaport",_city];
+				_textX = [ "STR_localizar_seaport",_city];
 			};
 		};
 		case (_siteX in controlsX): {
 			if (isOnRoad getMarkerPos _siteX) then {
-				_textX = format [localize "STR_localizar_roadblock",_city];
+				_textX = [ "STR_localizar_roadblock",_city];
 			} else {
-				_textX = format [localize "STR_localizar_outskirts",_city];
+				_textX = [ "STR_localizar_outskirts",_city];
 			};
 		};
 		case (_siteX in milAdministrationsX): {
-			_textX = format [localize "STR_milAdministration",_city];
+			_textX = [ "STR_milAdministration",_city];
 		};
 		case (_siteX == "CSAT_carrier");
 		case (_siteX == "NATO_carrier"): {
-			_textX = localize "STR_localizar_supportcorridor";
+			_textX = ["STR_localizar_supportcorridor"];
 		};
 	};
 };

--- a/A3A/addons/core/functions/Base/fn_localize_format_taskSetDescription.sqf
+++ b/A3A/addons/core/functions/Base/fn_localize_format_taskSetDescription.sqf
@@ -1,0 +1,93 @@
+/*
+Author: dambaev
+
+Description:
+  Walks deeply through task's title and description in order to localize and format nested 
+  arrays like [ "STR_A3A_Missions_AS_Convoy_task_dest_supplies",[ "STR_localizar_riverport",_city],_displayTime,_nameDest,FactionGet(reb,"name")]
+
+Arguments:
+  _taskId - task id used for BIS_fnc_taskCreate
+  _description - array of task's description used for BIS_fnc_taskCreate
+Return Value: <nil>
+Scope: Client
+Environment: Scheduled
+Public: No
+Dependencies:
+  BIS_fnc_taskSetDescription
+
+Example:
+  private _nameDest = [_mrkDest] call A3A_fnc_localizar;
+  private _nameOrigin = [_mrkOrigin] call A3A_fnc_localizar;
+  private _startDate = numberToDate [date select 0, _startDateNum];
+  private _displayTime = [_startDate] call A3A_fnc_dateToTimeString;
+  _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_supplies",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
+  _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_supplies"];
+  private _taskId = "CONVOY" + str A3A_taskCount;
+  [_taskId, "CONVOY", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+
+  [ _taskId,
+    [_textX,_taskTitle,_mrkDest]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
+
+*/
+
+
+if( isServer || !hasInterface) exitWith {};
+
+params ["_taskId", "_description"];
+
+_description params [ "_textRaw", "_taskTitleRaw", "_mrkDest"];
+
+_recursive_localize_format = {
+  params [ "_arr"];
+  private _ret = [];
+  {
+    _localized = _x;
+    switch (true) do
+    {
+      case (_localized isEqualType []):
+      {
+        _localized = [_x] call _recursive_localize_format;
+      };
+      case (_localized isEqualType "string"):
+      {
+        switch(true) do
+        {
+          case( (_x select [0,9]) == "STR_CITY_"):
+          {
+            _x_sz = count _x;
+            _marker = _x select [ 9, _x_sz - 9];
+            _localized = text (nearestLocation [getMarkerPos _marker, [
+                "Name",
+                "NameCity",
+                "NameCityCapital",
+                "NameMarine",
+                "NameVillage"
+              ]]);
+          };
+          case( (_x select [0,4]) == "STR_"):
+          {
+            _localized = localize _x;
+          };
+        };
+      };
+    };
+    _ret pushBack _localized;
+  } forEach( _arr);
+  format _ret;
+};
+
+_textX = _textRaw;
+if( _textRaw isEqualType []) then {
+  _textX = [_textRaw] call _recursive_localize_format;
+};
+
+_taskTitle = _taskTitleRaw;
+if( _taskTitleRaw isEqualType []) then {
+  _taskTitle = [_taskTitleRaw] call _recursive_localize_format;
+};
+
+
+[ _taskId,
+  [_textX,_taskTitle,_mrkDest]
+  ] call BIS_fnc_taskSetDescription;
+

--- a/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_attackHQ.sqf
@@ -27,8 +27,8 @@ private _taskId = "DEF_HQ" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        localize "STR_tasks_attackHq_desc",
-        localize "STR_tasks_attackHq_header",
+        ["STR_tasks_attackHq_desc"],
+        ["STR_tasks_attackHq_header"],
         respawnTeamPlayer
     ],
     _targPos,

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -38,7 +38,18 @@ private _size = [_mrkDest] call A3A_fnc_sizeMarker;
 
 private _nameDest = [_mrkDest] call A3A_fnc_localizar;
 private _taskId = "invaderPunish" + str A3A_taskCount;
-[[teamPlayer,civilian,Occupants],_taskId,[format [localize "STR_invaderPunish_desc",_nameDest,FactionGet(inv,"name")],format [localize "STR_invaderPunish_task",FactionGet(inv,"name")],_mrkDest],_posDest,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian,Occupants],
+  _taskId,
+  [ [ "STR_invaderPunish_desc",_nameDest,FactionGet(inv,"name")],
+    [ "STR_invaderPunish_task",FactionGet(inv,"name")],
+    _mrkDest
+  ],
+  _posDest,
+  false,
+  0,
+  true,
+  "Defend",
+  true] call BIS_fnc_taskCreate;
 [_taskId, "invaderPunish", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 

--- a/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_invaderPunish.sqf
@@ -51,6 +51,11 @@ private _taskId = "invaderPunish" + str A3A_taskCount;
   "Defend",
   true] call BIS_fnc_taskCreate;
 [_taskId, "invaderPunish", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_invaderPunish_desc",_nameDest,FactionGet(inv,"name")],
+    [ "STR_invaderPunish_task",FactionGet(inv,"name")],
+    _mrkDest
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 
 if (isNil "_delay") then {

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -32,8 +32,20 @@ private _nameDest = [_mrkDest] call A3A_fnc_localizar;
 private _nameEnemy = _faction get "name";
 private _taskId = "wavedAttack" + str A3A_taskCount;
 if (_targside == teamPlayer) then {
-    private _taskStr = format [localize "STR_wavedattack_desc", _nameEnemy, _nameDest];
-    [true,_taskId,[_taskStr,format [localize "STR_wavedattack_task",_nameEnemy],_mrkDest],markerPos _mrkDest,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
+    private _taskStr = ["STR_wavedattack_desc", _nameEnemy, _nameDest];
+    [ true,
+      _taskId,
+      [ _taskStr,
+        [ "STR_wavedattack_task",_nameEnemy],
+        _mrkDest
+      ],
+      markerPos _mrkDest,
+      false,
+      0,
+      true,
+      "Defend",
+      true
+      ] call BIS_fnc_taskCreate;
     [_taskId, "rebelAttack", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 } else {
     private _text = format [localize "STR_notifiers_wavedattack", _nameEnemy, Faction(_targside) get "name", _nameDest];

--- a/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
+++ b/A3A/addons/core/functions/CREATE/fn_wavedAttack.sqf
@@ -47,6 +47,8 @@ if (_targside == teamPlayer) then {
       true
       ] call BIS_fnc_taskCreate;
     [_taskId, "rebelAttack", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+    [ _taskId, [ _taskStr, [ "STR_wavedattack_task",_nameEnemy], _mrkDest ]
+      ] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 } else {
     private _text = format [localize "STR_notifiers_wavedattack", _nameEnemy, Faction(_targside) get "name", _nameDest];
     ["RadioIntercepted", [_text]] remoteExec ["BIS_fnc_showNotification", 0];

--- a/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
@@ -99,8 +99,8 @@ private _roadR = _roads select 0;
 sleep 1;
 
 //creating Task
-private _rebelTaskText = format [
-    localize "STR_A3A_Missions_AS_Ambush_task_desc", 
+private _rebelTaskText = [
+    "STR_A3A_Missions_AS_Ambush_task_desc",
     _originName, 
     _destinationName,
     _departingDisplayTime,
@@ -112,7 +112,10 @@ private _taskId = "AS" + str A3A_taskCount;
 [
     [teamPlayer,civilian],
     _taskId,
-    [_rebelTaskText, format [localize "STR_A3A_Missions_AS_Ambush_task_header", _faction get "name"], _missionOrigin],
+    [ _rebelTaskText,
+      [ "STR_A3A_Missions_AS_Ambush_task_header", _faction get "name"],
+      _missionOrigin
+    ],
     (position _roadR),
     false,
     0,

--- a/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Ambush.sqf
@@ -124,6 +124,10 @@ private _taskId = "AS" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ _rebelTaskText, [ "STR_A3A_Missions_AS_Ambush_task_header", _faction get "name"],
+      _missionOrigin
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 
 //spawning escort

--- a/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
@@ -22,15 +22,27 @@ private _limit = if (_difficultX) then {
 _limit params ["_dateLimitNum", "_displayTime"];
 
 _nameDest = [_markerX] call A3A_fnc_localizar;
-private _taskString = format [
-	localize "STR_A3A_Missions_AS_Official_task_desc",
+private _taskString = [
+	"STR_A3A_Missions_AS_Official_task_desc",
 	_faction get "name",
 	[_markerX] call A3A_fnc_localizar,
 	_displayTime
 ];
 
 private _taskId = "AS" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[_taskString,format [localize "STR_A3A_Missions_AS_Official_task_header", _faction get "name"],_markerX],_positionX,false,0,true,"Kill",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ _taskString,
+    [ "STR_A3A_Missions_AS_Official_task_header", _faction get "name"],
+    _markerX
+  ],
+  _positionX,
+  false,
+  0,
+  true,
+  "Kill",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _grp = createGroup _sideX;

--- a/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Official.sqf
@@ -44,6 +44,11 @@ private _taskId = "AS" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ _taskString,
+    [ "STR_A3A_Missions_AS_Official_task_header", _faction get "name"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _grp = createGroup _sideX;
 private _officialClass = _faction get "unitOfficial";

--- a/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
@@ -40,8 +40,8 @@ private _taskId = "AS" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskID,
 	[
-		format [localize "STR_A3A_Missions_AS_Smasher_task_desc", FactionGet(occ,"name"), _nameDest, _displayTime],
-		localize "STR_A3A_Missions_AS_Smasher_task_header",
+		[ "STR_A3A_Missions_AS_Smasher_task_desc", FactionGet(occ,"name"), _nameDest, _displayTime],
+		[ "STR_A3A_Missions_AS_Smasher_task_header" ],
 		_markerX
 	],
 	_positionX,
@@ -82,7 +82,7 @@ if (_difficultX) then {
 	} else {
 		selectRandom (_faction getOrDefault ["vehiclesHelisLightAttack", []]);
 	};
-	
+
 	private _heliPos = _posTask getPos [random [1000, 2000, 3000], random 360]; // replace this with an airbase or outpost, etc
 
 	private _heliGroup = createGroup _groupSFSide;
@@ -102,7 +102,7 @@ if (_difficultX) then {
 	for "_i" from 0 to 3 do
 	{
 		private _sfPos = _posTask getPos [random 10, random 360];
-		
+
 		private _typeGroup = selectRandom (_groupSFHash get "groupSpecOpsRandom");
 		private _groupSF = [_sfPos, _groupSFSide, _typeGroup, false, true] call A3A_fnc_spawnGroup;
 

--- a/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Smasher.sqf
@@ -52,6 +52,12 @@ private _taskId = "AS" + str A3A_taskCount;
 	true
 ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+    [ "STR_A3A_Missions_AS_Smasher_task_desc", FactionGet(occ,"name"), _nameDest, _displayTime],
+    [ "STR_A3A_Missions_AS_Smasher_task_header" ],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 // Wait until players are close enough to the city, the idea being that they will see the SF groups fighting the smasher (+ helps perf)
 waitUntil {

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -68,8 +68,8 @@ private _taskId = "AS" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskID,
 	[
-		format [localize "STR_A3A_Missions_AS_Traitor_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
-		localize "STR_A3A_Missions_AS_Traitor_task_header",
+		[ "STR_A3A_Missions_AS_Traitor_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
+		[ "STR_A3A_Missions_AS_Traitor_task_header"],
 		_markerX
 	],
 	_posTsk,

--- a/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Traitor.sqf
@@ -80,6 +80,12 @@ private _taskId = "AS" + str A3A_taskCount;
 	true
 ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+    [ "STR_A3A_Missions_AS_Traitor_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
+    [ "STR_A3A_Missions_AS_Traitor_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 traitorIntel = false; publicVariable "traitorIntel";
 

--- a/A3A/addons/core/functions/Missions/fn_AS_Zombies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Zombies.sqf
@@ -46,8 +46,8 @@ private _taskId = "AS" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskID,
 	[
-		format [localize "STR_A3A_Missions_AS_Zombies_task_desc", _nameDest, _displayTime],
-		localize "STR_A3A_Missions_AS_Zombies_task_header",
+		[ "STR_A3A_Missions_AS_Zombies_task_desc", _nameDest, _displayTime],
+		[ "STR_A3A_Missions_AS_Zombies_task_header"],
 		_markerX
 	],
 	_positionX,

--- a/A3A/addons/core/functions/Missions/fn_AS_Zombies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_Zombies.sqf
@@ -58,6 +58,11 @@ private _taskId = "AS" + str A3A_taskCount;
 	true
 ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_AS_Zombies_task_desc", _nameDest, _displayTime],
+    [ "STR_A3A_Missions_AS_Zombies_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 // Wait until players are close enough to the city to trigger mission
 waitUntil {

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -20,15 +20,27 @@ private _limit = if (_difficultX) then {
 _limit params ["_dateLimitNum", "_displayTime"];
 
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _taskString = format [
-	localize "STR_A3A_Missions_AS_specOP_task_desc",
+private _taskString = [
+	"STR_A3A_Missions_AS_specOP_task_desc",
 	_faction get "name",
 	_nameDest,
 	_displayTime
 ];
 private _taskId = "AS" + str A3A_taskCount;
 
-[[teamPlayer,civilian],_taskId,[_taskString,localize "STR_A3A_Missions_AS_specOP_task_header",_markerX],_positionX,false,0,true,"Kill",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ _taskString,
+    ["STR_A3A_Missions_AS_specOP_task_header"],
+    _markerX
+  ],
+  _positionX,
+  false,
+  0,
+  true,
+  "Kill",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 waitUntil {sleep 1;dateToNumber date > _dateLimitNum or {(spawner getVariable _markerX != 2 and !(sidesX getVariable [_markerX,sideUnknown] == teamPlayer))}};

--- a/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
+++ b/A3A/addons/core/functions/Missions/fn_AS_specOP.sqf
@@ -42,6 +42,11 @@ private _taskId = "AS" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ _taskString,
+    ["STR_A3A_Missions_AS_specOP_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1;dateToNumber date > _dateLimitNum or {(spawner getVariable _markerX != 2 and !(sidesX getVariable [_markerX,sideUnknown] == teamPlayer))}};
 

--- a/A3A/addons/core/functions/Missions/fn_CON_MilAdmin.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_MilAdmin.sqf
@@ -19,11 +19,23 @@ _limit params ["_dateLimitNum", "_displayTime"];
 private _markerSide = sidesX getVariable [_marker, sideUnknown];
 
 private _nameDest = [_marker] call A3A_fnc_localizar;
-private _textX = format [localize "STR_CON_MilAdmin_desc", _nameDest, _displayTime];
-private _taskName = localize "STR_CON_MilAdmin_task";
+private _textX = [ "STR_CON_MilAdmin_desc", _nameDest, _displayTime];
+private _taskName = [ "STR_CON_MilAdmin_task"];
 
 private _taskId = "CON" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[_textX,_taskName,_marker],_milAdministrationPos,false,0,true,"attack",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ _textX,
+    _taskName,
+    _marker
+  ],
+  _milAdministrationPos,
+  false,
+  0,
+  true,
+  "attack",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 

--- a/A3A/addons/core/functions/Missions/fn_CON_MilAdmin.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_MilAdmin.sqf
@@ -37,6 +37,11 @@ private _taskId = "CON" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ _textX,
+    _taskName,
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 
 private _milAdministrationIndex = A3A_milAdministrations findIf { _milAdministrationPos distance2D _x < 30 };

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
@@ -22,21 +22,21 @@ _limit params ["_dateLimitNum", "_displayTime"];
 private _markerSide = sidesX getVariable [_markerX, sideUnknown];
 
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _textX = "";
-private _taskName = "";
+private _textX = [];
+private _taskName = [];
 
 switch (true) do {
 	case (_markerX in resourcesX): {
-		_textX = format [localize "STR_CON_Outpost_resources_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_resources_task";
+		_textX = [ "STR_CON_Outpost_resources_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_resources_task"];
 	};
 	case (_markerX in controlsX): {
-		_textX = format [localize "STR_CON_Outpost_controls_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_controls_task";
+		_textX = [ "STR_CON_Outpost_controls_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_controls_task"];
 	};
 	default {
-		_textX = format [localize "STR_CON_Outpost_outposts_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_outposts_task";
+		_textX = [ "STR_CON_Outpost_outposts_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_outposts_task"];
 	};
 };
 

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost.sqf
@@ -43,6 +43,8 @@ switch (true) do {
 private _taskId = "CON" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_textX,_taskName,_markerX],_positionX,false,0,true,"Target",true] call BIS_fnc_taskCreate;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [_textX,_taskName,_markerX]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1; dateToNumber date > _dateLimitNum or {sidesX getVariable [_markerX,sideUnknown] == teamPlayer}};
 

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
@@ -17,23 +17,23 @@ if (_markerSide == Occupants) then {
 	_oppositeside = Occupants;
 };
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _textX = "";
-private _taskName = "";
+private _textX = [];
+private _taskName = [];
 if ((_oppositeside == Occupants && areOccupantsDefeated) || {(_oppositeside == Invaders && areInvadersDefeated)}) exitWith {
 	[[_markerX],"A3A_fnc_CON_Outpost"] remoteExec ["A3A_fnc_scheduler",2];
 };
 switch (true) do {
 	case (_markerX in resourcesX): {
-		_textX = format [localize "STR_CON_Outpost_resources_compet_desc", _nameDest, _displayTime, _oppositeside]; ///add stringtables
-		_taskName = localize "STR_CON_Outpost_resources_compet_task";
+		_textX = [ "STR_CON_Outpost_resources_compet_desc", _nameDest, _displayTime, _oppositeside]; ///add stringtables
+		_taskName = [ "STR_CON_Outpost_resources_compet_task"];
 	};
 	case (_markerX in controlsX): {
-		_textX = format [localize "STR_CON_Outpost_controls_compet_desc", _nameDest, _displayTime, _oppositeside];
-		_taskName = localize "STR_CON_Outpost_controls_compet_task";
+		_textX = [ "STR_CON_Outpost_controls_compet_desc", _nameDest, _displayTime, _oppositeside];
+		_taskName = [ "STR_CON_Outpost_controls_compet_task"];
 	};
 	default {
-		_textX = format [localize "STR_CON_Outpost_outposts_compet_desc", _nameDest, _displayTime, _oppositeside];
-		_taskName = localize "STR_CON_Outpost_outposts_compet_task";
+		_textX = [ "STR_CON_Outpost_outposts_compet_desc", _nameDest, _displayTime, _oppositeside];
+		_taskName = ["STR_CON_Outpost_outposts_compet_task"];
 	};
 };
 private _taskId = "CON" + str A3A_taskCount;

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost_Compet.sqf
@@ -39,6 +39,8 @@ switch (true) do {
 private _taskId = "CON" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_textX,_taskName,_markerX],_positionX,false,0,true,"Target",true] call BIS_fnc_taskCreate;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [_textX,_taskName,_markerX]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 private _delay = 30 + (round random 20);
 private _targPos = markerPos _markerX;
 private _airbase = [_oppositeside, markerPos _markerX] call A3A_fnc_availableBasesAir;

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost_Zombies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost_Zombies.sqf
@@ -24,25 +24,25 @@ if !(_civNonHuman) exitWith {
 private _markerSide = sidesX getVariable [_markerX, sideUnknown];
 
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _textX = "";
-private _taskName = "";
+private _textX = [];
+private _taskName = [];
 
 switch (true) do 
 {
 	case (_markerX in resourcesX): 
 	{
-		_textX = format [localize "STR_CON_Outpost_resources_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_resources_task";
+		_textX = [ "STR_CON_Outpost_resources_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_resources_task"];
 	};
 	case (_markerX in controlsX): 
 	{
-		_textX = format [localize "STR_CON_Outpost_controls_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_controls_task";
+		_textX = [ "STR_CON_Outpost_controls_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_controls_task"];
 	};
 	default 
 	{
-		_textX = format [localize "STR_CON_Outpost_outposts_desc", _nameDest, _displayTime];
-		_taskName = localize "STR_CON_Outpost_outposts_task";
+		_textX = [ "STR_CON_Outpost_outposts_desc", _nameDest, _displayTime];
+		_taskName = [ "STR_CON_Outpost_outposts_task"];
 	};
 };
 

--- a/A3A/addons/core/functions/Missions/fn_CON_Outpost_Zombies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_CON_Outpost_Zombies.sqf
@@ -59,6 +59,8 @@ private _taskId = "CON" + str A3A_taskCount;
 	true
 ] call BIS_fnc_taskCreate;
 [_taskId, "CON", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [_textX, _taskName, _markerX]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {
 	sleep 5;

--- a/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
@@ -29,8 +29,8 @@ private _taskId = "DES" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskId,
 	[
-		format [localize "STR_A3A_Missions_DES_Antenna_task_desc",_nameDest,_displayTime,FactionGet(occ,"name")],
-		localize "STR_A3A_Missions_DES_Antenna_task_header",
+		[ "STR_A3A_Missions_DES_Antenna_task_desc",_nameDest,_displayTime,FactionGet(occ,"name")],
+		[ "STR_A3A_Missions_DES_Antenna_task_header"],
 		_mrkFinal
 	],
 	_positionX,

--- a/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Antenna.sqf
@@ -41,6 +41,11 @@ private _taskId = "DES" + str A3A_taskCount;
 	true
 	] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_DES_Antenna_task_desc",_nameDest,_displayTime,FactionGet(occ,"name")],
+    [ "STR_A3A_Missions_DES_Antenna_task_header"],
+    _mrkFinal
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 waitUntil {sleep 1; dateToNumber date > _dateLimitNum or {!alive _antenna or {!(sidesX getVariable [_markerX,sideUnknown] == Occupants)}}};
 
 private _bonus = if (_difficultX) then {2} else {1};

--- a/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
@@ -137,8 +137,8 @@ private _taskId = "DES" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_A3A_Missions_DES_Artillery_task_desc", _nameDest, _displayTime],
-        localize "STR_A3A_Missions_DES_Artillery_task_header",
+        [ "STR_A3A_Missions_DES_Artillery_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_DES_Artillery_task_header"],
         _markerX
     ],
     _artilleryPosition,

--- a/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Artillery.sqf
@@ -149,6 +149,12 @@ private _taskId = "DES" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_A3A_Missions_DES_Artillery_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_DES_Artillery_task_header"],
+        _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 _artilleryVeh allowDamage true;
 

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -108,7 +108,17 @@ private _taskId = "DES" + str A3A_taskCount;
 [
     [teamPlayer,civilian],
     _taskId,
-    [format [localize "STR_A3A_Missions_DES_Heli_task_desc",_faction get "name", _location, _displayTime],localize "STR_A3A_Missions_DES_Heli_task_header",_taskMrk],_posCrashMrk,false,0,true,"Destroy",true] call BIS_fnc_taskCreate;
+    [ [ "STR_A3A_Missions_DES_Heli_task_desc",_faction get "name", _location, _displayTime],
+      [ "STR_A3A_Missions_DES_Heli_task_header"],
+      _taskMrk
+    ],
+    _posCrashMrk,
+    false,
+    0,
+    true,
+    "Destroy",
+    true
+    ] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 ////////////////

--- a/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Heli.sqf
@@ -120,6 +120,11 @@ private _taskId = "DES" + str A3A_taskCount;
     true
     ] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_DES_Heli_task_desc",_faction get "name", _location, _displayTime],
+      [ "STR_A3A_Missions_DES_Heli_task_header"],
+      _taskMrk
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 ////////////////
 //convoy spawn//

--- a/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
@@ -23,8 +23,8 @@ private _taskId = "DES" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskId,
 	[
-		format [localize "STR_A3A_Missions_DES_Vehicle_task_desc",_nameDest,_displayTime,getText (configFile >> "CfgVehicles" >> (_typeVehX) >> "displayName")],
-		localize "STR_A3A_Missions_DES_Vehicle_task_header",
+		[ "STR_A3A_Missions_DES_Vehicle_task_desc",_nameDest,_displayTime,getText (configFile >> "CfgVehicles" >> (_typeVehX) >> "displayName")],
+		[ "STR_A3A_Missions_DES_Vehicle_task_header"],
 		_markerX
 	],
 	_positionX,false,0,true,"Destroy",true

--- a/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
+++ b/A3A/addons/core/functions/Missions/fn_DES_Vehicle.sqf
@@ -30,6 +30,11 @@ private _taskId = "DES" + str A3A_taskCount;
 	_positionX,false,0,true,"Destroy",true
 ] call BIS_fnc_taskCreate;
 [_taskId, "DES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_DES_Vehicle_task_desc",_nameDest,_displayTime,getText (configFile >> "CfgVehicles" >> (_typeVehX) >> "displayName")],
+    [ "STR_A3A_Missions_DES_Vehicle_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 _truckCreated = false;
 waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or (spawner getVariable _markerX == 0)};

--- a/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
+++ b/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
@@ -82,8 +82,8 @@ private _taskId = "TRADER" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_trader_quest_description", FactionGet(occ,"name"), _worldName, name traderX, FactionGet(occ,"name")],
-        localize "STR_trader_quest_header",
+        [ "STR_trader_quest_description", FactionGet(occ,"name"), _worldName, name traderX, FactionGet(occ,"name")],
+        [ "STR_trader_quest_header"],
         _traderMarkerVague
     ],
     _markerVaguePosition,

--- a/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
+++ b/A3A/addons/core/functions/Missions/fn_ENC_Trader.sqf
@@ -94,6 +94,12 @@ private _taskId = "TRADER" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "TRADER", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_trader_quest_description", FactionGet(occ,"name"), _worldName, name traderX, FactionGet(occ,"name")],
+        [ "STR_trader_quest_header"],
+        _traderMarkerVague
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _trigger = createTrigger ["EmptyDetector", _traderPosition];
 _trigger setTriggerArea [30, 30, 0, false];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
@@ -35,8 +35,8 @@ private _taskId = "LOG" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_A3A_Missions_DES_Airdrop_task_desc", _nameDest, _displayTime],
-        localize "STR_A3A_Missions_LOG_Airdrop_task_header",
+        [ "STR_A3A_Missions_DES_Airdrop_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_LOG_Airdrop_task_header"],
         _markerX
     ],
     _positionX,

--- a/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Airdrop.sqf
@@ -47,6 +47,12 @@ private _taskId = "LOG" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_A3A_Missions_DES_Airdrop_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_LOG_Airdrop_task_header"],
+        _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1; (call SCRT_fnc_misc_getRebelPlayers) findIf {_x inArea [_positionX, 75, 75, 0, false]} != -1 or {dateToNumber date > _dateLimitNum}};
 

--- a/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
@@ -26,7 +26,19 @@ _pos = _pos findEmptyPosition [1,60,_typeVehX];
 if (count _pos == 0) then {_pos = position _road};
 
 private _taskId = "LOG" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_LOG_Ammo_task_desc",_nameDest,_displayTime],localize "STR_A3A_Missions_LOG_Ammo_task_header",_markerX],_pos,false,0,true,"rearm",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_A3A_Missions_LOG_Ammo_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_LOG_Ammo_task_header"],
+    _markerX
+  ],
+  _pos,
+  false,
+  0,
+  true,
+  "rearm",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or {(spawner getVariable _markerX != 2 and !(sidesX getVariable [_markerX,sideUnknown] == teamPlayer))}};

--- a/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Ammo.sqf
@@ -40,6 +40,11 @@ private _taskId = "LOG" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_LOG_Ammo_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_LOG_Ammo_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or {(spawner getVariable _markerX != 2 and !(sidesX getVariable [_markerX,sideUnknown] == teamPlayer))}};
 private _bonus = if (_difficultX) then {2} else {1};

--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -44,8 +44,10 @@ _truckX addEventHandler ["GetIn", {
 private _taskId = "LOG" + str A3A_taskCount;
 [
     [teamPlayer, civilian], _taskId,
-    [format [localize "STR_A3A_Missions_LOG_Bank_task_desc", _nameDest, _displayTime], 
-    localize "STR_A3A_Missions_LOG_Bank_task_header", _mrkFinal],
+    [ [ "STR_A3A_Missions_LOG_Bank_task_desc", _nameDest, _displayTime],
+      [ "STR_A3A_Missions_LOG_Bank_task_header"],
+      _mrkFinal
+    ],
     _positionX, false, 0, true, "Interact", true
 ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExec ["A3A_fnc_taskUpdate", 2];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Bank.sqf
@@ -51,6 +51,11 @@ private _taskId = "LOG" + str A3A_taskCount;
     _positionX, false, 0, true, "Interact", true
 ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExec ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_LOG_Bank_task_desc", _nameDest, _displayTime],
+      [ "STR_A3A_Missions_LOG_Bank_task_header"],
+      _mrkFinal
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 // Creating guards
 private _groups = [];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
@@ -148,7 +148,10 @@ private _rebelTaskText = format [
 [
     [teamPlayer,civilian],
     _taskId,
-    [format [localize "STR_A3A_Missions_LOG_crashsite_task_desc", _faction get "name", _startTimeDisplay, _displayTime], localize "STR_A3A_Missions_LOG_crashsite_task_header", _markerX],
+    [ [ "STR_A3A_Missions_LOG_crashsite_task_desc", _faction get "name", _startTimeDisplay, _displayTime],
+      [ "STR_A3A_Missions_LOG_crashsite_task_header"],
+      _markerX
+    ],
     _crashPositionMarker,
     false,
     0,
@@ -444,7 +447,10 @@ if (!isNil "traderMarker") then { //checking if trader is spawned
     [
         [teamPlayer,civilian],
         _taskId2,
-        [format [localize "STR_A3A_Missions_LOG_crashsite_task_alt", _faction get "name", _destinationName, _displayTime], localize "STR_A3A_Missions_LOG_crashsite_task_header", _markerX],
+        [ [ "STR_A3A_Missions_LOG_crashsite_task_alt", _faction get "name", _destinationName, _displayTime],
+          [ "STR_A3A_Missions_LOG_crashsite_task_header"],
+          _markerX
+        ],
         traderMarker,
         false,
         0,

--- a/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Crashsite.sqf
@@ -160,6 +160,11 @@ private _rebelTaskText = format [
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_LOG_crashsite_task_desc", _faction get "name", _startTimeDisplay, _displayTime],
+      [ "STR_A3A_Missions_LOG_crashsite_task_header"],
+      _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 ///checking if players reached minimum distance to start vfx or if time limit has passed
 private _missionStart = serverTime;
@@ -459,6 +464,11 @@ if (!isNil "traderMarker") then { //checking if trader is spawned
         true
     ] call BIS_fnc_taskCreate;
     [_taskId2, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+    [ _taskId2,
+      [ [ "STR_A3A_Missions_LOG_crashsite_task_alt", _faction get "name", _destinationName, _displayTime],
+              [ "STR_A3A_Missions_LOG_crashsite_task_header"],
+              _markerX
+            ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 };
 
 if (!isNil "traderMarker") then { // check if trader is present

--- a/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
@@ -179,7 +179,10 @@ private _rebelTaskText = format [
 [
     [teamPlayer,civilian],
     _taskId,
-    [format [localize "STR_A3A_Missions_LOG_Helicrash_task_desc", _faction get "name", _destinationName, _displayTime], localize "STR_A3A_Missions_LOG_Helicrash_task_header", _markerX],
+    [ [ "STR_A3A_Missions_LOG_Helicrash_task_desc", _faction get "name", _destinationName, _displayTime],
+      [ "STR_A3A_Missions_LOG_Helicrash_task_header"],
+      _markerX
+    ],
     _crashPositionMarker,
     false,
     0,

--- a/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Helicrash.sqf
@@ -191,6 +191,11 @@ private _rebelTaskText = format [
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_LOG_Helicrash_task_desc", _faction get "name", _destinationName, _displayTime],
+      [ "STR_A3A_Missions_LOG_Helicrash_task_header"],
+      _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 //loiter helicopter
 _searchHeliData = [[(_crashPosition select 0) + random 100, (_crashPosition select 1) + random 100, 300 + random 500], 0, _searchHeliClass, _sideX] call A3A_fnc_spawnVehicle;

--- a/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
@@ -48,8 +48,8 @@ _limit params ["_dateLimitNum", "_displayTime"];
 
 //Name of seaport marker
 private _nameDest = [_markerX] call A3A_fnc_localizar;
-private _title = localize "STR_A3A_Missions_LOG_Salvage_task_header";
-private _text = format [localize "STR_A3A_Missions_LOG_Salvage_task_desc", _nameDest, _displayTime];
+private _title = [ "STR_A3A_Missions_LOG_Salvage_task_header"];
+private _text =  [ "STR_A3A_Missions_LOG_Salvage_task_desc", _nameDest, _displayTime];
 private _taskId = "LOG" + str A3A_taskCount;
 [[teamPlayer, civilian], _taskId, [ _text, _title, [_mrk1, _mrk2, _mrk3]], _positionX, false, 0, true, "rearm", true] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];

--- a/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_LOG_Salvage.sqf
@@ -53,6 +53,8 @@ private _text =  [ "STR_A3A_Missions_LOG_Salvage_task_desc", _nameDest, _display
 private _taskId = "LOG" + str A3A_taskCount;
 [[teamPlayer, civilian], _taskId, [ _text, _title, [_mrk1, _mrk2, _mrk3]], _positionX, false, 0, true, "rearm", true] call BIS_fnc_taskCreate;
 [_taskId, "LOG", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ _text, _title, [_mrk1, _mrk2, _mrk3]]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 //salvageRope action
 [] remoteExec ["A3A_fnc_SalvageRope", 0, true];

--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -15,8 +15,8 @@ private _taskId = "REP" + str A3A_taskCount;
 	[teamPlayer, civilian],
 	_taskId,
 	[
-		format [localize "STR_A3A_Missions_REP_Antenna_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
-		localize "STR_A3A_Missions_REP_Antenna_task_header",
+		[ "STR_A3A_Missions_REP_Antenna_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
+		[ "STR_A3A_Missions_REP_Antenna_task_header"],
 		_markerX
 	],
 	getPos _antennaDead,

--- a/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
+++ b/A3A/addons/core/functions/Missions/fn_REP_Antenna.sqf
@@ -23,6 +23,12 @@ private _taskId = "REP" + str A3A_taskCount;
 	false, 0, true, "Destroy", true
 ] call BIS_fnc_taskCreate;
 [_taskId, "REP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+		[ "STR_A3A_Missions_REP_Antenna_task_desc",FactionGet(occ,"name"),_nameDest,_displayTime],
+		[ "STR_A3A_Missions_REP_Antenna_task_header"],
+		_markerX
+	]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1;(dateToNumber date > _dateLimitNum) or (spawner getVariable _markerX != 2)};
 

--- a/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
@@ -47,10 +47,20 @@ if (count _potentials > 0) then {
 };
 private _taskId = "RES" + str A3A_taskCount;
 if (count _potentials > 0) then {
-	[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],localize "STR_A3A_Missions_RES_Deserters_task_header",_markerX],_spawnPos,false,0,true,"run",true] call BIS_fnc_taskCreate;///add stringtables
+	[ [teamPlayer,civilian],
+          _taskId,
+          [ [ "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],
+            [ "STR_A3A_Missions_RES_Deserters_task_header"],
+            _markerX
+          ],_spawnPos,false,0,true,"run",true] call BIS_fnc_taskCreate;///add stringtables
 	[_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 } else {
-	[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],localize "STR_A3A_Missions_RES_Deserters_task_header",_markerX],_positionX,false,0,true,"run",true] call BIS_fnc_taskCreate;
+	[ [teamPlayer,civilian],
+          _taskId,
+          [ [ "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],
+            [ "STR_A3A_Missions_RES_Deserters_task_header"],
+            _markerX
+          ],_positionX,false,0,true,"run",true] call BIS_fnc_taskCreate;
 	[_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 };
 waitUntil {

--- a/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Deserters.sqf
@@ -54,6 +54,11 @@ if (count _potentials > 0) then {
             _markerX
           ],_spawnPos,false,0,true,"run",true] call BIS_fnc_taskCreate;///add stringtables
 	[_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+        [ _taskId,
+          [ [ "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],
+                    [ "STR_A3A_Missions_RES_Deserters_task_header"],
+                    _markerX
+          ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 } else {
 	[ [teamPlayer,civilian],
           _taskId,
@@ -62,6 +67,11 @@ if (count _potentials > 0) then {
             _markerX
           ],_positionX,false,0,true,"run",true] call BIS_fnc_taskCreate;
 	[_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+        [ _taskId,
+          [ [ "STR_A3A_Missions_RES_Deserters_task_desc",_nameDest,_displayTime],
+                    [ "STR_A3A_Missions_RES_Deserters_task_header"],
+                    _markerX
+          ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 };
 waitUntil {
     sleep 1;

--- a/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
@@ -160,8 +160,8 @@ private _taskId = "RES" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_A3A_Missions_RES_Informer_task_desc", _faction get "name", _destinationName, _displayTime],
-        localize "STR_A3A_Missions_RES_Informer_task_header",
+        [ "STR_A3A_Missions_RES_Informer_task_desc", _faction get "name", _destinationName, _displayTime],
+        [ "STR_A3A_Missions_RES_Informer_task_header"],
         _markerX
     ],
     _positionX,

--- a/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Informer.sqf
@@ -172,6 +172,12 @@ private _taskId = "RES" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_A3A_Missions_RES_Informer_task_desc", _faction get "name", _destinationName, _displayTime],
+        [ "STR_A3A_Missions_RES_Informer_task_header"],
+        _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 Info("Informer has spawned, waiting until players will be close to the city");
 

--- a/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
@@ -21,7 +21,19 @@ _limit params ["_dateLimitNum", "_displayTime"];
 private _nameDest = [_markerX] call A3A_fnc_localizar;
 
 private _taskId = "RES" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_RES_Prisoners_task_desc",_nameDest,_displayTime],localize "STR_A3A_Missions_RES_Prisoners_task_header",_markerX],_positionX,false,0,true,"run",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_A3A_Missions_RES_Prisoners_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_RES_Prisoners_task_header"],
+    _markerX
+  ],
+  _positionX,
+  false,
+  0,
+  true,
+  "run",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _posHouse = [];

--- a/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Prisoners.sqf
@@ -35,6 +35,11 @@ private _taskId = "RES" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_RES_Prisoners_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_RES_Prisoners_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _posHouse = [];
 private _countX = 0;

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -36,12 +36,12 @@ private _header = nil;
 private _posTsk = nil;
 
 if (_sideX == Occupants) then {
-	_text = format [localize "STR_A3A_Missions_RES_Refugees_task_desc_1",FactionGet(reb, "name"), _nameDest,_displayTime];
-	_header = format [localize "STR_A3A_Missions_RES_Refugees_task_header_1",FactionGet(reb, "name")];
+	_text = [ "STR_A3A_Missions_RES_Refugees_task_desc_1",FactionGet(reb, "name"), _nameDest,_displayTime];
+	_header = [ "STR_A3A_Missions_RES_Refugees_task_header_1",FactionGet(reb, "name")];
 	_posTsk = (position _houseX) getPos [random 100, random 360];
 } else {
-	_text = format [localize "STR_A3A_Missions_RES_Refugees_task_desc_2",_nameDest, _faction get "name",_displayTime];
-	_header = localize "STR_A3A_Missions_RES_Refugees_task_header_2";
+	_text = [ "STR_A3A_Missions_RES_Refugees_task_desc_2",_nameDest, _faction get "name",_displayTime];
+	_header = [ "STR_A3A_Missions_RES_Refugees_task_header_2"];
 	_posTsk = position _houseX;
 };
 
@@ -135,7 +135,7 @@ if (_sideX == Invaders) then {
 		};
 
 	[_groupX, "Patrol_Area", 25, 50, 100, true, _positionX, true] call A3A_fnc_patrolLoop;
-	
+
 	{[_x,""] call A3A_fnc_NATOinit} forEach units _groupX;
 	_groupX1 = [_houseX buildingExit 0, Occupants, _faction get "groupPolice"] call A3A_fnc_spawnGroup;
 };

--- a/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Refugees.sqf
@@ -48,6 +48,8 @@ if (_sideX == Occupants) then {
 private _taskId = "RES" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_text,_header,_nameDest],_posTsk,false,0,true,"run",true] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [_text,_header,_nameDest]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 _groupPOW = createGroup teamPlayer;
 for "_i" from 1 to (((count _posHouse) - 1) min 6) do {

--- a/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
@@ -116,8 +116,8 @@ private _taskId = "RES" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_A3A_Missions_RES_Shipwreck_task_desc", _nameDest, _displayTime],
-        localize "STR_A3A_Missions_RES_Shipwreck_task_header",
+        [ "STR_A3A_Missions_RES_Shipwreck_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_RES_Shipwreck_task_header"],
         _markerX
     ],
     _shorePosition,

--- a/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RES_Shipwreck.sqf
@@ -128,6 +128,12 @@ private _taskId = "RES" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_A3A_Missions_RES_Shipwreck_task_desc", _nameDest, _displayTime],
+        [ "STR_A3A_Missions_RES_Shipwreck_task_header"],
+        _markerX
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1;dateToNumber date > _dateLimitNum or {(call SCRT_fnc_misc_getRebelPlayers) inAreaArray [_shorePosition, distanceSPWN1, distanceSPWN1] isNotEqualTo []}};
 

--- a/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
@@ -81,8 +81,8 @@ private _taskId = "AS" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskID,
 	[
-		format [localize "STR_A3A_Missions_AS_RIV_Traitor_task_desc", A3A_faction_riv get "name", A3A_faction_reb get "name", _nameDest, _displayTime],
-		localize "STR_A3A_Missions_AS_RIV_Traitor_task_header",
+		[ "STR_A3A_Missions_AS_RIV_Traitor_task_desc", A3A_faction_riv get "name", A3A_faction_reb get "name", _nameDest, _displayTime],
+		[ "STR_A3A_Missions_AS_RIV_Traitor_task_header"],
 		_markerX
 	],
 	_posTsk,

--- a/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_AS_Traitor.sqf
@@ -93,6 +93,11 @@ private _taskId = "AS" + str A3A_taskCount;
 	true
 ] call BIS_fnc_taskCreate;
 [_taskId, "AS", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_AS_RIV_Traitor_task_desc", A3A_faction_riv get "name", A3A_faction_reb get "name", _nameDest, _displayTime],
+    [ "STR_A3A_Missions_AS_RIV_Traitor_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 sleep 15;
 _traitor allowDamage true;

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
@@ -145,8 +145,8 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_RIV_ATT_cell_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
-        format [localize "STR_RIV_ATT_cell_header", A3A_faction_riv get "name"],
+        [ "STR_RIV_ATT_cell_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_cell_header", A3A_faction_riv get "name"],
         _marker
     ],
     _targetPos,

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Cell.sqf
@@ -157,6 +157,12 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RIV_ATT", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_RIV_ATT_cell_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_cell_header", A3A_faction_riv get "name"],
+        _marker
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {sleep 1; (call SCRT_fnc_misc_getRebelPlayers) inAreaArray [_targetPos, distanceSPWN1, distanceSPWN1] isNotEqualTo [] || {dateToNumber date > _dateLimitNum}};
 

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
@@ -75,8 +75,8 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_RIV_ATT_hideout_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
-        format [localize "STR_RIV_ATT_hideout_header", A3A_faction_riv get "name"],
+        [ "STR_RIV_ATT_hideout_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_hideout_header", A3A_faction_riv get "name"],
         _marker
     ],
     _hideoutPosition,

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Hideout.sqf
@@ -87,6 +87,12 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RIV_ATT", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_RIV_ATT_hideout_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_hideout_header", A3A_faction_riv get "name"],
+        _marker
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {
     sleep 1;

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
@@ -110,8 +110,8 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [localize "STR_RIV_ATT_transfer_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
-        format [localize "STR_RIV_ATT_transfer_header", A3A_faction_riv get "name"],
+        [ "STR_RIV_ATT_transfer_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_transfer_header", A3A_faction_riv get "name"],
         _marker
     ],
     _hideoutPosition,

--- a/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ATT_Transfer.sqf
@@ -122,6 +122,12 @@ private _taskId = "RIV_ATT" + str A3A_taskCount;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RIV_ATT", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_RIV_ATT_transfer_text", A3A_faction_riv get "name", ([_marker] call A3A_fnc_localizar), _displayTime],
+        [ "STR_RIV_ATT_transfer_header", A3A_faction_riv get "name"],
+        _marker
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {
     sleep 1;

--- a/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
@@ -245,8 +245,8 @@ private _intelLeaderPosition = position _intelLeader;
     [teamPlayer,civilian],
     _taskId,
     [
-        format [(localize "STR_rivals_quest_description"),A3A_faction_occ get "name"],
-        (localize "STR_rivals_quest_header"),
+        [ "STR_rivals_quest_description",A3A_faction_occ get "name"],
+        [ "STR_rivals_quest_header"],
         _marker
     ],
     _intelLeaderPosition,
@@ -323,8 +323,8 @@ sleep 2;
     [teamPlayer,civilian],
     _taskId,
     [
-		format [(localize "STR_rivals_quest_update_description"), _displayTime],
-		format [(localize "STR_rivals_quest_update_header"), A3A_faction_riv get "name"],
+		[ "STR_rivals_quest_update_description", _displayTime],
+		[ "STR_rivals_quest_update_header", A3A_faction_riv get "name"],
         _marker
     ],
     _roadPosition,

--- a/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_ENC_Rivals.sqf
@@ -257,6 +257,12 @@ private _intelLeaderPosition = position _intelLeader;
     true
 ] call BIS_fnc_taskCreate;
 [_taskId, "RIV_ENC", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [
+        [ "STR_rivals_quest_description",A3A_faction_occ get "name"],
+        [ "STR_rivals_quest_header"],
+        _marker
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 waitUntil {
     sleep 2;
@@ -336,6 +342,12 @@ sleep 2;
 ] call BIS_fnc_taskCreate;
 [_taskId, "RIV_ENC", "ASSIGNED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 _taskId call BIS_fnc_taskSetCurrent;
+[ _taskId,
+  [
+    [ "STR_rivals_quest_update_description", _displayTime],
+    [ "STR_rivals_quest_update_header", A3A_faction_riv get "name"],
+    _marker
+    ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _group1Position = [
 		_roadPosition, //center

--- a/A3A/addons/core/functions/Missions/fn_RIV_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_RES_Prisoners.sqf
@@ -24,7 +24,19 @@ _limit params ["_dateLimitNum", "_displayTime"];
 private _nameDest = [_markerX] call A3A_fnc_localizar;
 
 private _taskId = "RES" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_RIV_RES_Prisoners_task_desc",_faction get "name", _nameDest, _displayTime],localize "STR_A3A_Missions_RIV_RES_Prisoners_task_header",_markerX],_positionX,false,0,true,"run",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [localize "STR_A3A_Missions_RIV_RES_Prisoners_task_desc",_faction get "name", _nameDest, _displayTime],
+    [ "STR_A3A_Missions_RIV_RES_Prisoners_task_header"],
+    _markerX
+  ],
+  _positionX,
+  false,
+  0,
+  true,
+  "run",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _posHouse = [];

--- a/A3A/addons/core/functions/Missions/fn_RIV_RES_Prisoners.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_RES_Prisoners.sqf
@@ -38,6 +38,11 @@ private _taskId = "RES" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "RES", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [localize "STR_A3A_Missions_RIV_RES_Prisoners_task_desc",_faction get "name", _nameDest, _displayTime],
+    [ "STR_A3A_Missions_RIV_RES_Prisoners_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _posHouse = [];
 private _countX = 0;

--- a/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
@@ -167,8 +167,8 @@ private _taskId = "SUPP" + str A3A_taskCount;
 	[teamPlayer,civilian],
 	_taskId,
 	[
-		format [localize "STR_A3A_Missions_RIV_SUPP_Salvage_task_desc", _nameDest, _faction get "name", _displayTime],
-		localize "STR_A3A_Missions_RIV_SUPP_Salvage_task_header",
+		[ "STR_A3A_Missions_RIV_SUPP_Salvage_task_desc", _nameDest, _faction get "name", _displayTime],
+		[ "STR_A3A_Missions_RIV_SUPP_Salvage_task_header"],
 		_markerX
 	],_startingRoadPosition,false,0,true,"truck",true] call BIS_fnc_taskCreate;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];

--- a/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
+++ b/A3A/addons/core/functions/Missions/fn_RIV_SUPP_Salvage.sqf
@@ -172,6 +172,11 @@ private _taskId = "SUPP" + str A3A_taskCount;
 		_markerX
 	],_startingRoadPosition,false,0,true,"truck",true] call BIS_fnc_taskCreate;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_RIV_SUPP_Salvage_task_desc", _nameDest, _faction get "name", _displayTime],
+    [ "STR_A3A_Missions_RIV_SUPP_Salvage_task_header"],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 Info("Waiting until players will be near the zone.");
 

--- a/A3A/addons/core/functions/Missions/fn_SUPP_Supplies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_SUPP_Supplies.sqf
@@ -21,7 +21,19 @@ _limit params ["_dateLimitNum", "_displayTime"];
 
 private _nameDest = [_markerX] call A3A_fnc_localizar;
 private _taskId = "SUPP" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_Missions_SUPP_Supplies_task_desc",_nameDest,_displayTime],format [localize "STR_A3A_Missions_SUPP_Supplies_task_header", _nameDest],_markerX],_positionX,false,0,true,"Heal",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_A3A_Missions_SUPP_Supplies_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_SUPP_Supplies_task_header", _nameDest],
+    _markerX
+  ],
+  _positionX,
+  false,
+  0,
+  true,
+  "Heal",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 //Creating the box

--- a/A3A/addons/core/functions/Missions/fn_SUPP_Supplies.sqf
+++ b/A3A/addons/core/functions/Missions/fn_SUPP_Supplies.sqf
@@ -35,6 +35,11 @@ private _taskId = "SUPP" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "SUPP", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_Missions_SUPP_Supplies_task_desc",_nameDest,_displayTime],
+    [ "STR_A3A_Missions_SUPP_Supplies_task_header", _nameDest],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 //Creating the box
 private _pos = (getMarkerPos respawnTeamPlayer) findEmptyPosition [1,50,"Land_FoodSacks_01_cargo_brown_F"];

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -90,36 +90,36 @@ switch (toLowerANSI _convoyType) do ///why? toLowerANSI
 {
     case "ammunition": ///shouldn't they all start from the Capital?
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_ammo",_nameOrigin,_displayTime,_nameDest];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_ammo";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_ammo",_nameOrigin,_displayTime,_nameDest];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_ammo"];
         _taskIcon = "rearm";
         _typeVehObj = selectRandom (_milFaction get "vehiclesAmmoTrucks");
     };
     case "fuel":
 	{
-		_textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_fuel",_nameOrigin,_displayTime,_nameDest];
-		_taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_fuel";
+		_textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_fuel",_nameOrigin,_displayTime,_nameDest];
+		_taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_fuel"];
 		_taskIcon = "refuel";
 		_typeVehObj = selectRandom (_milFaction get "vehiclesFuelTrucks");
 	};
     case "repair":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_repair",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_repair";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_repair",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_repair"];
         _taskIcon = "repair";
         _typeVehObj = selectRandom (_milFaction get "vehiclesRepairTrucks");
     };
     case "armor":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_armor",_nameOrigin,_displayTime,_nameDest];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_armor";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_armor",_nameOrigin,_displayTime,_nameDest];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_armor"];
         _taskIcon = "destroy";
         _typeVehObj = selectRandom (_milFaction get "vehiclesArmor");
     };
     case "prisoners":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_prisoners",_nameOrigin,_displayTime,_nameDest];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_prisoners";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_prisoners",_nameOrigin,_displayTime,_nameDest];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_prisoners"];
         _taskIcon = "run";
         _typeVehObj = selectRandom ( switch true do {
             case (tierWar < 5): { (_milFaction get "vehiclesMilitiaTrucks") };
@@ -129,8 +129,8 @@ switch (toLowerANSI _convoyType) do ///why? toLowerANSI
     };
     case "reinforcements":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_reinf",_nameOrigin,_displayTime,_nameDest];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_reinf";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_reinf",_nameOrigin,_displayTime,_nameDest];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_reinf"];
         _taskIcon = "meet";
         _typeVehObj = selectRandom ( switch true do {
             case (tierWar < 5): { (_milFaction get "vehiclesMilitiaTrucks") };
@@ -140,16 +140,16 @@ switch (toLowerANSI _convoyType) do ///why? toLowerANSI
     };
     case "money":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_money",_nameOrigin,_displayTime,_nameDest];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_money";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_money",_nameOrigin,_displayTime,_nameDest];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_money"];
         _taskIcon = "takeoff"; ///"truck" icon doesn't exist
         _vehiclePool = if (_civDisabled) then { _milFaction get "vehiclesMilitiaTrucks" } else { _civFaction get "vehiclesCivIndustrial" } select { _x isEqualType "" }; // * convert weighted list to normal array
         _typeVehObj = selectRandom (_rebFaction getOrDefault ["vehiclesCivSupply", _vehiclePool]);
     };
     case "supplies":
     {
-        _textX = format [localize "STR_A3A_Missions_AS_Convoy_task_dest_supplies",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
-        _taskTitle = localize "STR_A3A_Missions_AS_Convoy_task_header_supplies";
+        _textX = [ "STR_A3A_Missions_AS_Convoy_task_dest_supplies",_nameOrigin,_displayTime,_nameDest,FactionGet(reb,"name")];
+        _taskTitle = [ "STR_A3A_Missions_AS_Convoy_task_header_supplies"];
         _taskIcon = "box";
         _vehiclePool = if (_civDisabled) then { _milFaction get "vehiclesMilitiaTrucks" } else { _civFaction getOrDefault ["vehiclesCivMedical", _civFaction get "vehiclesCivIndustrial"] } select { _x isEqualType "" }; // * convert weighted list to normal array
         _typeVehObj = selectRandom (_rebFaction getOrDefault ["vehiclesCivSupply", _vehiclePool]);

--- a/A3A/addons/core/functions/Missions/fn_convoy.sqf
+++ b/A3A/addons/core/functions/Missions/fn_convoy.sqf
@@ -164,6 +164,8 @@ private _posDest = navGrid select ([_mrkDest] call A3A_fnc_getMarkerNavPoint) se
 private _taskId = "CONVOY" + str A3A_taskCount;
 [[teamPlayer,civilian],_taskId,[_textX,_taskTitle,_mrkDest],_posDest,false,0,true,_taskIcon,true] call BIS_fnc_taskCreate;
 [_taskId, "CONVOY", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [_textX,_taskTitle,_mrkDest]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 ServerInfo_3("%1 convoy mission created from %2 to %3", _convoyType, _mrkOrigin, _mrkDest);
 

--- a/A3A/addons/core/functions/Missions/fn_underAttack.sqf
+++ b/A3A/addons/core/functions/Missions/fn_underAttack.sqf
@@ -23,7 +23,19 @@ else
 };
 if (_sideX == teamPlayer) then {_sideX = [teamPlayer,civilian]};
 
-[_sideX,_markerX,[format [localize "STR_A3A_Missions_underattack_task_desc",_nameDest,_nameENY],format [localize "STR_A3A_Missions_underattack_task_header",_nameENY],_markerX],getMarkerPos _markerX,false,0,true,"Defend",true] call BIS_fnc_taskCreate;
+[ _sideX,
+  _markerX,
+  [ [ "STR_A3A_Missions_underattack_task_desc",_nameDest,_nameENY],
+    [localize "STR_A3A_Missions_underattack_task_header",_nameENY],
+    _markerX
+  ],
+  getMarkerPos _markerX,
+  false,
+  0,
+  true,
+  "Defend",
+  true
+  ] call BIS_fnc_taskCreate;
 
 if (_sideX isEqualType []) then {_sideX = teamPlayer};
 

--- a/A3A/addons/core/functions/Missions/fn_underAttack.sqf
+++ b/A3A/addons/core/functions/Missions/fn_underAttack.sqf
@@ -36,6 +36,11 @@ if (_sideX == teamPlayer) then {_sideX = [teamPlayer,civilian]};
   "Defend",
   true
   ] call BIS_fnc_taskCreate;
+[ _markerX,
+  [ [ "STR_A3A_Missions_underattack_task_desc",_nameDest,_nameENY],
+    [localize "STR_A3A_Missions_underattack_task_header",_nameENY],
+    _markerX
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 if (_sideX isEqualType []) then {_sideX = teamPlayer};
 

--- a/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
@@ -25,7 +25,19 @@ _mrk setMarkerBrushLocal "DiagGrid";
 _mrk setMarkerText (localize "STR_marker_minefield");
 
 private _taskId = "Mines" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_A3A_reinf_minefield_task_desc",_quantity],"Minefield Deploy",_mrk],_positionTel,false,0,true,"map",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_A3A_reinf_minefield_task_desc",_quantity],
+    [ "STR_A3A_reinf_minefield_task_header"],
+    _mrk
+  ],
+  _positionTel,
+  false,
+  0,
+  true,
+  "map",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "Mines", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _groupX = createGroup teamPlayer;
@@ -68,7 +80,7 @@ if ((_truckX distance _positionTel < 50) and ({alive _x} count units _groupX > 0
 	[petros,"hint",localize "STR_hints_build_minefield_engie_start"] remoteExec ["A3A_fnc_commsMP",[teamPlayer,civilian]];
 
 	[_groupX, "Patrol_Area", 25, 50, 100, true, _positionTel, true] call A3A_fnc_patrolLoop;
-	
+
 	sleep 30;
 	if ((alive _truckX) and ({alive _x} count units _groupX > 0)) then
 		{

--- a/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
+++ b/A3A/addons/core/functions/REINF/fn_buildMinefield.sqf
@@ -39,6 +39,11 @@ private _taskId = "Mines" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "Mines", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_A3A_reinf_minefield_task_desc",_quantity],
+    [ "STR_A3A_reinf_minefield_task_header"],
+    _mrk
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _groupX = createGroup teamPlayer;
 

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
@@ -18,7 +18,19 @@ _marker setMarkerShape "ICON";
 (45 call SCRT_fnc_misc_getTimeLimit) params ["_dateLimitNum", "_displayTime"];
 
 private _taskId = "outpostTask" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_aaempl_deploy_desc", _displayTime],localize "STR_aaempl_deploy_header",_marker],_position,false,0,true,"Move",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_aaempl_deploy_desc", _displayTime],
+    [ "STR_aaempl_deploy_header"],
+    _marker
+  ],
+  _position,
+  false,
+  0,
+  true,
+  "Move",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _formatX = A3A_faction_reb get "groupAaEmpl";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAa.sqf
@@ -32,6 +32,11 @@ private _taskId = "outpostTask" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_aaempl_deploy_desc", _displayTime],
+    [ "STR_aaempl_deploy_header"],
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _formatX = A3A_faction_reb get "groupAaEmpl";
 private _groupX = [["Synd_HQ"] call A3A_fnc_findAiSpawnPosition, teamPlayer, _formatX] call A3A_fnc_spawnGroup;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
@@ -18,7 +18,19 @@ _marker setMarkerShape "ICON";
 (45 call SCRT_fnc_misc_getTimeLimit) params ["_dateLimitNum", "_displayTime"];
 
 private _taskId = "outpostTask" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_atempl_deploy_desc", _displayTime],localize "STR_atempl_deploy_header",_marker],_position,false,0,true,"Move",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_atempl_deploy_desc", _displayTime],
+    [ "STR_atempl_deploy_header"],
+    _marker
+  ],
+  _position,
+  false,
+  0,
+  true,
+  "Move",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _formatX = A3A_faction_reb get "groupAtEmpl";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createAt.sqf
@@ -32,6 +32,11 @@ private _taskId = "outpostTask" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_atempl_deploy_desc", _displayTime],
+    [ "STR_atempl_deploy_header"],
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _formatX = A3A_faction_reb get "groupAtEmpl";
 private _groupX = [["Synd_HQ"] call A3A_fnc_findAiSpawnPosition, teamPlayer, _formatX] call A3A_fnc_spawnGroup;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
@@ -18,7 +18,19 @@ _marker setMarkerShape "ICON";
 (45 call SCRT_fnc_misc_getTimeLimit) params ["_dateLimitNum", "_displayTime"];
 
 private _taskId = "outpostTask" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_hmgempl_deploy_desc", _displayTime],localize "STR_hmgempl_deploy_header",_marker],_position,false,0,true,"Move",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_hmgempl_deploy_desc", _displayTime],
+    [ "STR_hmgempl_deploy_header"],
+    _marker
+  ],
+  _position,
+  false,
+  0,
+  true,
+  "Move",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _formatX = A3A_faction_reb get "groupHmgEmpl";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createHmg.sqf
@@ -32,6 +32,11 @@ private _taskId = "outpostTask" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_hmgempl_deploy_desc", _displayTime],
+    [ "STR_hmgempl_deploy_header"],
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _formatX = A3A_faction_reb get "groupHmgEmpl";
 private _groupX = [["Synd_HQ"] call A3A_fnc_findAiSpawnPosition, teamPlayer, _formatX] call A3A_fnc_spawnGroup;

--- a/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
@@ -18,7 +18,19 @@ _marker setMarkerShape "ICON";
 (45 call SCRT_fnc_misc_getTimeLimit) params ["_dateLimitNum", "_displayTime"];
 
 private _taskId = "outpostTask" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_roadblock_deploy_desc", _displayTime],localize "STR_roadblock_deploy_header",_marker],_position,false,0,true,"Move",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_roadblock_deploy_desc", _displayTime],
+    [ "STR_roadblock_deploy_header"],
+    _marker
+  ],
+  _position,
+  false,
+  0,
+  true,
+  "Move",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _riflemanType = A3A_faction_reb get "unitRifle";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createRoadblock.sqf
@@ -32,6 +32,11 @@ private _taskId = "outpostTask" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_roadblock_deploy_desc", _displayTime],
+    [ "STR_roadblock_deploy_header"],
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _riflemanType = A3A_faction_reb get "unitRifle";
 private _squadType = A3A_faction_reb get "groupSquad";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
@@ -18,7 +18,19 @@ _marker setMarkerShape "ICON";
 (45 call SCRT_fnc_misc_getTimeLimit) params ["_dateLimitNum", "_displayTime"];
 
 private _taskId = "outpostTask" + str A3A_taskCount;
-[[teamPlayer,civilian],_taskId,[format [localize "STR_watchpost_deploy_desc", _displayTime],localize "STR_watchpost_deploy_header",_marker],_position,false,0,true,"Move",true] call BIS_fnc_taskCreate;
+[ [teamPlayer,civilian],
+  _taskId,
+  [ [ "STR_watchpost_deploy_desc", _displayTime],
+    [ "STR_watchpost_deploy_header"],
+    _marker
+  ],
+  _position,
+  false,
+  0,
+  true,
+  "Move",
+  true
+  ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
 
 private _typeGroup = A3A_faction_reb get "groupSniper";

--- a/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
+++ b/A3A/addons/scrt/Outpost/fn_outpost_createWatchpost.sqf
@@ -32,6 +32,11 @@ private _taskId = "outpostTask" + str A3A_taskCount;
   true
   ] call BIS_fnc_taskCreate;
 [_taskId, "outpostTask", "CREATED"] remoteExecCall ["A3A_fnc_taskUpdate", 2];
+[ _taskId,
+  [ [ "STR_watchpost_deploy_desc", _displayTime],
+    [ "STR_watchpost_deploy_header"],
+    _marker
+  ]] remoteExec [ "A3A_fnc_localize_format_taskSetDescription", 0];
 
 private _typeGroup = A3A_faction_reb get "groupSniper";
 private _typeVehX = (A3A_faction_reb get "vehiclesBasic") select 0;


### PR DESCRIPTION
Server's locale is not always matching client's locale.

Instead of localizing descriptions and titles of the tasks on the server side, this PR:
1. using array of strings ready to be used to `localize` and `format`;
2. adds `A3A_fnc_localize_format_taskSetDescription` to be used on client side to deeply localize and format tasks' descriptions and titles and update the task with client's localized versions.


## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

accordingly to https://community.bistudio.com/wiki/BIS_fnc_taskCreate#Example_4 
 `BIS_fnc_taskCreate` is able to offload localization to the client side by providing array of string as a description.

```
in Stringtable.xml
<Key ID="STR_CITY_TASK">
	<English>Clear %1 of enemies</English>
	<!-- more languages -->
</Key>
SQF:

[
	_side,
	_taskID,
	[
		// format array, string to be localised, parameters for format %1, %2 ...
		[ "STR_CITY_TASK", _cityName ],
		[ "STR_CITY_TASK", _cityName ],
		""
	]
] call BIS_fnc_taskCreate;
```

**How can your changes be tested, or reproduced?**

1. Setup dedicated server;
4. connect client with locale1 (say English), wait for a mission and remember mission description language;
5. change client locale and reconnect, wait for a mission and remember mission description.

The expected result is that both languages will be different. Before change mission description will always be in server's language.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server. I override functions on my server to depend on steam version of Antistasi. I am not sure if `BIS_fnc_taskSetDescription` is local and unsure if clients with different locale can race and overwrite description for each others.

Is further work needed?

- [ ] Needs further testing. I haven't tested locality of `BIS_fnc_taskSetDescription` and behavior of clients with different locales.
- [x] Needs further changes. The only side effect is that city supply missions title contains reference to city name, which is not being localized by `BIS_fnc_taskCreate` while it is using title in "new mission" popup window. I propose to remove destination argument from `STR_A3A_Missions_SUPP_Supplies_task_header` to make it in-sync with other missions' titles (as they contain no destinations).
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #936 

## Notes

> ...