### PR TITLE
Fixes/spell locations out

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -155,6 +155,8 @@ class CfgFunctions
             class initPetros {};
             class isFrontline {};
             class isFrontlineNoFIA {};
+            class isRiverportMap {};
+            class isSeaportMap {};
             class arePositionsConnected {};
             class joinMultipleGroups {};
             class localizar {};

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -146,6 +146,7 @@ class CfgFunctions
             class garbageCleanerTracker {};
             class garrisonInfo {};
             class getAggroLevelString {};
+            class getLocationName {};
             class getRecentDamage {};
             class getVehiclesAirSupport {};
             class getVehiclesGroundSupport {};

--- a/A3A/addons/core/functions/Base/fn_getLocationName.sqf
+++ b/A3A/addons/core/functions/Base/fn_getLocationName.sqf
@@ -1,0 +1,94 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_getLocationName
+
+Description:
+    Return location marker name based on location type
+
+Parameters:
+    0: _marker - Location marker name <STRING>
+
+Optional:
+    1: _wrap - Wrap location name with location type <BOOL> (default: false)
+
+Example:
+    (begin example)
+    ["outpost_3"] call A3A_fnc_getLocationName; // --> Thunder Ridge
+    ["outpost_3", true] call A3A_fnc_getLocationName; // --> Thunder Ridge Outpost
+    (end example)
+
+Returns:
+    Location marker name <STRING> or nil, if marker not associable
+
+Environment:
+    Client/Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+if !assert(params[
+    ["_marker", nil, [""]]
+]) exitWith {};
+
+private _wrap = param[1, false, [true]];
+
+if (isNil QGVAR(locationNamesCache)) then {
+    GVAR(locationNamesCache) = createHashMap;
+    GVAR(locationNamesRepository) = [
+        // nsArray, fallbackStr, wrapStr, locationNamesStr, condition
+        ["airportsX", "STR_localizar_airbase", "STR_airbase", "STR_A3AU_airfieldNames"],
+        ["controlsX", "STR_localizar_roadblock", "", nil, {isOnRoad markerPos _this}],
+        ["controlsX", "STR_localizar_outskirts"],
+        ["factories", "STR_factory"],
+        ["milbases", "STR_localizar_milbase", "STR_milbase", "STR_A3AU_milbaseNames"],
+        ["milAdministrationsX", "STR_milAdministration"],
+        ["mrkAntennas", "STR_radiotower"],
+        ["outposts", "STR_localizar_outpost", "STR_outpost", "STR_A3AU_outpostNames"],
+        ["resourcesX", "STR_resources"],
+        ["seaports", "STR_localizar_riverport", "STR_port_river", "STR_A3AU_seaportNames", {[] call A3A_fnc_isRiverportMap}],
+        ["seaports", "STR_localizar_seaport", "STR_port_sea", "STR_A3AU_seaportNames"]
+    ] apply {
+        _x params["_key", "_fallback", ["_wrapStr", ""], ["_namesLocalization", nil], ["_condition", {true}, [{}]]];
+
+        if (isNil "_namesLocalization") then {
+            [_key, _fallback, _wrapStr, [], _condition];
+        } else {
+            [_key, _fallback, _wrapStr, localize _namesLocalization splitString "|", _condition];
+        };
+    };
+};
+
+private _markerKey = format["%1:%2", ["norm", "wrap"] select _wrap, _marker];
+private _name = GVAR(locationNamesCache) get _markerKey;
+
+if (isNil "_name") then {
+    private _index = GVAR(locationNamesRepository) findIf {
+        _x params["_key","","","","_condition"];
+
+        (_marker in (missionNamespace getVariable _key)) &&
+        {_marker call _condition};
+    };
+
+    if !assert(_index >= 0) exitWith { Error_1("Location marker '%1' not found in any location type.",_marker) };
+
+    (GVAR(locationNamesRepository) select _index) params["_key", "_fallback", "_wrapStr", "_names"];
+
+    _index = (missionNamespace getVariable _key) find _marker;
+
+    if !assert(_index >= 0) exitWith { Error_2("Location marker '%1' not found in location type '%2'.",_marker,_key) };
+
+    if (_index < count _names) then {
+        _name = _names select _index;
+        if (_wrap && { _wrapStr isNotEqualTo "" }) then {
+            _name = format[localize _wrapStr, _name];
+        };
+    } else {
+    	private _city = [citiesX, markerPos _marker] call BIS_fnc_nearestPosition;
+        _name = format[localize _fallback, _city];
+    };
+
+    GVAR(locationNamesCache) set[_markerKey, _name];
+};
+
+RETNIL(_name);

--- a/A3A/addons/core/functions/Base/fn_isRiverportMap.sqf
+++ b/A3A/addons/core/functions/Base/fn_isRiverportMap.sqf
@@ -1,0 +1,31 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_isRiverportMap
+
+Description:
+    Whether ports on water are to be considered riverports on this map
+
+Parameters:
+
+Optional:
+    0: _mapName - name of the map <STRING> (default: worldName)
+
+Example:
+    (begin example)
+    [] call A3A_fnc_isRiverportMap; // --> true/false
+    ["enoch"] call A3A_fnc_isRiverportMap; // --> true
+    (end example)
+
+Returns:
+    <BOOL> true if ports on water are to be considered riverports on this map, false otherwise
+
+Environment:
+    Client/Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+private _map = param[0, worldName, [""]];
+
+toLowerANSI _map in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"];

--- a/A3A/addons/core/functions/Base/fn_isRiverportMap.sqf
+++ b/A3A/addons/core/functions/Base/fn_isRiverportMap.sqf
@@ -28,4 +28,5 @@ Author:
 ---------------------------------------------------------------------------- */
 private _map = param[0, worldName, [""]];
 
-toLowerANSI _map in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"];
+getNumber(configFile >> "A3A" >> "mapInfo" >> _map >> "hasRiverPorts") != 0;
+

--- a/A3A/addons/core/functions/Base/fn_isSeaportMap.sqf
+++ b/A3A/addons/core/functions/Base/fn_isSeaportMap.sqf
@@ -1,0 +1,29 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_isSeaportMap
+
+Description:
+    Whether ports on water are to be considered seaports on this map
+
+Parameters:
+
+Optional:
+    0: _mapName - name of the map <STRING> (default: worldName)
+
+Example:
+    (begin example)
+    [] call A3A_fnc_isSeaportMap; // --> true/false
+    ["enoch"] call A3A_fnc_isSeaportMap; // --> false
+    (end example)
+
+Returns:
+    <BOOL> true if ports on water are to be considered seaports on this map, false otherwise
+
+Environment:
+    Client/Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+!(call A3A_fnc_isRiverportMap);

--- a/A3A/addons/core/functions/Base/fn_localizar.sqf
+++ b/A3A/addons/core/functions/Base/fn_localizar.sqf
@@ -1,52 +1,8 @@
-params ["_siteX"];
+if !assert(params[
+	["_siteX", nil, [""]]
+]) exitWith {""};
 
-private _pos = getMarkerPos _siteX;
-private _textX = "";
+if (_siteX in citiesX) exitWith { _siteX };
+if (_siteX in ["CSAT_carrier", "NATO_carrier"]) exitWith { localize "STR_localizar_supportcorridor" };
 
-if (_siteX in citiesX) then {
-	_textX = format ["%1",_siteX];
-} else {
-	private _city = [citiesX, _pos] call BIS_fnc_nearestPosition;
-
-	switch (true) do {
-		case (_siteX in airportsX): {
-			_textX = format [localize "STR_localizar_airbase",_city];
-		};
-		case (_siteX in milbases): {
-			_textX = format [localize "STR_localizar_milbase",_city];
-		};
-		case (_siteX in resourcesX): {
-			_textX = format [localize "STR_localizar_resource",_city];
-		};
-		case (_siteX in factories): {
-			_textX = format [localize "STR_localizar_factory",_city];
-		};
-		case (_siteX in outposts): {
-			_textX = format [localize "STR_localizar_outpost",_city];
-		};
-		case (_siteX in seaports): {
-			if (toLowerANSI worldName in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"]) then {
-				_textX = format [localize "STR_localizar_riverport",_city];
-			} else {
-				_textX = format [localize "STR_localizar_seaport",_city];
-			};
-		};
-		case (_siteX in controlsX): {
-			if (isOnRoad getMarkerPos _siteX) then {
-				_textX = format [localize "STR_localizar_roadblock",_city];
-			} else {
-				_textX = format [localize "STR_localizar_outskirts",_city];
-			};
-		};
-		case (_siteX in milAdministrationsX): {
-			_textX = format [localize "STR_milAdministration",_city];
-		};
-		case (_siteX == "CSAT_carrier");
-		case (_siteX == "NATO_carrier"): {
-			_textX = localize "STR_localizar_supportcorridor";
-		};
-	};
-};
-
-
-_textX
+[_siteX, true] call A3A_fnc_getLocationName;

--- a/A3A/addons/core/functions/Base/fn_markerChange.sqf
+++ b/A3A/addons/core/functions/Base/fn_markerChange.sqf
@@ -227,7 +227,7 @@ switch (true) do {
 			};
 		};
 
-		if (toLowerANSI worldName in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"]) then {
+		if ([] call A3A_fnc_isRiverportMap) then {
 			["TaskSucceeded", ["", localize "STR_notifiers_riverport_taken"]] remoteExec ["BIS_fnc_showNotification",_winner];
 			["TaskFailed", ["", localize "STR_notifiers_riverport_lost"]] remoteExec ["BIS_fnc_showNotification",_loser];
 			["TaskUpdated",["",format [localize "STR_notifiers_riverport_lost_other",_textX]]] remoteExec ["BIS_fnc_showNotification",_other];

--- a/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
@@ -154,14 +154,6 @@ if (_isMilAdmin || _originalName in mrkAntennas || _originalName in resourcesX |
     };
 };
 
-private _getLocName = {
-    params ["_array", "_locKey"];
-    private _idx = _array find _originalName;
-    if (_idx < 0) exitWith {""};
-    private _names = (localize _locKey) splitString "|";
-    if (_idx < count _names) then { _names select _idx } else { "" };
-};
-
 private _markerTitle = call {
     if (_isSyndicateHeadquarters) exitWith { format [localize "STR_A3U_HOVER_RESISTANCE_HQ", _factionName] };
     if (_isTraderMarker) exitWith { localize "STR_A3U_HOVER_BLACK_MARKET" };
@@ -169,20 +161,6 @@ private _markerTitle = call {
     
     // FETCH LIVE SPAWN COUNT FROM NAMESPACE
     if (_isRallyPointMarker) exitWith { format [localize "STR_marker_RP", str (missionNamespace getVariable ["rallyPointSpawnCount", 0])] };
-    
-    if (_isMilAdmin) exitWith { format [localize "STR_milAdministration", _nearestCityName] };
-    if (_originalName in mrkAntennas) exitWith { format [localize "STR_radiotower", _nearestCityName] };
-    if (_originalName in resourcesX) exitWith { format [localize "STR_resources", _nearestCityName] };
-    if (_originalName in factories) exitWith { format [localize "STR_factory", _nearestCityName] };
-
-    if (_originalName in airportsX) exitWith { format [localize "STR_airbase", [airportsX, "STR_A3AU_airfieldNames"] call _getLocName] };
-    if (_originalName in outposts) exitWith { format [localize "STR_outpost", [outposts, "STR_A3AU_outpostNames"] call _getLocName] };
-    if (_originalName in milbases) exitWith { format [localize "STR_milbase", [milbases, "STR_A3AU_milbaseNames"] call _getLocName] };
-    
-    if (_originalName in seaports) exitWith {
-        private _portName = [seaports, "STR_A3AU_seaportNames"] call _getLocName;
-        format [["STR_port_sea", "STR_port_river"] select ([] call A3A_fnc_isRiverportMap), _portName];
-    };
 
     if (_originalName in watchpostsFIA) exitWith { format [localize "STR_marker_watchpost", _factionName] };
     if (_originalName in roadblocksFIA) exitWith { format [localize "STR_marker_roadblock", _factionName] };
@@ -190,7 +168,8 @@ private _markerTitle = call {
     if (_originalName in atpostsFIA) exitWith { format [localize "STR_marker_at_empl", _factionName] };
     if (_originalName in hmgpostsFIA) exitWith { format [localize "STR_marker_hmg_empl", _factionName] };
 
-    ""
+    private _title = [_originalName, true] call A3A_fnc_getLocationName;
+    RETDEF(_title,"");
 };
 
 if (_isDestroyed) then { _markerTitle = format ["%1 %2", _markerTitle, localize "STR_destroyed"]; };

--- a/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
+++ b/A3A/addons/core/functions/Base/fn_mrkUpdate.sqf
@@ -181,7 +181,7 @@ private _markerTitle = call {
     
     if (_originalName in seaports) exitWith {
         private _portName = [seaports, "STR_A3AU_seaportNames"] call _getLocName;
-        format [localize (if (toLowerANSI worldName in ["enoch", "vn_khe_sanh", "esseker"]) then {"STR_port_river"} else {"STR_port_sea"}), _portName]
+        format [["STR_port_sea", "STR_port_river"] select ([] call A3A_fnc_isRiverportMap), _portName];
     };
 
     if (_originalName in watchpostsFIA) exitWith { format [localize "STR_marker_watchpost", _factionName] };

--- a/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
+++ b/A3A/addons/core/functions/Missions/fn_missionRequest.sqf
@@ -251,7 +251,7 @@ switch (_type) do {
 			private _site = selectRandom _possibleMarkers;
 
 			private _shipwreckPosition = [0,0,0];
-			if (!(toLowerAnsi worldName in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal", "takistan"]) && {random 100 < 20}) then {
+			if (([] call A3A_fnc_isSeaportMap) && {random 100 < 20}) then {
 				_shipwreckPosition = [
 					(getMarkerPos _site),
 					0,

--- a/A3A/addons/core/functions/init/fn_initBases.sqf
+++ b/A3A/addons/core/functions/init/fn_initBases.sqf
@@ -77,6 +77,6 @@ private _roadblockPositions = controlsX apply { markerPos _x };
 [_mrkCSAT, factories, "A3AU_factory_mrk", localize "STR_factory"] call _fnc_initMarkerList;
 [_mrkCSAT, outposts, "A3AU_outpost_mrk", localize "STR_outpost", true] call _fnc_initMarkerList;
 [_mrkCSAT, milbases, "A3AU_milbase_mrk", localize "STR_milbase", true] call _fnc_initMarkerList;
-[_mrkCSAT, seaports, "b_naval", ["STR_port_sea", "STR_port_river"] select ([] call A3A_fnc_isRiverportMap)] call _fnc_initMarkerList;
+[_mrkCSAT, seaports, "b_naval", localize(["STR_port_sea", "STR_port_river"] select ([] call A3A_fnc_isRiverportMap))] call _fnc_initMarkerList;
 
 Info("InitBases completed");

--- a/A3A/addons/core/functions/init/fn_initBases.sqf
+++ b/A3A/addons/core/functions/init/fn_initBases.sqf
@@ -77,10 +77,6 @@ private _roadblockPositions = controlsX apply { markerPos _x };
 [_mrkCSAT, factories, "A3AU_factory_mrk", localize "STR_factory"] call _fnc_initMarkerList;
 [_mrkCSAT, outposts, "A3AU_outpost_mrk", localize "STR_outpost", true] call _fnc_initMarkerList;
 [_mrkCSAT, milbases, "A3AU_milbase_mrk", localize "STR_milbase", true] call _fnc_initMarkerList;
-[_mrkCSAT, seaports, "b_naval", localize "STR_port_sea"] call _fnc_initMarkerList;
-// private _portName = [
-//     localize "STR_port_sea",
-//     localize "STR_port_river"
-// ] select (toLowerANSI worldName in ["enoch", "vn_khe_sanh", "esseker", "sefrouramal"]); // Will keep for future
+[_mrkCSAT, seaports, "b_naval", ["STR_port_sea", "STR_port_river"] select ([] call A3A_fnc_isRiverportMap)] call _fnc_initMarkerList;
 
 Info("InitBases completed");

--- a/A3A/addons/maps/Antistasi_Enoch.Enoch/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_Enoch.Enoch/mapInfo.hpp
@@ -19,6 +19,7 @@ class enoch {
 		{1470.69,7390.76,0},{10549.7,11113.2,0},{5955.1,4134.83,0},{3293.84,2045.38,0},{11065.1,4330.7,-1.52588e-005}
 	};
 	climate = "temperate";
+	hasRiverPorts = 1;
 	buildObjects[] = {
 		BUILDABLES_HISTORIC,
 		BUILDABLES_UNIVERSAL,

--- a/A3A/addons/maps/Antistasi_Esseker.Esseker/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_Esseker.Esseker/mapInfo.hpp
@@ -30,6 +30,7 @@ class esseker {
 		{10065.3,9862.26,0},{7810.47,6892.65,0},{6271.49,7005.4,0},{8824.48,5785.3,0.0515652},{4656.4,8115.58,0.00173187},{4576.44,3671.31,0.237198},{2713.67,4540.18,-0.0525513}
 	};
 	climate = "temperate";
+	hasRiverPorts = 1;
 	buildObjects[] = {
 		BUILDABLES_HISTORIC,
 		BUILDABLES_UNIVERSAL,

--- a/A3A/addons/maps/Antistasi_SefrouRamal.SefrouRamal/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_SefrouRamal.SefrouRamal/mapInfo.hpp
@@ -15,6 +15,7 @@ class sefrouramal {
 		{4499.87,2902.21,0}, {5565.09,5087.64,0}
 	};
 	climate = "arid";
+	hasRiverPorts = 1;
 	buildObjects[] = {
 		BUILDABLES_HISTORIC,
 		BUILDABLES_UNIVERSAL,

--- a/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mapInfo.hpp
+++ b/A3A/addons/maps/Antistasi_vn_khe_sanh.vn_khe_sanh/mapInfo.hpp
@@ -33,6 +33,7 @@ class vn_khe_sanh {
 		{10884.1,3920.57,2.28882e-005}
 	};
 	climate = "tropical";
+	hasRiverPorts = 1;
 	buildObjects[] = {
 		BUILDABLES_HISTORIC,
 		BUILDABLES_UNIVERSAL,


### PR DESCRIPTION
## What type of PR is this?
- [ ] Bug
- [X] Change
- [ ] Feature
- [X] Miscellaneous

## What have you changed, and why?

**Information:**

> With #830 done, "bigger" locations have names now.
> 
> On Columbia, I had a convoy that went _"[...] from outpost near City-A to outpost near City-A."_ Both outposts' closest city was "City-A", so the message was quite useless. This PR makes use of outpost, airport, seaport etc. names and uses them in messages presented to players. It would now show _"[...] from Iron Vanguard Outpost to Thunderfall Outpost."_
> 
> Also, on a side-note (side-feature), this PR removes hard-coded lists which maps are considered land-locked (i.e.: have river-ports as opposed to seaports) to the maps' respective config.
> 
> This PR keeps ignoring the issue raised with #940 and will still generate server-side localization which might mismatch clients' languages.

**How can your changes be tested, or reproduced?**

> See above.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.
- [ ] There's #940 which this PR _will_ clash with

## Please specify which Issue this PR Resolves (If Applicable).

N/A