### PR TITLE
[ACEUnconscious] Fix undefined `_groupLeader` bug

### DIFF
--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -12,7 +12,7 @@ Info("initACEUnconsciousHandler started");
 
 ["ace_unconscious", {
 	params["_unit", "_knockout"];
-	private _group = _group;
+	private _group = group _unit;
 	private _unitIsLocal = local _unit;
 	private _groupIsLocal = local _group;
 	private _realSide = side _group;		// setUnconscious in ACE often breaks this otherwise

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -24,13 +24,29 @@ Info("initACEUnconsciousHandler started");
         // Pass group lead if unit is the leader
         if (_unit == _groupLeader) then
         {
-            private _index = (units (group _unit)) findIf {_x call A3A_fnc_canFight};
-            if(_index != -1) then {
-                group _unit selectLeader ((units group _unit) select _index);
+            private _allUnits = (units (group _unit)) select {_x call A3A_fnc_canFight};
 
-				// Save previous group leader
-				group _unit setVariable ["A3A_previousGroupLeader", _groupLeader, true];
-            };
+			// Ensure there are any units available to select
+			if (!isNil {_allUnits param [0]}) then {
+				private _playerUnits = _allUnits select {isPlayer _x};
+				private _newLeader = _playerUnits param [0];
+
+				// Check if there is an eligible player unit first
+				if (isNil "_newLeader") then {
+					private _aiUnits = _allUnits select {!isPlayer _x};
+
+					// If not select an AI unit
+					_newLeader = _aiUnits param [0];
+				};
+
+				// Should never be nil, but just in case
+				if (!isNil "_newLeader") then {
+					group _unit selectLeader _newLeader;
+
+					// Save previous group leader
+					group _unit setVariable ["A3A_previousGroupLeader", _groupLeader, true];
+				};
+			};
         };
 
 		if (_realSide == Occupants || _realSide == Invaders) then {

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -12,82 +12,93 @@ Info("initACEUnconsciousHandler started");
 
 ["ace_unconscious", {
 	params["_unit", "_knockout"];
-	if !(local _unit) exitWith {};				// handler runs everywhere, only process where unit is local
-	private _realSide = side group _unit;		// setUnconscious in ACE often breaks this otherwise
+	private _group = _group;
+	private _unitIsLocal = local _unit;
+	private _groupIsLocal = local _group;
+	private _realSide = side _group;		// setUnconscious in ACE often breaks this otherwise
 
 	if (_knockout) exitWith
 	{
-		_unit setVariable ["incapacitated", true, true];	// for canFight tests
+		if (_unitIsLocal) then {
+			_unit setVariable ["incapacitated", true, true];	// for canFight tests
+		};
 
-		private _groupLeader = leader (group _unit);
+		if (_groupIsLocal) then {
+			private _groupLeader = leader _group;
 
-        // Pass group lead if unit is the leader
-        if (_unit == _groupLeader) then
-        {
-            private _allUnits = (units (group _unit)) select {_x call A3A_fnc_canFight};
+			// Pass group lead if unit is the leader
+			if (_unit == _groupLeader) then
+			{
+				private _allUnits = (units _group) select {_x call A3A_fnc_canFight};
 
-			// Ensure there are any units available to select
-			if (!isNil {_allUnits param [0]}) then {
-				private _playerUnits = _allUnits select {isPlayer _x};
-				private _newLeader = _playerUnits param [0];
+				// Ensure there are any units available to select
+				if (!isNil {_allUnits param [0]}) then {
+					private _playerUnits = _allUnits select {isPlayer _x};
+					private _newLeader = _playerUnits param [0];
 
-				// Check if there is an eligible player unit first
-				if (isNil "_newLeader") then {
-					private _aiUnits = _allUnits select {!isPlayer _x};
+					// Check if there is an eligible player unit first
+					if (isNil "_newLeader") then {
+						private _aiUnits = _allUnits select {!isPlayer _x};
 
-					// If not select an AI unit
-					_newLeader = _aiUnits param [0];
-				};
+						// If not select an AI unit
+						_newLeader = _aiUnits param [0];
+					};
 
-				// Should never be nil, but just in case
-				if (!isNil "_newLeader") then {
-					[group _unit, _newLeader] remoteExec ["selectLeader", groupOwner group _unit];
+					// Should never be nil, but just in case
+					if (!isNil "_newLeader") then {
+						_group selectLeader _newLeader;
 
-					// Save previous group leader
-					group _unit setVariable ["A3A_previousGroupLeader", _groupLeader, true];
+						// Save previous group leader
+						_group setVariable ["A3A_previousGroupLeader", _groupLeader, true];
+					};
 				};
 			};
-        };
+		};
 
-		if (_realSide == Occupants || _realSide == Invaders) then {
-			[_unit, group _unit, _unit getVariable ["ace_medical_lastDamageSource", objNull]] spawn A3A_fnc_AIReactOnKill;
+		if (_unitIsLocal && (_realSide == Occupants || _realSide == Invaders)) then {
+			[_unit, _group, _unit getVariable ["ace_medical_lastDamageSource", objNull]] spawn A3A_fnc_AIReactOnKill;
 		};
 	};
 
 	// Unit woke up
-	_unit setVariable ["incapacitated", false, true];
-
-	private _previousGroupLeader = group _unit getVariable ["A3A_previousGroupLeader", objNull];
-
-	if !(_unit getVariable ["ACE_captives_isHandcuffed", false]) then {
-		_unit setCaptive false;			// match vanilla behaviour
+	if (_unitIsLocal) then {
+		_unit setVariable ["incapacitated", false, true];
 	};
 
-	if (_unit == _previousGroupLeader) then {
-		group _unit selectLeader _unit;
-		group _unit setVariable ["A3A_previousGroupLeader", nil, true];
-	};
-	
-	if (isPlayer _unit) exitWith {};					// don't force surrender with players
-	if (_realSide != Occupants && _realSide != Invaders) exitWith {};
-	if (_unit getVariable ["surrendered", false]) exitWith {};		// don't surrender twice
+	if (_groupIsLocal) then {
+		private _previousGroupLeader = _group getVariable ["A3A_previousGroupLeader", objNull];
 
-	// surrender if we don't have a primary weapon
-	if (primaryWeapon _unit == "") exitWith { [_unit] spawn A3A_fnc_surrenderAction };
-
-	// find closest fighting unit within 50m
-	private _nearestUnit = objNull;
-	private _minDist = 999;
-	{
-		private _dist = _x distance _unit;
-		if (side _x != civilian && _x != _unit && _dist < _minDist && {_x call A3A_fnc_canFight}) then {
-			_minDist = _dist;
-			_nearestUnit = _x;
+		if (_unit == _previousGroupLeader) then {
+			_group selectLeader _unit;
+			_group setVariable ["A3A_previousGroupLeader", nil, true];
 		};
-	} forEach (_unit nearEntities ["Man", 50]);
+	};
 
-	if (side _nearestUnit == teamPlayer) then { [_unit] spawn A3A_fnc_surrenderAction };
+	if (_unitIsLocal) then {
+		if !(_unit getVariable ["ACE_captives_isHandcuffed", false]) then {
+			_unit setCaptive false;			// match vanilla behaviour
+		};
+		
+		if (isPlayer _unit) exitWith {};					// don't force surrender with players
+		if (_realSide != Occupants && _realSide != Invaders) exitWith {};
+		if (_unit getVariable ["surrendered", false]) exitWith {};		// don't surrender twice
 
+		// surrender if we don't have a primary weapon
+		if (primaryWeapon _unit == "") exitWith { [_unit] spawn A3A_fnc_surrenderAction };
+
+		// find closest fighting unit within 50m
+		private _nearestUnit = objNull;
+		private _minDist = 999;
+		{
+			private _dist = _x distance _unit;
+			if (side _x != civilian && _x != _unit && _dist < _minDist && {_x call A3A_fnc_canFight}) then {
+				_minDist = _dist;
+				_nearestUnit = _x;
+			};
+		} forEach (_unit nearEntities ["Man", 50]);
+
+		if (side _nearestUnit == teamPlayer) then { [_unit] spawn A3A_fnc_surrenderAction };
+	};
 }] call CBA_fnc_addEventHandler;
 
 Info("initACEUnconsciousHandler completed");

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -15,11 +15,11 @@ Info("initACEUnconsciousHandler started");
 	if !(local _unit) exitWith {};				// handler runs everywhere, only process where unit is local
 	private _realSide = side group _unit;		// setUnconscious in ACE often breaks this otherwise
 
+	private _groupLeader = leader (group _unit);
+
 	if (_knockout) exitWith
 	{
 		_unit setVariable ["incapacitated", true, true];	// for canFight tests
-
-	_groupLeader = leader (group _unit);
 
         // Pass group lead if unit is the leader
         if (_unit == leader (group _unit)) then

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -22,7 +22,7 @@ Info("initACEUnconsciousHandler started");
 		_unit setVariable ["incapacitated", true, true];	// for canFight tests
 
         // Pass group lead if unit is the leader
-        if (_unit == leader (group _unit)) then
+        if (_unit == _groupLeader) then
         {
             private _index = (units (group _unit)) findIf {_x call A3A_fnc_canFight};
             if(_index != -1) then {

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -41,7 +41,7 @@ Info("initACEUnconsciousHandler started");
 
 				// Should never be nil, but just in case
 				if (!isNil "_newLeader") then {
-					group _unit selectLeader _newLeader;
+					[group _unit, _newLeader] remoteExec ["selectLeader", groupOwner group _unit];
 
 					// Save previous group leader
 					group _unit setVariable ["A3A_previousGroupLeader", _groupLeader, true];

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -32,7 +32,7 @@ Info("initACEUnconsciousHandler started");
 				private _allUnits = (units _group) select {_x call A3A_fnc_canFight};
 
 				// Ensure there are any units available to select
-				if (!isNil {_allUnits param [0]}) then {
+				if (_allUnits isNotEqualTo []) then {
 					private _playerUnits = _allUnits select {isPlayer _x};
 					private _newLeader = _playerUnits param [0];
 

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -55,7 +55,7 @@ Info("initACEUnconsciousHandler started");
 			};
 		};
 
-		if (_unitIsLocal && (_realSide == Occupants || _realSide == Invaders)) then {
+		if (_unitIsLocal && { _realSide in [Occupants, Invaders] }) then {
 			[_unit, _group, _unit getVariable ["ace_medical_lastDamageSource", objNull]] spawn A3A_fnc_AIReactOnKill;
 		};
 	};

--- a/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
+++ b/A3A/addons/core/functions/init/fn_initACEUnconsciousHandler.sqf
@@ -15,11 +15,11 @@ Info("initACEUnconsciousHandler started");
 	if !(local _unit) exitWith {};				// handler runs everywhere, only process where unit is local
 	private _realSide = side group _unit;		// setUnconscious in ACE often breaks this otherwise
 
-	private _groupLeader = leader (group _unit);
-
 	if (_knockout) exitWith
 	{
 		_unit setVariable ["incapacitated", true, true];	// for canFight tests
+
+		private _groupLeader = leader (group _unit);
 
         // Pass group lead if unit is the leader
         if (_unit == _groupLeader) then
@@ -27,6 +27,9 @@ Info("initACEUnconsciousHandler started");
             private _index = (units (group _unit)) findIf {_x call A3A_fnc_canFight};
             if(_index != -1) then {
                 group _unit selectLeader ((units group _unit) select _index);
+
+				// Save previous group leader
+				group _unit setVariable ["A3A_previousGroupLeader", _groupLeader, true];
             };
         };
 
@@ -38,12 +41,15 @@ Info("initACEUnconsciousHandler started");
 	// Unit woke up
 	_unit setVariable ["incapacitated", false, true];
 
+	private _previousGroupLeader = group _unit getVariable ["A3A_previousGroupLeader", objNull];
+
 	if !(_unit getVariable ["ACE_captives_isHandcuffed", false]) then {
 		_unit setCaptive false;			// match vanilla behaviour
 	};
 
-	if (_unit == _groupLeader) then {
+	if (_unit == _previousGroupLeader) then {
 		group _unit selectLeader _unit;
+		group _unit setVariable ["A3A_previousGroupLeader", nil, true];
 	};
 	
 	if (isPlayer _unit) exitWith {};					// don't force surrender with players


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> When group leaders would go unconscious and wake back up an error would occur: `File x\A3A\addons\core\functions\init\fn_initACEUnconsciousHandler.sqf..., line 44`. This is because `_groupLeader` was only defined in the knockout, not for the above scope, where it is used to transfer the group back to the previous leader.
> 
> This change also makes the system prefer human players over AI for squad lead selection.

**How can your changes be tested, or reproduced?**

> Best tested with 2 human players, but can be done with an AI in your group 
1. Join the same group
2. Have the leader go unconscious
3. Leadership should be transferred to the other unit
  3a. If the other unit is a player they should gain control over AI units in your squad
5. Wake up the previous leader
6. Leadership should transfer back properly to the previous leader

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...