### PR TITLE
Add empty radar and sam vehicles to faction defaults

### DIFF
--- a/A3A/addons/core/Templates/Templates/FactionDefaults/EnemyDefaults.sqf
+++ b/A3A/addons/core/Templates/Templates/FactionDefaults/EnemyDefaults.sqf
@@ -28,6 +28,8 @@
 ["vehiclesPlanesLargeCAS", []] call _fnc_saveToTemplate;
 ["vehiclesPlanesLargeAA", []] call _fnc_saveToTemplate;
 ["vehiclesPlanesGunship", []] call _fnc_saveToTemplate;
+["vehicleRadar", ""] call _fnc_saveToTemplate;
+["vehicleSam", ""] call _fnc_saveToTemplate;
 
 ["flares", ["F_40mm_white", "F_40mm_Red", "F_40mm_Yellow", "F_40mm_Green"]] call _fnc_saveToTemplate;
 


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

## What have you changed, and why?

**Information:**

> Adds empty string for `vehicleRadar` and `vehicleSam` to enemy faction defaults, to prevent potential issues with templates that don't include them post #941

> fn_compileMissionAssets uses getOrDefault with default value of empty array (`[]`) when getting the various vehicle types. Thus, if one of the occ / inv template does not have the key defined at all and the other does (properly as a string), the game will attempt to add an empty array and a string and throw a fit. So we just make sure to statically define these vehicles as empty string in the defaults file while still allowing the templates to override it.

**How can your changes be tested, or reproduced?**

> Load template without one or both vehicles defined anywhere. Ensure no issues.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

N/A
