### PR TITLE
AI don't mount locked or unarmed vehicles

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -123,6 +123,7 @@ class CfgFunctions
             class blackout {};
             class buildHQ {};
             class calculateAggression {};
+            class canAIMountVehicle {};
             class canMoveHQ {};
             class chooseAttack {};
             class citiesToCivPatrol {};

--- a/A3A/addons/core/functions/Base/fn_canAIMountVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_canAIMountVehicle.sqf
@@ -1,4 +1,5 @@
 #include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
 /* ----------------------------------------------------------------------------
 Function: A3A_fnc_canAIMountVehicle
 
@@ -32,7 +33,7 @@ Author:
     UnseenKill/gor3Splatter
 ---------------------------------------------------------------------------- */
 if !assert(params[
-    ["_vehicle", nil, objNull]
+    ["_vehicle", nil, [objNull]]
 ]) exitWith { false };
 
 private _requireAIFlagSet = param[1, false, [true]];

--- a/A3A/addons/core/functions/Base/fn_canAIMountVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_canAIMountVehicle.sqf
@@ -1,0 +1,59 @@
+#include "..\..\script_component.hpp"
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_canAIMountVehicle
+
+Description:
+    Determine whether a vehicle can be mounted by AI.
+    
+    Checks for locked status (physical & AI-flag), actual availability of
+    turrets, etc.
+
+Parameters:
+    0: _vehicle - the vehicle to check <OBJECT>
+
+Optional:
+    1: _requireAIFlagSet - override vehicle's AI flag should to match this (default: false) <BOOL>
+
+Example:
+    (begin example)
+    // Basic check
+    [objectParent player] call A3A_fnc_canAIMountVehicle;
+    // Override AI flag requirement; vehicle must be locked for AI
+    [objectParent player, true] call A3A_fnc_canAIMountVehicle;
+    (end example)
+
+Returns:
+    Whether or not AI may mount this vehicle <BOOL>
+
+Environment:
+    Client/Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+if !assert(params[
+    ["_vehicle", nil, objNull]
+]) exitWith { false };
+
+private _requireAIFlagSet = param[1, false, [true]];
+
+if (
+    (locked _vehicle >= 2) || 
+    { !isNull attachedTo _vehicle } ||
+    { _vehicle getVariable["ownerSide", teamPlayer] isNotEqualTo teamPlayer } ||
+    { _vehicle getVariable["lockedForAI", false] isNotEqualTo _requireAIFlagSet }
+) exitWith { false };
+
+// Only evaluate this once since the condition is used in user actions and runs
+// every frame.
+if (isNil { _vehicle getVariable QGVAR(aiMountHasTurrets) }) then {
+    // Check if there's a gunner or turret role available for AI to mount
+    private _hasTurrets = fullCrew[_vehicle, "", true] findIf {
+        _x params["", "_role"];
+        _role in["gunner", "turret"];
+    } isNotEqualTo -1;
+
+    _vehicle setVariable[QGVAR(aiMountHasTurrets), _hasTurrets];
+};
+
+_vehicle getVariable QGVAR(aiMountHasTurrets);

--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -309,7 +309,7 @@ switch _typeX do
         _flag addAction [localize "STR_antistasi_actions_move_static_prevent_ai", A3A_fnc_lockStatic, nil, 1, false, true, "", VEHICLE_STATIC_COND(false), 4];
         _flag addAction [localize "STR_antistasi_actions_move_this_asset", A3A_fnc_carryItem, nil, 1.5, false, true, "", QUOTE(
             (isPlayer _this) && {isNull objectParent _this} && {_this call A3A_fnc_isMember} &&
-            {_target getVariable ['ownerSide', teamPlayer] == teamPlayer} && {locked _target < 2} && {isNull attachedTo _target} &&
+            {_target getVariable[ARR_2(QQUOTE(ownerSide),teamPlayer)] == teamPlayer} && {locked _target < 2} && {isNull attachedTo _target} &&
             {crew _target isEqualTo []} && {!(call A3A_fnc_isCarrying)}
         ), 4];
     };

--- a/A3A/addons/core/functions/Base/fn_flagaction.sqf
+++ b/A3A/addons/core/functions/Base/fn_flagaction.sqf
@@ -300,20 +300,26 @@ switch _typeX do
     {
         _flag addAction [localize "STR_antistasi_actions_move_static_weapon_emplacement", SCRT_fnc_common_moveOutpostStatic, nil, 4, true, false, "", "isPlayer _this", 4];
     };
+
+    #define VEHICLE_STATIC_COND(aiFlagVar1) \
+        QUOTE((isPlayer _this) && {isNull objectParent _this} && {_this call A3A_fnc_isMember} && {[ARR_2(_target,aiFlagVar1)] call A3A_fnc_canAIMountVehicle})
     case "static":
     {
-        private _cond = "(isPlayer _this) && {isNull objectParent _this} && {_target getVariable ['ownerSide', teamPlayer] == teamPlayer} && {locked _target < 2} && {isNull attachedTo _target} && {_this call A3A_fnc_isMember} && ";
-        _flag addAction [localize "STR_antistasi_actions_move_static_allow_ai", A3A_fnc_unlockStatic, nil, 1, false, true, "", _cond+"{!isNil {_target getVariable 'lockedForAI'}}", 4];
-        _flag addAction [localize "STR_antistasi_actions_move_static_prevent_ai", A3A_fnc_lockStatic, nil, 1, false, true, "", _cond+"{isNil {_target getVariable 'lockedForAI'}}", 4];
-    //    _flag addAction [localize "STR_antistasi_actions_move_static_kick_ai", A3A_fnc_lockStatic, nil, 1, true, false, "", _cond+"isNil {_target getVariable 'lockedForAI'} and !(isNull gunner _target) and !(isPlayer gunner _target)}", 4];
-        _flag addAction [localize "STR_antistasi_actions_move_this_asset", A3A_fnc_carryItem, nil, 1.5, false, true, "",  _cond+"{crew _target isEqualTo []} && {!(call A3A_fnc_isCarrying)}", 4];
+        _flag addAction [localize "STR_antistasi_actions_move_static_allow_ai", A3A_fnc_unlockStatic, nil, 1, false, true, "", VEHICLE_STATIC_COND(true), 4];
+        _flag addAction [localize "STR_antistasi_actions_move_static_prevent_ai", A3A_fnc_lockStatic, nil, 1, false, true, "", VEHICLE_STATIC_COND(false), 4];
+        _flag addAction [localize "STR_antistasi_actions_move_this_asset", A3A_fnc_carryItem, nil, 1.5, false, true, "", QUOTE(
+            (isPlayer _this) && {isNull objectParent _this} && {_this call A3A_fnc_isMember} &&
+            {_target getVariable ['ownerSide', teamPlayer] == teamPlayer} && {locked _target < 2} && {isNull attachedTo _target} &&
+            {crew _target isEqualTo []} && {!(call A3A_fnc_isCarrying)}
+        ), 4];
     };
     case "vehiclestatic":
     {
-        private _cond = "(_target getVariable ['ownerSide', teamPlayer] == teamPlayer) && {locked _target < 2} && {isNull attachedTo _target} && {_this call A3A_fnc_isMember} && ";
-        _flag addAction [localize "STR_antistasi_actions_move_vehicle_allow_ai", A3A_fnc_unlockStatic, nil, 1, false, true, "", _cond+"{!isNil {_target getVariable 'lockedForAI'}}", 4];
-        _flag addAction [localize "STR_antistasi_actions_move_vehicle_prevent_ai", A3A_fnc_lockStatic, nil, 1, false, true, "", _cond+"{isNil {_target getVariable 'lockedForAI'}}", 4];
+        _flag addAction [localize "STR_antistasi_actions_move_vehicle_allow_ai", A3A_fnc_unlockStatic, nil, 1, false, true, "", VEHICLE_STATIC_COND(true), 4];
+        _flag addAction [localize "STR_antistasi_actions_move_vehicle_prevent_ai", A3A_fnc_lockStatic, nil, 1, false, true, "", VEHICLE_STATIC_COND(false), 4];
     };
+    #undef VEHICLE_STATIC_COND
+
     case "rivals_quest":
     {
         _flag addAction [

--- a/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
+++ b/A3A/addons/core/functions/Base/fn_updateRebelStatics.sqf
@@ -55,8 +55,8 @@ if (_statics isEqualTo []) exitWith {};
 
 // Find unlocked & unoccupied statics
 private _freeStatics = _statics select {
-    (isNull gunner _x) &&
-    { !(_x getVariable["lockedForAI", false]) }
+    (isNull gunner _x) && 
+    { [_x] call A3A_fnc_canAIMountVehicle };
 };
 if (_freeStatics isEqualTo []) exitWith {};
 


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Introduced new `A3A_fnc_canAIMountVehicle` function to _really_ identify whether a vehicle should be mounted by AI.
> 
> I've noticed AI mounting vehicles on freshly captured airbases while those vehicles were:
> a) still locked
> b) fuel trucks without gunner seats
> 
> This patch remedies the above situations.

**How can your changes be tested, or reproduced?**

> No more of the above. Also, "Allow AIs to use this vehicle" action no longer available for "useless" vehicles.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
