### PR TITLE
Fix remaining rally points

### DIFF
--- a/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
@@ -168,7 +168,7 @@ private _markerTitle = call {
     if (_originalName in citiesX) exitWith { markerText _originalName };
     
     // FETCH LIVE SPAWN COUNT FROM NAMESPACE
-    if (_isRallyPointMarker) exitWith { format [localize "STR_marker_RP", str (missionNamespace getVariable ["rallyPointSpawnCount", 0])] };
+    if (_isRallyPointMarker) exitWith { format [localize "STR_marker_RP", str (rallyPointRoot getVariable ["remainingTravels", 0])] };
     
     if (_isMilAdmin) exitWith { format [localize "STR_milAdministration", _nearestCityName] };
     if (_originalName in mrkAntennas) exitWith { format [localize "STR_radiotower", _nearestCityName] };
@@ -301,7 +301,7 @@ private _specialDefinitions = [
     
     // FETCH LIVE SPAWN COUNT FROM NAMESPACE FOR SPECIAL DEFS
     private _specTitle = if (_specTitleLoc == "STR_marker_RP") then {
-        format [localize _specTitleLoc, str (missionNamespace getVariable ["rallyPointSpawnCount", 0])]
+        format [localize _specTitleLoc, str (rallyPointRoot getVariable ["remainingTravels", 0])]
     } else {
         format [localize _specTitleLoc, _specFaction getOrDefault ["name", ""]]
     };

--- a/A3A/addons/scrt/Rally/fn_rally_placeRallyPoint.sqf
+++ b/A3A/addons/scrt/Rally/fn_rally_placeRallyPoint.sqf
@@ -7,7 +7,6 @@ if (rallyPointSpawnCount isEqualTo 0) exitWith
 { 
 	private _warningText = "<t font ='PuristaSemibold' align = 'center' shadow='1' shadowColor='#000000' size='0.8' color='#ebebeb'>" + localize "STR_params_rallyPointSpawnCountDisabled" +"</t>"; 
 	[_warningText,0,safezoneY+0.5] spawn BIS_fnc_dynamicText; 
-    
 };
 
 private _rallyPointClass = FactionGet(reb,"rallyPoint");
@@ -53,10 +52,10 @@ rallyPointMarker setMarkerAlpha 1;
 sidesX setVariable [rallyPointMarker,teamPlayer,true];
 publicVariable "rallyPointMarker";
 
-[rallyPointMarker] call A3A_fnc_mrkUpdate;
-
 rallyProps append [_backpack1, _backpack2, _bag, _ammobox];
 publicVariable "rallyProps";
 
-rallyPointRoot setVariable ["remainingTravels", rallyPointSpawnCount, true];
+rallyPointRoot setVariable ["remainingTravels", rallyPointSpawnCount, true]; // rallyPointSpawnCount is used to disable the rally points AND set the amount of uses PER rp
 publicVariable "rallyPointRoot";
+
+[rallyPointMarker] call A3A_fnc_mrkUpdate; // If we do this before remainingTravels is set then it doesn't work properly

--- a/A3A/addons/scrt/Rally/fn_rally_travelToRallyPoint.sqf
+++ b/A3A/addons/scrt/Rally/fn_rally_travelToRallyPoint.sqf
@@ -75,7 +75,6 @@ cutText [localize "STR_cut_RP_FT_success", "BLACK IN", 1];
 // Update both variables and trigger the universal map UI refresh
 _remainingTravels = _remainingTravels - 1;
 rallyPointRoot setVariable ["remainingTravels", _remainingTravels, true];
-missionNamespace setVariable ["rallyPointSpawnCount", _remainingTravels, true];
 
 [rallyPointMarker] call A3A_fnc_mrkUpdate;
 


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Changes introduced in #970 overwrite the game parameter `rallyPointSpawnCount` and update it with remaining travel counts from currently deployed rally point, essentially making rally points a one-way feature: if the current rally point's fast travels are depleted, `rallyPointSpawnCount` also becomes zero, permanently disabling rally points.

**How can your changes be tested, or reproduced?**

> Newly placed rally points start at 10 (or whatever is configured) again after fast traveling at least once.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
