### PR TITLE
Fix: RP travel number

### DIFF
--- a/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
@@ -166,7 +166,8 @@ private _markerTitle = call {
     if (_isTraderMarker) exitWith { localize "STR_A3U_HOVER_BLACK_MARKET" };
     if (_originalName in citiesX) exitWith { markerText _originalName };
     
-    if (_isRallyPointMarker) exitWith { format [localize "STR_marker_RP", str RETDEF(rallyPointSpawnCount,0)] };
+    // FETCH LIVE SPAWN COUNT FROM NAMESPACE
+    if (_isRallyPointMarker) exitWith { format [localize "STR_marker_RP", str (missionNamespace getVariable ["rallyPointSpawnCount", 0])] };
     
     if (_isMilAdmin) exitWith { format [localize "STR_milAdministration", _nearestCityName] };
     if (_originalName in mrkAntennas) exitWith { format [localize "STR_radiotower", _nearestCityName] };
@@ -296,8 +297,10 @@ private _specialDefinitions = [
     };
     
     private _specFlag = if (_specFlagOverride != "") then {_specFlagOverride} else {_specFaction getOrDefault ["flagMarkerType", ""]};
+    
+    // FETCH LIVE SPAWN COUNT FROM NAMESPACE FOR SPECIAL DEFS
     private _specTitle = if (_specTitleLoc == "STR_marker_RP") then {
-        format [localize _specTitleLoc, if (isNil "rallyPointSpawnCount") then {"0"} else {str rallyPointSpawnCount}]
+        format [localize _specTitleLoc, str (missionNamespace getVariable ["rallyPointSpawnCount", 0])]
     } else {
         format [localize _specTitleLoc, _specFaction getOrDefault ["name", ""]]
     };
@@ -316,7 +319,8 @@ private _isUISilentUpdate = missionNamespace getVariable ["A3U_suppressNetworkFo
 if (!_isUISilentUpdate) then {
     [_hoverMarkers] remoteExecCall ["A3U_fnc_handleMrkUpdate", 2]; 
 
-    if (A3AU_setting_alwaysShowMarkerName || {_originalName in (airportsX + milbases)}) then {
+    // ENFORCE VISIBILITY RULE: HQ, Trader, and Rally Points always show text labels
+    if (A3AU_setting_alwaysShowMarkerName || {_originalName in (airportsX + milbases)} || {_isSyndicateHeadquarters} || {_isTraderMarker} || {_isRallyPointMarker}) then {
         _visibleMarkerName setMarkerText _markerLabelOnly;
     } else {
         _visibleMarkerName setMarkerText "";

--- a/A3A/addons/scrt/Rally/fn_rally_placeRallyPoint.sqf
+++ b/A3A/addons/scrt/Rally/fn_rally_placeRallyPoint.sqf
@@ -53,7 +53,7 @@ rallyPointMarker setMarkerAlpha 1;
 sidesX setVariable [rallyPointMarker,teamPlayer,true];
 publicVariable "rallyPointMarker";
 
-[rallyPointMarker] remoteExec ["A3A_fnc_mrkUpdate", 0, true];
+[rallyPointMarker] call A3A_fnc_mrkUpdate;
 
 rallyProps append [_backpack1, _backpack2, _bag, _ammobox];
 publicVariable "rallyProps";

--- a/A3A/addons/scrt/Rally/fn_rally_travelToRallyPoint.sqf
+++ b/A3A/addons/scrt/Rally/fn_rally_travelToRallyPoint.sqf
@@ -72,9 +72,11 @@ while {_timePassed < _distanceX} do {
 disableUserInput false;
 cutText [localize "STR_cut_RP_FT_success", "BLACK IN", 1];
 
-private _remainingTravels = _remainingTravels - 1;
+// Update both variables and trigger the universal map UI refresh
+_remainingTravels = _remainingTravels - 1;
 rallyPointRoot setVariable ["remainingTravels", _remainingTravels, true];
-rallyPointMarker setMarkerText (format [localize "STR_marker_RP", str _remainingTravels]);
+missionNamespace setVariable ["rallyPointSpawnCount", _remainingTravels, true];
+
 [rallyPointMarker] call A3A_fnc_mrkUpdate;
 
 if (_remainingTravels < 1) then {


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> fixed an issue where rally point marker doesnt show the correct travels remaining on rally points

**How can your changes be tested, or reproduced?**

> place rally point using any rally point travel amounts (set in the parameters) and open the map to check if its updated both inside the context menu and the text connected to the marker.

**Does this PR include changes not authored by you?**

- [ ] No
- [x] Yes (See below)

***If yes:***

- [x] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...