### PR TITLE
Save utility items

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -627,6 +627,7 @@ class CfgFunctions
 
         class Save {
             file = QPATHTOFOLDER(functions\Save);
+            class addToStaticsToSave {};
             class collectParamPresetData {};
             class collectSaveData {};
             class deleteSave {};

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -628,12 +628,14 @@ class CfgFunctions
         class Save {
             file = QPATHTOFOLDER(functions\Save);
             class addToStaticsToSave {};
+            class applyObjectSaveData {};
             class collectParamPresetData {};
             class collectSaveData {};
             class deleteSave {};
             class loadPlayer {};
             class loadServer {};
             class savePlayer {};
+            class getObjectSaveData {};
             class getStatVariable {};
             class loadStat {};
             class resetPlayer {};

--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -860,10 +860,12 @@ class CfgFunctions
 
         class UtilityItems {
             file = QPATHTOFOLDER(functions\UtilityItems);
+            class applyObjectSaveData_BuildBox {};
             class attachedObjects {};
             class buyItem {};
             class carryItem {};
             class dropItem {};
+            class getObjectSaveData_BuildBox {};
             class initMovableObject {};
             class initObject {};
             class initObjectRemote {};

--- a/A3A/addons/core/CfgVehicles.hpp
+++ b/A3A/addons/core/CfgVehicles.hpp
@@ -1,3 +1,14 @@
+#define EMPTY_INVENTORY() \
+    class TransportMagazines {}; \
+    class TransportWeapons {}; \
+    class TransportItems {}; \
+    class TransportBackpacks {}
+#define SAVE_DATA_CALLBACKS(SUFFIX) \
+    GVAR(saveDataGetter) = QUOTE(call FUNCMAIN(DOUBLES(getObjectSaveData,SUFFIX))); \
+    GVAR(saveDataSetter) = QUOTE(call FUNCMAIN(DOUBLES(applyObjectSaveData,SUFFIX)))
+#define SAVE_DATA_CALLBACKS_BUILD_BOX() \
+    SAVE_DATA_CALLBACKS(BuildBox)
+
 class CfgVehicles
 {
     class Box_NATO_Uniforms_F;
@@ -172,10 +183,29 @@ class CfgVehicles
     class C_Man_1;
     class a3a_unit_civ : C_Man_1 {};
   
+    class Land_PlasticCase_01_small_black_F;
+    class Land_PlasticCase_01_medium_black_F;
+    class Land_PlasticCase_01_large_black_F;
     class NATO_Box_Base;
 
-	
-    class A3AU_Build_Box_base: NATO_Box_Base {
+    class A3AU_Build_Box_ExtraSmall : Land_PlasticCase_01_small_black_F {
+        scope = 1;
+        displayName = "Build Box (Extra Small)";
+
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
+    };
+
+    class A3AU_Build_Box_Small : Land_PlasticCase_01_medium_black_F {
+        scope = 1;
+        displayName = "Build Box (Small)";
+
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
+    };
+
+	class A3AU_Build_Box_Large_1: NATO_Box_Base {
+        mapSize = 2.3399999;
         author = AUTHOR;
         hiddenSelections[] = 
         {
@@ -187,10 +217,6 @@ class CfgVehicles
             QPATHTOFOLDER(Pictures\items\AmmoBox_signs_CA.paa),
             QPATHTOFOLDER(Pictures\items\AmmoBox_black_CO.paa)
         };
-	};
-
-	class A3AU_Build_Box_Large_1: A3AU_Build_Box_base {
-        mapSize = 2.3399999;
         class SimpleObject
         {
             eden = 1;
@@ -203,13 +229,20 @@ class CfgVehicles
         editorPreview = QPATHTOFOLDER(Pictures\items\A3AU_Build_Box_Large_1.jpg);
         _generalMacro = "Box_NATO_WpsLaunch_F";
         scope = 2;
-        displayName = "Build Box (Large)";
+        displayName = "Build Box (Medium)";
         model = "\A3\weapons_F\AmmoBoxes\WpnsBox_long_F";
         icon = "iconCrateLong";
-        class TransportMagazines{};
-        class TransportWeapons{};
-        class TransportItems{};
-        class TransportBackpacks{};
+
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
+    };
+
+    class A3AU_Build_Box_Large_2: Land_PlasticCase_01_large_black_F {
+        scope = 1;
+        displayName = "Build Box (Large)";
+
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
     };
 
     class Box_NATO_AmmoVeh_F;
@@ -223,10 +256,8 @@ class CfgVehicles
         ace_dragging_canDrag = 0;
         ace_dragging_canCarry = 0;
 
-        class TransportMagazines{};
-        class TransportWeapons{};
-        class TransportItems{};
-        class TransportBackpacks{};
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
     };
 
     class GVAR(Box_BuildingPlacer_Additions_Base): Box_NATO_Uniforms_F {
@@ -236,10 +267,8 @@ class CfgVehicles
 
         GVAR(buildableObjects)[] = {};
 
-        class TransportMagazines{};
-        class TransportWeapons{};
-        class TransportItems{};
-        class TransportBackpacks{};
+        SAVE_DATA_CALLBACKS_BUILD_BOX();
+        EMPTY_INVENTORY();
     };
 
     class GVAR(Box_BuildingPlacer_Decorations): GVAR(Box_BuildingPlacer_Additions_Base) {

--- a/A3A/addons/core/UtilityItems.hpp
+++ b/A3A/addons/core/UtilityItems.hpp
@@ -8,7 +8,7 @@ class UtilityItems {
     };
 
     class BuildBox: Base {
-        flags[] = {"place", "move", "build"};
+        flags[] = {"place", "move", "build", "save"};
     };
 
     class A3AU_Build_Box_ExtraSmall: BuildBox {

--- a/A3A/addons/core/UtilityItems.hpp
+++ b/A3A/addons/core/UtilityItems.hpp
@@ -11,13 +11,13 @@ class UtilityItems {
         flags[] = {"place", "move", "build"};
     };
 
-    class Land_PlasticCase_01_small_black_F: BuildBox {
+    class A3AU_Build_Box_ExtraSmall: BuildBox {
         scope = 1;
         displayName = "Build Box (Extra Small)";
         price = 250;
     };
 
-    class Land_PlasticCase_01_medium_black_F: BuildBox {
+    class A3AU_Build_Box_Small: BuildBox {
         scope = 1;
         displayName = "Build Box (Small)";
         price = 500;
@@ -29,7 +29,7 @@ class UtilityItems {
         price = 2500;
     };
 
-    class Land_PlasticCase_01_large_black_F: BuildBox {
+    class A3AU_Build_Box_Large_2: BuildBox {
         scope = 1;
         displayName = "Build Box (Large)";
         price = 5000;

--- a/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
+++ b/A3A/addons/core/functions/REINF/fn_addFIAveh.sqf
@@ -54,8 +54,7 @@ private _fnc_placed = {
 	[_vehicle, teamPlayer] call A3A_fnc_AIVehInit;
 
 	if (_vehicle isKindOf "StaticWeapon") then {
-		staticsToSave pushBack _vehicle; 
-		publicVariable "staticsToSave";
+		[_vehicle] call A3A_fnc_addToStaticsToSave;
 	};
 };
 

--- a/A3A/addons/core/functions/Save/fn_addToStaticsToSave.sqf
+++ b/A3A/addons/core/functions/Save/fn_addToStaticsToSave.sqf
@@ -1,0 +1,44 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_addToStaticsToSave
+
+Description:
+    Add an object/vehicle to the server staticsToSave array
+
+Parameters:
+    0: _object - Object/vehicle to add <OBJECT>
+
+Optional:
+
+Example:
+    (begin example)
+    [cursorTarget] call A3A_fnc_addToStaticsToSave;
+    (end example)
+
+Returns:
+    Nothing
+
+Environment:
+    Client/Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(addStaticsToSave),_this);
+
+if !assert(params[
+    ["_object", nil, [objNull]]
+]) exitWith {};
+if !assert(!isNull _object) exitWith {};
+
+if !(isServer) exitWith { _this remoteExec["A3A_fnc_addToStaticsToSave", 2] };
+
+if (_object in staticsToSave) exitWith {
+    Verbose_1("Object %1 already in staticsToSave array, skipping",_object);
+};
+
+staticsToSave pushBack _object;
+publicVariable "staticsToSave";
+
+nil;

--- a/A3A/addons/core/functions/Save/fn_applyObjectSaveData.sqf
+++ b/A3A/addons/core/functions/Save/fn_applyObjectSaveData.sqf
@@ -1,0 +1,44 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_applyObjectSaveData
+
+Description:
+    Restore/apply additional save data for an object that's part of the save
+
+Parameters:
+    0: _object - Object to apply save data to <OBJECT>
+    1: _saveData - Save data to apply <ANY>
+
+Optional:
+
+Example:
+
+Returns:
+    Nothing
+
+Environment:
+    Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(applyObjectSaveData),_this);
+
+if !assert(params[
+    ["_object", nil, [objNull]]
+]) exitWith {};
+if !assert(!isNull _object) exitWith {};
+
+private _saveData = param[1, nil];
+
+if (isNil "_saveData") exitWith {};
+
+if !(isText(configOf _object >> QGVAR(saveDataSetter))) exitWith {
+    Warning_1("applyObjectSaveData: object class %1 has additional save data, but no setter defined",typeOf _object);
+    nil;
+};
+
+call compile getText(configOf _object >> QGVAR(saveDataSetter));
+
+nil;

--- a/A3A/addons/core/functions/Save/fn_getObjectSaveData.sqf
+++ b/A3A/addons/core/functions/Save/fn_getObjectSaveData.sqf
@@ -1,0 +1,34 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_getObjectSaveData
+
+Description:
+    Return additional save data for an object that's to become part of the save
+
+Parameters:
+    0: _object - The object to save <OBJECT>
+
+Optional:
+
+Example:
+
+Returns:
+    Additional save data for object <ANY>
+
+Environment:
+    Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(getObjectSaveData),_this);
+
+if !assert(params[
+    ["_object", nil, [objNull]]
+]) exitWith {};
+if !assert(!isNull _object) exitWith {};
+
+if !(isText(configOf _object >> QGVAR(saveDataGetter))) exitWith {};
+
+[_object] call compile getText(configOf _object >> QGVAR(saveDataGetter));

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -379,7 +379,13 @@ if (_varName in specialVarLoads) then {
             _list sort false;
             _list apply {
                 _x params["","","","_data"];
-                _data params ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped"];
+
+                // This isn't pretty; we need versioning...
+                if (count _data <= 5) then {
+                    _data params["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_objectSaveData"];
+                } else {
+                    _data params["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped", "_objectSaveData"];
+                };
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey
@@ -392,6 +398,11 @@ if (_varName in specialVarLoads) then {
                     _veh setVectorDirAndUp [_xVectorDir,_xVectorUp];
                 };
                 [_veh, teamPlayer] call A3A_fnc_AIVEHinit;                  // Calls initObject instead if it's a buyable item
+
+                if !(isNil "_objectSaveData") then {
+                    [_veh, _objectSaveData] call A3A_fnc_applyObjectSaveData;
+                };
+
                 // TODO: Check whether various buyable items turn up as "Building"
                 if (isNil {_veh getVariable "A3A_canGarage"}) then {        // Buyable items should set this
                     switch true do {

--- a/A3A/addons/core/functions/Save/fn_loadStat.sqf
+++ b/A3A/addons/core/functions/Save/fn_loadStat.sqf
@@ -381,11 +381,12 @@ if (_varName in specialVarLoads) then {
                 _x params["","","","_data"];
 
                 // This isn't pretty; we need versioning...
-                if (count _data <= 5) then {
-                    _data params["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_objectSaveData"];
+                private _params = if (count _data <= 5) then {
+                    ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_objectSaveData"];
                 } else {
-                    _data params["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped", "_objectSaveData"];
+                    ["_typeVehX", "_posVeh", "_xVectorUp", "_xVectorDir", "_state", "_customization", "_flipped", "_objectSaveData"];
                 };
+                _data params _params;
                 private _veh = createVehicle [_typeVehX,[0,0,1000],[],0,"CAN_COLLIDE"];
                 Debug_2("staticsX: created %1 -> %2",_typeVehX,_veh);
                 // This is only here to handle old save states. Could be removed after a few version itterations. -Hazey

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -196,8 +196,7 @@ vehicles select {
 		!(typeOf _x in A3A_utilityItemHM) &&
 		{ fullCrew[_x, "", true] isNotEqualTo [] } && // no crew seats, not in utilityItems, not saved
 		{ crew _x findIf { (alive _x) && (!isPlayer _x) } == -1 } // no AI-crewed vehicles, those are refunded
-	} ||
-	{ "save" in ((A3A_utilityItemHM get typeOf _x) select 4) } 
+	}
 } apply {
     _arrayEst pushBackUnique _x;
 };
@@ -239,6 +238,12 @@ _arrayEst = _arrayEst apply {
 };
 
 reverse _arrayEst;
+
+diag_log text "[VEHICLES/STATICS] ---------------------------------------------------------";
+{
+	diag_log text format["#%1: %2", _foreachIndex, _x];
+} forEach _arrayEst;
+
 ["staticsX", _arrayEst] call A3A_fnc_setStatVariable;
 
 private _excessiveConstructions = maxConstructions - (count constructionsToSave);

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -234,6 +234,12 @@ _arrayEst = _arrayEst apply {
 		];
 	};
 
+	private _saveData = [_x] call A3A_fnc_getObjectSaveData;
+
+	if !(isNil "_saveData") then {
+		_properties pushBack _saveData;
+	};
+
 	_properties;
 };
 

--- a/A3A/addons/core/functions/Save/fn_saveLoop.sqf
+++ b/A3A/addons/core/functions/Save/fn_saveLoop.sqf
@@ -238,12 +238,6 @@ _arrayEst = _arrayEst apply {
 };
 
 reverse _arrayEst;
-
-diag_log text "[VEHICLES/STATICS] ---------------------------------------------------------";
-{
-	diag_log text format["#%1: %2", _foreachIndex, _x];
-} forEach _arrayEst;
-
 ["staticsX", _arrayEst] call A3A_fnc_setStatVariable;
 
 private _excessiveConstructions = maxConstructions - (count constructionsToSave);

--- a/A3A/addons/core/functions/UtilityItems/fn_applyObjectSaveData_BuildBox.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_applyObjectSaveData_BuildBox.sqf
@@ -35,6 +35,7 @@ if !assert(_saveData params[
     ["_remainingBudget", nil, [0]]
 ]) exitWith {};
 
-_object setVariable["A3A_build_money", _remainingBudget, true];
+_object setVariable["A3A_itemPrice", _remainingBudget, true];
+_object setVariable["A3A_build_money", (A3A_utilityItemHM get typeOf _object) select 1, true];
 
 nil;

--- a/A3A/addons/core/functions/UtilityItems/fn_applyObjectSaveData_BuildBox.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_applyObjectSaveData_BuildBox.sqf
@@ -1,0 +1,40 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_applyObjectSaveData_BuildBox
+
+Description:
+    Apply build boxes' remaining budget from object save data
+
+Parameters:
+    0: _object - The object to apply save data to <OBJECT>
+    1: _saveData - Save data to apply <ANY> (expected: <ARRAY>)
+
+Optional:
+
+Example:
+
+Returns:
+    Nothing
+
+Environment:
+    Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(applyObjectSaveData_BuildBox),_this);
+
+if !assert(params[
+    ["_object", nil, [objNull]],
+    ["_saveData", nil, [[]]]
+]) exitWith {};
+if !assert(!isNull _object) exitWith {};
+
+if !assert(_saveData params[
+    ["_remainingBudget", nil, [0]]
+]) exitWith {};
+
+_object setVariable["A3A_build_money", _remainingBudget, true];
+
+nil;

--- a/A3A/addons/core/functions/UtilityItems/fn_getObjectSaveData_BuildBox.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_getObjectSaveData_BuildBox.sqf
@@ -1,0 +1,32 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_getObjectSaveData_BuildBox
+
+Description:
+    Return build boxes' remaining budget to include in object save data
+
+Parameters:
+    0: _object - The object to save <OBJECT>
+
+Optional:
+
+Example:
+
+Returns:
+    Additional save data for object <ARRAY>
+
+Environment:
+    Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(getObjectSaveData_BuildBox),_this);
+
+if !assert(params[
+    ["_object", nil, [objNull]]
+]) exitWith {};
+if !assert(!isNull _object) exitWith {};
+
+[_object getVariable["A3A_build_money", 0]];

--- a/A3A/addons/core/functions/UtilityItems/fn_getObjectSaveData_BuildBox.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_getObjectSaveData_BuildBox.sqf
@@ -29,4 +29,4 @@ if !assert(params[
 ]) exitWith {};
 if !assert(!isNull _object) exitWith {};
 
-[_object getVariable["A3A_build_money", 0]];
+[_object getVariable["A3A_itemPrice", 0]];

--- a/A3A/addons/core/functions/UtilityItems/fn_initObject.sqf
+++ b/A3A/addons/core/functions/UtilityItems/fn_initObject.sqf
@@ -52,6 +52,9 @@ if ("loot" in _flags) then {
     };
 };
 
+if ("save" in _flags) then {
+    [_object] call A3A_fnc_addToStaticsToSave;
+};
 
 _object setVariable ["A3A_canGarage", true, true];
 _object setVariable ["A3A_itemPrice", _price, true];

--- a/A3A/addons/core/functions/init/fn_initClient.sqf
+++ b/A3A/addons/core/functions/init/fn_initClient.sqf
@@ -288,10 +288,7 @@ player addEventHandler ["WeaponAssembled", {
     private _veh = _this select 1;
     [_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
     if (_veh isKindOf "StaticWeapon") then {
-        if (not(_veh in staticsToSave)) then {
-            staticsToSave pushBack _veh;
-            publicVariable "staticsToSave";
-        };
+        [_veh] call A3A_fnc_addToStaticsToSave;
         _markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
         _pos = position _veh;
         [_veh] call A3A_Logistics_fnc_addLoadAction;

--- a/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
+++ b/A3A/addons/core/functions/proxy/fn_onPlayerRespawn.sqf
@@ -232,10 +232,7 @@ if (side group _newUnit == teamPlayer) then
 		private _veh = _this select 1;
 		[_veh, teamPlayer] call A3A_fnc_AIVEHinit;		// will flip/capture if already initialized
 		if (_veh isKindOf "StaticWeapon") then {
-			if (not(_veh in staticsToSave)) then {
-				staticsToSave pushBack _veh;
-				publicVariable "staticsToSave";
-			};
+	        [_veh] call A3A_fnc_addToStaticsToSave;
 			_markersX = markersX select {sidesX getVariable [_x,sideUnknown] == teamPlayer};
 			_pos = position _veh;
 			if (_markersX findIf {_pos inArea _x} != -1) then {


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug
- [ ] Change
- [X] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> This PR addresses the issue raised in #1009 and introduces these new mechanics:
> 
> 1. _New_ function `A3A_fnc_addToStaticsToSave`: server-safe variant to manipulate `staticsToSave` global variable
> 2. _Adds_ object save data framework: object/vehicle classes can define a callback with which additional object data is read/written from/to save game data
> 3. _Adds_ builder boxes, bought "other" items (medic tent et al.) to save game

**How can your changes be tested, or reproduced?**

> 1. Buy builder box
> 2. Build something
> 3. Buy+place medical tent
> 4. Save game
> 5. Restart & load
> 6. Builder box should still be there with the deducted amount from build from step 2
> 7. Medical tent should still be there

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following.

`*` - Mandatory

- [X] These changes are my own. `*`
- [X] These changes are ready for review. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

This PR closes #1009.
