### PR TITLE
Allow for copy/pasting loadouts

### DIFF
--- a/A3A/addons/scrt/Stringtable.xml
+++ b/A3A/addons/scrt/Stringtable.xml
@@ -11207,6 +11207,46 @@
                 <French>Réinitialise l'équipement à l'état aléatoire par défaut.</French>
                 <Turkish>Sınıf teçhizatını varsayılan, rastgele duruma sıfırlar.</Turkish>
             </Key>
+            <Key ID="STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_tooltip">
+                <Original>Resets class loadout to default, copy loadout with Shift pressed, paste loadout with Ctrl pressed.</Original>
+                <Russian>Сбрасывает снаряжение класса до стандартного состояния, копирует снаряжение при нажатом Shift, вставляет снаряжение при нажатом Ctrl.</Russian>
+                <Chinesesimp>将职业装备重置为默认状态，按住Shift键复制装备，按住Ctrl键粘贴装备。</Chinesesimp>
+                <Korean>병과 로드아웃을 기본 상태로 재설정하고 Shift를 누른 상태에서 로드아웃을 복사하고 Ctrl을 누른 상태에서 로드아웃을 붙여넣습니다.</Korean>
+                <French>Réinitialise l'équipement à l'état par défaut, copie l'équipement avec Shift enfoncé, colle l'équipement avec Ctrl enfoncé.</French>
+                <Turkish>Sınıf teçhizatını varsayılan duruma sıfırlar, Shift basılıyken teçhizatı kopyalar, Ctrl basılıyken teçhizatı yapıştırır.</Turkish>
+            </Key>
+            <Key ID="STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_copied">
+                <Original>Loadout for "%1" copied.</Original>
+                <Russian>Снаряжение для "%1" скопировано.</Russian>
+                <Chinesesimp>已复制“%1”的装载</Chinesesimp>
+                <Korean>"%1" 병과 로드아웃이 복사되었습니다.</Korean>
+                <French>L'équipement pour "%1" a été copié.</French>
+                <Turkish>"%1" sınıf teçhizatı kopyalandı.</Turkish>
+            </Key>
+            <Key ID="STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_no_loadout_configured">
+                <Original>No loadout configured to copy.</Original>
+                <Russian>Нет снаряжения для копирования.</Russian>
+                <Chinesesimp>没有配置的装载可供复制</Chinesesimp>
+                <Korean>복사할 구성된 로드아웃이 없습니다.</Korean>
+                <French>Aucun équipement configuré à copier.</French>
+                <Turkish>Kopyalanacak teçhizat yapılandırılmamış.</Turkish>
+            </Key>
+            <Key ID="STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_no_loadout_stored">
+                <Original>No loadout stored to paste.</Original>
+                <Russian>Нет сохранённого снаряжения для вставки.</Russian>
+                <Chinesesimp>没有存储的装载可供粘贴</Chinesesimp>
+                <Korean>붙여넣을 저장된 로드아웃이 없습니다.</Korean>
+                <French>Aucun équipement enregistré à coller.</French>
+                <Turkish>Yapıştırmak için kaydedilmiş teçhizat yok.</Turkish>
+            </Key>
+            <Key ID="STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_pasted">
+                <Original>Copied loadout pasted into "%1" class loadout.</Original>
+                <Russian>Скопированное снаряжение вставлено в снаряжение класса "%1".</Russian>
+                <Chinesesimp>已将复制的装载粘贴到“%1”职业装载中</Chinesesimp>
+                <Korean>복사된 로드아웃이 "%1" 병과 로드아웃에 붙여넣어졌습니다.</Korean>
+                <French>L'équipement copié a été collé dans l'équipement de la classe "%1".</French>
+                <Turkish>Kopyalanan teçhizat "%1" sınıf teçhizatına yapıştırıldı.</Turkish>
+            </Key>
             <Key ID="STR_antistasi_dialogs_hq_button_rebel_set_loadout_button_tooltip">
                 <Original>Opens Arsenal with the current class loadout. To save custom loadout, press SAVE in Arsenal.</Original>
                 <Russian>Открывает арсенал для этого класса повстанцев. Для сохранения снаряжения, нажмите в арсенале СОХРАНИТЬ.</Russian>

--- a/A3A/addons/scrt/UI/fn_ui_createRebelLoadoutMenu.sqf
+++ b/A3A/addons/scrt/UI/fn_ui_createRebelLoadoutMenu.sqf
@@ -1,59 +1,95 @@
-createDialog 'rebelLoadoutMenu';
+#include "..\script_component.hpp"
 
-private _addLoadoutMark = {
-    params ["_control"];
-    private _oldText = ctrlText _control;
-    _control ctrlSetText format ["%1 %2", _oldText, "[x]"];
+createDialog "rebelLoadoutMenu";
+
+private _config = configFile >> "rebelLoadoutMenu";
+private _idd = getNumber(_config >> "idd");
+private _display = findDisplay _idd;
+
+if (isNull _display) exitWith {};
+
+_display setVariable[QGVAR(loadoutCopy), nil];
+uiNamespace setVariable[QGVAR(rebelLoadoutMenuDisplay), _display];
+
+QUOTE(isText(_x >> QQUOTE(loadoutMoniker))) configClasses(_config >> "Controls") apply {
+    private _loadoutMoniker = getText(_x >> "loadoutMoniker");
+    private _textControl = _display displayCtrl getNumber(_x >> "idc");
+    private _arsenalButtonControl = _display displayCtrl getNumber(_x >> "loadoutArsenalButtonIDC");
+    private _resetButtonControl = _display displayCtrl getNumber(_x >> "loadoutResetButtonIDC");
+
+    // add mark if loadout has been set before
+    if (A3A_faction_reb get _loadoutMoniker in rebelLoadouts) then {
+        _textControl ctrlSetText format["%1 [x]", ctrlText _textControl];
+        _textControl setVariable[QGVAR(hasLoadout), true];
+    };
+
+    // arsenal button action
+    _arsenalButtonControl setVariable["loadoutMoniker", _loadoutMoniker];
+    _arsenalButtonControl ctrlAddEventHandler["ButtonClick", {
+        if !assert(params[["_control", nil, [controlNull]]]) exitWith {};
+        private _moniker = _control getVariable "loadoutMoniker";
+
+        currentRebelLoadout = A3A_faction_reb get _moniker;
+        [] call JN_fnc_arsenal_handleAction;
+    }];
+
+    // copy, paste, reset button action
+    _resetButtonControl setVariable["textControl", _textControl];
+    _resetButtonControl setVariable["loadoutMoniker", _loadoutMoniker];
+    _resetButtonControl ctrlAddEventHandler["MouseButtonClick", {
+        if !assert(params[
+            ["_control", nil, [controlNull]],
+            ["_button", nil, [0]],
+            "", // _xPos
+            "", // _yPos
+            ["_shift", nil, [false]],
+            ["_ctrl", nil, [false]],
+            ["_alt", nil, [false]]
+        ]) exitWith {};
+
+        private _display = uiNamespace getVariable QGVAR(rebelLoadoutMenuDisplay);
+        private _moniker = _control getVariable "loadoutMoniker";
+
+        switch true do {
+            case (_button isNotEqualTo 0);
+            case (_alt);
+            case (_ctrl && _shift): {
+                // do nothing for non-left clicks, alt presses or combined ctrl+shift presses
+            };
+            case (_ctrl): { // paste loadout
+                if (isNil {_display getVariable QGVAR(loadoutCopy)}) exitWith {
+                    playSound "A3AP_UiFailure";
+                    systemChat localize "STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_no_loadout_stored";
+                };
+
+                rebelLoadouts set[A3A_faction_reb get _moniker, _display getVariable QGVAR(loadoutCopy)];
+
+                private _textControl = _control getVariable "textControl";
+
+                if !(_textControl getVariable[QGVAR(hasLoadout), false]) then {
+                    _textControl setVariable[QGVAR(hasLoadout), true];
+                    _textControl ctrlSetText format["%1 [x]", ctrlText _textControl];
+                };
+
+        		playSound "A3AP_UiSuccess";
+                systemChat format[localize "STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_pasted", A3A_faction_reb get _moniker];
+            };
+            case (_shift): { // copy loadout
+                if !(A3A_faction_reb get _moniker in rebelLoadouts) exitWith {
+                    playSound "A3AP_UiFailure";
+                    systemChat localize "STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_no_loadout_configured";
+                };
+
+                _display setVariable[QGVAR(loadoutCopy), +(rebelLoadouts get(A3A_faction_reb get _moniker))];
+
+                playSound "A3AP_UiSuccess";
+                systemChat format[localize "STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_copied", A3A_faction_reb get _moniker];
+            };
+            default {
+                (A3A_faction_reb get _moniker) call SCRT_fnc_arsenal_clearLoadout;
+            };
+        };
+    }];
 };
 
-private _display = findDisplay 120000;
-
-if (str (_display) != "no display") then {
-    if ((A3A_faction_reb get "unitRifle") in rebelLoadouts) then {
-        [(_display displayCtrl 120001)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitMG") in rebelLoadouts) then {
-        [(_display displayCtrl 120002)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitMedic") in rebelLoadouts) then {
-       [(_display displayCtrl 120003)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitEng") in rebelLoadouts) then {
-        [(_display displayCtrl 120004)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitGL") in rebelLoadouts) then {
-        [(_display displayCtrl 120005)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitSniper") in rebelLoadouts) then {
-        [(_display displayCtrl 120006)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitLAT") in rebelLoadouts) then {
-        [(_display displayCtrl 120007)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitCrew") in rebelLoadouts) then {
-        [(_display displayCtrl 120008)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitSL") in rebelLoadouts) then {
-        [(_display displayCtrl 120009)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitExp") in rebelLoadouts) then {
-        [(_display displayCtrl 120010)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitAT") in rebelLoadouts) then {
-        [(_display displayCtrl 120011)] call _addLoadoutMark;
-    };
-
-    if ((A3A_faction_reb get "unitAA") in rebelLoadouts) then {
-        [(_display displayCtrl 120012)] call _addLoadoutMark;
-    };
-};
+nil;

--- a/A3A/addons/scrt/UILayouts/menu.hpp
+++ b/A3A/addons/scrt/UILayouts/menu.hpp
@@ -1370,6 +1370,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.258 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitRifle";
+			loadoutArsenalButtonIDC = 1200101;
+			loadoutResetButtonIDC = 1200201;
 		};
 
 		class l2Text: SimpleText
@@ -1380,6 +1383,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.291 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitMG";
+			loadoutArsenalButtonIDC = 1200102;
+			loadoutResetButtonIDC = 1200202;
 		};
 
 		class l3Text: SimpleText
@@ -1390,6 +1396,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.324 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitMedic";
+			loadoutArsenalButtonIDC = 1200103;
+			loadoutResetButtonIDC = 1200203;
 		};
 
 		class l4Text: SimpleText
@@ -1400,6 +1409,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.357 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitEng";
+			loadoutArsenalButtonIDC = 1200104;
+			loadoutResetButtonIDC = 1200204;
 		};
 
 		class l5Text: SimpleText
@@ -1410,6 +1422,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.39 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitGL";
+			loadoutArsenalButtonIDC = 1200105;
+			loadoutResetButtonIDC = 1200205;
 		};
 
 		class l6Text: SimpleText
@@ -1420,6 +1435,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.423 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitSniper";
+			loadoutArsenalButtonIDC = 1200106;
+			loadoutResetButtonIDC = 1200206;
 		};
 
 		class l7Text: SimpleText
@@ -1430,6 +1448,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.456 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitLAT";
+			loadoutArsenalButtonIDC = 1200107;
+			loadoutResetButtonIDC = 1200207;
 		};
 
 		class l8Text: SimpleText
@@ -1440,6 +1461,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.489 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitCrew";
+			loadoutArsenalButtonIDC = 1200108;
+			loadoutResetButtonIDC = 1200208;
 		};
 
 		class l9Text: SimpleText
@@ -1450,6 +1474,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.522 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitSL";
+			loadoutArsenalButtonIDC = 1200109;
+			loadoutResetButtonIDC = 1200209;
 		};
 
 		class l10Text: SimpleText
@@ -1460,6 +1487,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.555 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitExp";
+			loadoutArsenalButtonIDC = 1200110;
+			loadoutResetButtonIDC = 1200210;
 		};
 
 		class l11Text: SimpleText
@@ -1470,6 +1500,9 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.588 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitAT";
+			loadoutArsenalButtonIDC = 1200111;
+			loadoutResetButtonIDC = 1200211;
 		};
 
 		class l12Text: SimpleText
@@ -1480,246 +1513,225 @@ class rebelLoadoutMenu: SimpleMenuMedium
 			y = 0.621 * safezoneH + safezoneY;
 			w = 0.0773437 * safezoneW;	
 			h = 0.022 * safezoneH;
+			loadoutMoniker = "unitAA";
+			loadoutArsenalButtonIDC = 1200112;
+			loadoutResetButtonIDC = 1200212;
 		};
 
 		class l1ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200101;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.258 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitRifle'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l1ResetButton: ResetButton
+		class l1ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200201;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.258 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitRifle') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l2ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200102;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.291 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitMG'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l2ResetButton: ResetButton
+		class l2ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200202;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.291 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitMG') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l3ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200103;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.324 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitMedic'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l3ResetButton: ResetButton
+		class l3ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200203;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.324 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitMedic') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l4ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200104;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.357 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitEng'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l4ResetButton: ResetButton
+		class l4ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200204;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.357 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitEng') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 		
 		class l5ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200105;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.39 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitGL'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l5ResetButton: ResetButton
+		class l5ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200205;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.39 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitGL') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l6ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200106;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.423 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitSniper'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l6ResetButton: ResetButton
+		class l6ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200206;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.423 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitSniper') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l7ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200107;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.456 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitLAT'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l7ResetButton: ResetButton
+		class l7ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200207;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.456 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitLAT') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l8ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200108;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.489 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitCrew'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l8ResetButton: ResetButton
+		class l8ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200208;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.489 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitCrew') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l9ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200109;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.522 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitSL'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l9ResetButton: ResetButton
+		class l9ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200209;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.522 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitSL') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l10ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200110;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.555 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitExp'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l10ResetButton: ResetButton
+		class l10ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200210;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.555 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitExp') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l11ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200111;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.588 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitAT'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l11ResetButton: ResetButton
+		class l11ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200211;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.588 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitAT') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 
 		class l12ArsenalButton: ArsenalButton
 		{
-			idc = -1;
+			idc = 1200112;
 			x = 0.54125 * safezoneW + safezoneX;
 			y = 0.621 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "currentRebelLoadout = A3A_faction_reb get 'unitAA'; [] call JN_fnc_arsenal_handleAction;";
 		};
 
-		class l12ResetButton: ResetButton
+		class l12ResetButton: CopyPasteResetButton
 		{
-			idc = -1;
+			idc = 1200212;
 			x = 0.561875 * safezoneW + safezoneX;
 			y = 0.621 * safezoneH + safezoneY;
 			w = 0.0103125 * safezoneW;
 			h = 0.022 * safezoneH;
-			action = "(A3A_faction_reb get 'unitAA') call SCRT_fnc_arsenal_clearLoadout;";
 		};
 	};
 };

--- a/A3A/addons/scrt/defines.hpp
+++ b/A3A/addons/scrt/defines.hpp
@@ -927,6 +927,11 @@ class ResetButton : ScrtRscSimpleMenuButton
 	tooltip = $STR_antistasi_dialogs_hq_button_rebel_reset_button_tooltip;
 };
 
+class CopyPasteResetButton : ResetButton
+{
+	tooltip = $STR_antistasi_dialogs_hq_button_rebel_copy_paste_reset_combo_button_tooltip;
+};
+
 class SimpleMenu
 {
 	movingenable=false;


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [X] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Add functionality to rebel loadouts menu to copy/paste loadouts across classes.
>
> This PR is best viewed in side-by-side mode rather than the unified diff.

**How can your changes be tested, or reproduced?**

> (Also explained in the reset button hover text)
>
> 1. Open rebel loadout menu
> 2. Shift+Click reset button to copy loadout
> 3. Ctrl+Click reset button to paste loadout into other class

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.
- [X] Maybe a better icon to indicate copy/paste possibility but I suck at gfx.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
