### PR TITLE
Fix: Cosmetic CBA setting

### DIFF
--- a/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
+++ b/A3A/addons/core/functions/Ammunition/fn_equipmentSort.sqf
@@ -148,7 +148,7 @@ if ("specialVN" in A3A_factionEquipFlags) then {
 	];
 };
 
-if ((missionNamespace getVariable ["A3U_setting_enableCosmetics", false] isEqualTo false) || {cosmeticsEnabled isEqualTo false}) then {
+if (cosmeticsEnabled isEqualTo false) then {
 	allCosmeticGlasses = [];
 	allCosmeticHeadgear = [];
 }; // It's annoying in some modsets (like halo or clone wars) to have a ton of modern cosmetic gear.


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> A3U_setting_enableCosmetics was removed, default now evaluates to false breaking cosmetics

**How can your changes be tested, or reproduced?**

> ...

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...