### PR TITLE
Declare `dummyNVGs` publicly for headless clients

### DIFF
--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -492,6 +492,10 @@ Info("Sorting grouped class categories");
 Info("Building loot lists");
 [] call A3A_fnc_loot;
 
+// Used in headless clients (NATOinit).
+// Defined in equipmentSort
+ONLY_DECLARE_SERVER_VAR(dummyNVGs);
+
 if (["tts_emission"] call A3U_fnc_hasAddon) then {call A3U_fnc_emission};
 
 if (["diwako_anomalies_main"] call A3U_fnc_hasAddon) then {call A3U_fnc_fillMapAnomalies};


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Added a server variable declaration for `dummyNVGs` as it is used on headless clients in `NATOinit`.

**How can your changes be tested, or reproduced?**

> 1. Start antistasi mission with a dedicated server
> 2. Open console and run `dummyNVGs` on the client
> 3. You should see that it returns an array rather than nothing (which will also now be defined on HCs)

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [x] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
Fixes #963

## Notes
> Tested on dedicated server. Executing `dummyNVGs` from the client shows an array, as expected and should now also be declared on headless clients.
<img width="553" height="594" alt="image" src="https://github.com/user-attachments/assets/b1049b4d-e781-4971-814b-089c3915e1b4" />
