### PR TITLE
Allow `fn_localLog` to accept strings

### DIFF
--- a/A3A/addons/core/functions/Utility/fn_localLog.sqf
+++ b/A3A/addons/core/functions/Utility/fn_localLog.sqf
@@ -3,7 +3,7 @@
     Description:
         logs argument as text
 
-    Argument: <Array> Texts to log
+    Argument: <Array|String> Text(s) to log
 
     Return Value:
     <nil>
@@ -17,4 +17,8 @@
 
     License: MIT License
 */
-{diag_log text _x} forEach _this;
+if (_this isEqualType []) exitWith {
+    {diag_log text _x} forEach _this;
+};
+
+diag_log text _this;


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> When `fn_log` was called by clients with server logging enabled (errors or headless client logs), they would produce the following error due to `_logLine` being a string and `fn_localLog` expecting an array.
```
20:54:24 Error in expression <
{diag_log text _x} forEach _this;
}>
20:54:24   Error position: <forEach _this;
}>
20:54:24   Error foreach: Type String, expected Array,HashMap
20:54:24 File x\A3A\addons\core\functions\Utility\fn_localLog.sqf..., line 20
```

**How can your changes be tested, or reproduced?**

> 1. Start an Antistasi mission prior to checking out this PR.
> 2. Run `"Some string to log" call A3A_fnc_localLog;` (the example in `fn_localLog.sqf`)
> 3. Observe the above error in the RPT.
> 4. Repeat the above steps after checking out this PR and observe the string being properly logged to the RPT.

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)
## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
N/A

## Notes

> This bug is caused by `fn_log.sqf`. When it logs to the server, it calls this function, but only ever supplies a string: `_logLine remoteExec ["A3A_fnc_localLog", 2];`