### PR TITLE
Vehicle pricing unification

### DIFF
--- a/A3A/addons/core/CfgFunctions.hpp
+++ b/A3A/addons/core/CfgFunctions.hpp
@@ -413,6 +413,7 @@ class CfgFunctions
             class initUtilityItems {};
             class initGarrisons {};
             class initPreJIP { preInit = 1; };
+            class initPricingLists {};
             class initSpawnPlaces {};
             class generateRoadblock {};
 

--- a/A3A/addons/core/Pricing.hpp
+++ b/A3A/addons/core/Pricing.hpp
@@ -1,3 +1,4 @@
+// Prices are fall-back prices for vehicles that aren't in the black market list
 class Pricing {
     class Vehicle {
         class Base {
@@ -30,6 +31,11 @@ class Pricing {
             class Groups: Groups {
                 rallyPoint = 100;
 
+                staticAA = 1200;
+                staticAT = 1000;
+                staticMGs = 500;
+                staticMortars = 2500;
+
                 unitAA = 500;
                 unitAT = 500;
                 unitEng = 100;
@@ -43,14 +49,26 @@ class Pricing {
                 unitSL = 150;
                 unitSniper = 150;
 
-                vehiclesAA = 13000;
+                vehiclesAA = 1500;
                 vehiclesAPCs = 5000;
                 vehiclesArtillery = 13000;
+                vehiclesAT = 1000;
+                vehiclesBasic = 100;
+                vehiclesBoat = 500;
+                vehiclesCivBoat = 200;
+                vehiclesCivCar = 200;
+                vehiclesCivHeli = 5000;
+                vehiclesCivPlane = 5000;
+                vehiclesCivTruck = 600;
                 vehiclesHelisAttack = 13000;
                 vehiclesHelisLightAttack = 5000;
                 vehiclesHelisLight = 6000;
                 vehiclesIFVs = 5000;
+                vehiclesLightArmed = 800;
                 vehiclesLightTanks = 7000;
+                vehiclesLightUnarmed = 200;
+                vehiclesMedical = 600;
+                vehiclesPlane = 5000;
                 vehiclesPlanesAA = 15000;
                 vehiclesPlanesCAS = 15000;
                 vehiclesPlanesGunship = 20000;
@@ -58,7 +76,7 @@ class Pricing {
                 vehiclesPlanesLargeCAS = 15000;
                 vehiclesTanks = 13000;
                 vehiclesTransportAir = 5000;
-                vehiclesTruck = 1500;
+                vehiclesTruck = 300;
                 vehiclesUAVs = 5000;
             };
         };

--- a/A3A/addons/core/Pricing.hpp
+++ b/A3A/addons/core/Pricing.hpp
@@ -1,0 +1,83 @@
+class Pricing {
+    class Vehicle {
+        class Base {
+            scope = 0;
+            moniker = "";
+
+            class Groups {};
+            class Vehicles {};
+        };
+
+        class FactionDefault: Base {
+            scope = 1;
+            moniker = "all";
+
+            class Groups {
+                vehiclesBoats = 3000;
+                vehiclesLight = 1500;
+                vehiclesLightAPCs = 3000;
+            };
+
+            class Vehicles {
+                Land_RepairDepot_01_green_F = 10000;
+            };
+        };
+
+        class Rebel: Base {
+            scope = 1;
+            moniker = "reb";
+
+            class Groups: Groups {
+                rallyPoint = 100;
+
+                unitAA = 500;
+                unitAT = 500;
+                unitEng = 100;
+                unitExp = 100;
+                unitCrew = 50;
+                unitGL = 75;
+                unitLAT = 75;
+                unitMedic = 100;
+                unitMG = 75;
+                unitRifle = 50;
+                unitSL = 150;
+                unitSniper = 150;
+
+                vehiclesAA = 13000;
+                vehiclesAPCs = 5000;
+                vehiclesArtillery = 13000;
+                vehiclesHelisAttack = 13000;
+                vehiclesHelisLightAttack = 5000;
+                vehiclesHelisLight = 6000;
+                vehiclesIFVs = 5000;
+                vehiclesLightTanks = 7000;
+                vehiclesPlanesAA = 15000;
+                vehiclesPlanesCAS = 15000;
+                vehiclesPlanesGunship = 20000;
+                vehiclesPlanesLargeAA = 15000;
+                vehiclesPlanesLargeCAS = 15000;
+                vehiclesTanks = 13000;
+                vehiclesTransportAir = 5000;
+                vehiclesTruck = 1500;
+                vehiclesUAVs = 5000;
+            };
+        };
+
+        class Civilian: Base {
+        };
+
+        class Occupier: Base {
+            class Groups {
+                vehiclesAmmoTrucks = 3000;
+                vehiclesCargoTrucks = 1500;
+                vehiclesFuelTrucks = 3000;
+                vehiclesMedical = 3000;
+                vehiclesMilitiaTrucks = 1500;
+                vehiclesRepairTrucks = 3000;
+                vehiclesTrucks = 1500;
+            };
+        };
+
+        class Invader: Occupier {};
+    };
+};

--- a/A3A/addons/core/config.cpp
+++ b/A3A/addons/core/config.cpp
@@ -45,6 +45,7 @@ class A3A {
     #include "Templates.hpp"
     #include "UtilityItems.hpp"
     #include "Params.hpp"
+    #include "Pricing.hpp"
 
 #if __A3_DEBUG__
     #include "CfgFunctions.hpp"

--- a/A3A/addons/core/functions/Base/fn_getVehicleSellPrice.sqf
+++ b/A3A/addons/core/functions/Base/fn_getVehicleSellPrice.sqf
@@ -7,10 +7,10 @@ FIX_LINE_NUMBERS()
 
 #define OccAndInv(VAR) (FactionGet(occ, VAR) + FactionGet(inv, VAR))
 
-params ["_veh"];
+params ["_veh", ["_defaultPrice", 1000]];
 
 private _typeX = if (_veh isEqualType objNull) then {typeOf _veh} else {_veh};
 
-private _price = ([_typeX] call A3A_fnc_vehiclePrice) / 2;
+private _price = ([_typeX, _defaultPrice] call A3A_fnc_vehiclePrice) / 2;
 
 _price;

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -81,54 +81,7 @@ if (_veh getVariable ["A3A_sellVehicle_inProgress",false]) exitWith {[localize "
 _veh setVariable ["A3A_sellVehicle_inProgress",true,false];  // Only processed on the server. It is absolutely pointless trying to network this due to race conditions.
 
 private _typeX = typeOf _veh;
-private _costs = call {
-    if (_typeX in _blacklistedAssets) exitWith {0};
-    if (_veh isKindOf "StaticWeapon") exitWith {100};			// in case rebel static is same as enemy statics
-    if (_typeX in (FactionGet(all,"vehiclesReb") + FactionGet(reb,"vehiclesCivCar") + FactionGet(reb,"vehiclesCivTruck"))) exitWith { ([_typeX] call A3A_fnc_vehiclePrice) / 2 };
-
-    private _rebAa = FactionGet(reb, "vehiclesAA");
-    if (_rebAa isNotEqualTo [] && {_typeX isEqualTo _rebAa}) exitWith {([_typeX] call A3A_fnc_vehiclePrice) / 2};
-
-    if (
-        (_typeX in arrayCivVeh)
-        or (_typeX in civBoats)
-        or (_typeX in (FactionGet(reb,"vehiclesCivBoat") + FactionGet(reb,"vehiclesCivCar") + FactionGet(reb,"vehiclesCivTruck")))
-    ) exitWith {100};
-    if (
-        (_typeX in FactionGet(all,"vehiclesLight"))
-        or (_typeX in OccAndInv("vehiclesTrucks"))
-        or (_typeX in OccAndInv("vehiclesCargoTrucks"))
-        or (_typeX in OccAndInv("vehiclesMilitiaTrucks"))
-        or (_typeX in FactionGet(reb,"vehiclesTruck"))
-    ) exitWith {750};
-    if (
-        (_typeX in FactionGet(all,"vehiclesBoats"))
-        or (_typeX in FactionGet(all,"vehiclesLightAPCs"))
-        or (_typeX in OccAndInv("vehiclesAmmoTrucks"))
-        or (_typeX in OccAndInv("vehiclesRepairTrucks"))
-        or (_typeX in OccAndInv("vehiclesFuelTrucks"))
-        or (_typeX in OccAndInv("vehiclesMedical"))
-    ) exitWith {1500};
-    if (_typeX in [FactionGet(reb,"vehiclesCivHeli")]) exitWith {([_typeX] call A3A_fnc_vehiclePrice) / 2};
-    if (_typeX in (FactionGet(all,"vehiclesHelisLight"))) exitWith {3000};
-    if (
-        (_typeX in FactionGet(all,"vehiclesAPCs"))
-        || (_typeX in FactionGet(all,"vehiclesIFVs"))
-        || (_typeX in FactionGet(all,"vehiclesHelisLightAttack"))
-        || (_typeX in FactionGet(all,"vehiclesTransportAir"))
-        || (_typeX in FactionGet(all,"vehiclesUAVs"))
-    ) exitWith {2500};
-    if (_typeX in FactionGet(all,"vehiclesLightTanks")) exitWith {3500};
-    if (
-        (_typeX in FactionGet(all,"vehiclesHelisAttack"))
-        or (_typeX in FactionGet(all,"vehiclesTanks"))
-        or (_typeX in FactionGet(all,"vehiclesAA"))
-        or (_typeX in FactionGet(all,"vehiclesArtillery"))
-    ) exitWith {6500};
-    if (_typeX in (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"))) exitWith {7500};
-    if (_typeX in (FactionGet(all,"vehiclesPlanesGunship"))) exitWith {10000};
-    0;
-};
+private _costs = [_typeX, 0] call A3A_fnc_getVehicleSellPrice;
 
 if (_costs == 0) exitWith {
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];

--- a/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
+++ b/A3A/addons/core/functions/Base/fn_sellVehicle.sqf
@@ -81,7 +81,7 @@ if (_veh getVariable ["A3A_sellVehicle_inProgress",false]) exitWith {[localize "
 _veh setVariable ["A3A_sellVehicle_inProgress",true,false];  // Only processed on the server. It is absolutely pointless trying to network this due to race conditions.
 
 private _typeX = typeOf _veh;
-private _costs = [_typeX, 0] call A3A_fnc_getVehicleSellPrice;
+private _costs = [_typeX] call A3A_fnc_getVehicleSellPrice;
 
 if (_costs == 0) exitWith {
     _veh setVariable ["A3A_sellVehicle_inProgress",false,false];

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -29,12 +29,20 @@ private _costsBM = [_typeX] call A3U_fnc_blackMarketVehiclePrice;
 
 if (isNil "_costsBM") then {_costsBM = 0};
 
-if (_costs isNotEqualTo 0 && {_costsBM isNotEqualTo 0}) then {
-	_costs = _costs min _costsBM;
-};
+if (_typeX in A3A_rebelVehicles) then {
+	if (_costs isNotEqualTo 0 && {_costsBM isNotEqualTo 0}) then {
+		_costs = _costs min _costsBM;
+	};
 
-if (_costs isEqualTo 0 && {_costsBM isNotEqualTo 0}) then {
-	_costs = _costsBM;
+	if (_costs isEqualTo 0 && {_costsBM isNotEqualTo 0}) then {
+		_costs = _costsBM;
+	};
+} else {
+	// For non-rebel vehicles, use whichever is greater as there is no infinite money hack possible
+	// as these vehicles can only be bought with the BM cost.
+	if (_costsBM > _costs) then {
+		_costs = _costsBM;
+	};
 };
 
 if (_costs <= 0) then { // if the cost is less than 0

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -29,7 +29,7 @@ private _costsBM = [_typeX] call A3U_fnc_blackMarketVehiclePrice;
 
 if (isNil "_costsBM") then {_costsBM = 0};
 
-if (_typeX in A3A_rebelVehicles) then {
+if (_typeX in A3A_rebelVehicleCosts) then {
 	if (_costs isNotEqualTo 0 && {_costsBM isNotEqualTo 0}) then {
 		_costs = _costs min _costsBM;
 	};

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -46,7 +46,7 @@ if (_typeX in A3A_rebelVehicles) then {
 };
 
 if (_costs <= 0) then { // if the cost is less than 0
-	Error_3("Invalid vehicle price for %1. Got: %2. Defaulting to %2", _typeX, _costs, _defaultPrice);
+	Error_3("Invalid vehicle price for %1. Got: %2. Defaulting to %3", _typeX, _costs, _defaultPrice);
 	_costs = _defaultPrice; // reset the cost to the default price
 };
 

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -46,7 +46,7 @@ if (_typeX in A3A_rebelVehicles) then {
 };
 
 if (_costs <= 0) then { // if the cost is less than 0
-	Error_2("%1 was an invalid price. Defaulting to %2", _costs, _defaultPrice);
+	Error_3("Invalid vehicle price for %1. Got: %2. Defaulting to %2", _typeX, _costs, _defaultPrice);
 	_costs = _defaultPrice; // reset the cost to the default price
 };
 

--- a/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
+++ b/A3A/addons/core/functions/REINF/fn_vehiclePrice.sqf
@@ -1,11 +1,9 @@
 #include "..\..\script_component.hpp"
 FIX_LINE_NUMBERS()
 
-params ["_typeX"];
+params ["_typeX", ["_defaultPrice", 1000]];
 
 private _costs = server getVariable _typeX;
-
-private _defaultPrice = 1000;
 
 _costs = if (isNil "_costs") then {
 	Error_1("Invalid vehicle price :%1.", _typeX);

--- a/A3A/addons/core/functions/init/fn_initPricingLists.sqf
+++ b/A3A/addons/core/functions/init/fn_initPricingLists.sqf
@@ -1,0 +1,88 @@
+#include "..\..\script_component.hpp"
+FIX_LINE_NUMBERS()
+/* ----------------------------------------------------------------------------
+Function: A3A_fnc_initPricingLists
+
+Description:
+    Initializes the pricing lists for various vehicles and items in the game.
+
+Parameters:
+
+Optional:
+
+Example:
+    Called by fn_initVarServer.sqf
+
+Returns:
+    <HASHMAP> of vehicle class names to their respective prices
+
+Environment:
+    Server, Unscheduled
+
+Author:
+    UnseenKill/gor3Splatter
+---------------------------------------------------------------------------- */
+Trace_1(QFUNCMAIN(initPricingLists),_this);
+
+private _prices = createHashMap;
+
+// Find validly scoped direct descendants of the Vehicle class in the Pricing config
+QUOTE(getNumber(_x >> 'scope') > 0) configClasses(configFile >> "A3A" >> "Pricing" >> "Vehicle") apply {
+    private _config = _x;
+    private _moniker = getText(_x >> "moniker");
+
+    Trace_2(QFUNCMAIN(initPricingLists),_config,_moniker);
+
+    private _map = missionNamespace getVariable format["A3A_faction_%1", _moniker];
+
+    if (isNil "_map") then {
+        Warning_1("No such faction: '%1'",_moniker);
+        continue;
+    };
+
+    // Iterate over each group's properties in the config and set the
+    // corresponding server variables for the faction's vehicles
+    configProperties[_config >> "Groups"] apply {
+        private _group = configName _x;
+        private _price = getNumber _x;
+
+        Trace_2(QFUNCMAIN(initPricingLists),_group,_price);
+
+        private _vehicles = _map get _group;
+        if (isNil "_vehicles") then {
+            Warning_2("No vehicles found for faction %1 group: '%2'",_moniker,_group);
+            continue;
+        };
+
+        // Convert string entries to single item list
+        if !(_vehicles isEqualType []) then {
+            _vehicles = [_vehicles];
+        };
+
+        _vehicles apply {
+            Trace_4(QFUNCMAIN(initPricingLists),_moniker,_group,_x,_price);
+            _prices set[_x, _price];
+        };
+    };
+
+    // Iterate over each group's individual vehicle configs and apply
+    configProperties[_config >> "Vehicles"] apply {
+        private _vehicle = configName _x;
+        private _price = getNumber _x;
+
+        Trace_3(QFUNCMAIN(initPricingLists),_vehicle,_price);
+
+        _prices set[_vehicle, _price];
+    };
+};
+
+// Now everything's collected. See if there are undefined vehicle classes
+// and drop them.
+_prices apply {
+    if !(isClass(configFile >> "CfgVehicles" >> _x)) then {
+        _prices deleteAt _x;
+        Warning_2("Undefined class in vehicle/price combo: '%1'/'%2'", _x, _y);
+    };
+};
+
+_prices;

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -647,59 +647,42 @@ Info("Creating pricelist");
 
 server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 
-private _ignoreVehicles = keys A3A_rebelVehicleCosts;
-
 {
-	server setVariable [_x, _y, true];
-} forEach A3A_rebelVehicleCosts;
-
-{
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 1500, true];
-	};
+	server setVariable [_x, 1500, true];
 } forEach (FactionGet(all,"vehiclesLight") + OccAndInv("vehiclesTrucks") + OccAndInv("vehiclesCargoTrucks") + OccAndInv("vehiclesMilitiaTrucks") + FactionGet(reb,"vehiclesTruck"));
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 3000, true];
-	};
+	server setVariable [_x, 3000, true];
 } forEach (FactionGet(all,"vehiclesBoats") + FactionGet(all,"vehiclesLightAPCs") + OccAndInv("vehiclesAmmoTrucks") + OccAndInv("vehiclesRepairTrucks") + OccAndInv("vehiclesFuelTrucks") + OccAndInv("vehiclesMedical"));
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 5000, true];
-	};
+	server setVariable [_x, 5000, true];
 } forEach (FactionGet(all,"vehiclesAPCs") + FactionGet(all,"vehiclesIFVs") + FactionGet(all,"vehiclesHelisLightAttack") + FactionGet(all,"vehiclesTransportAir") + FactionGet(all,"vehiclesUAVs"));
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 6000, true];
-	};
+	server setVariable [_x, 6000, true];
 } forEach FactionGet(all,"vehiclesHelisLight");
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 7000, true];
-	};
+	server setVariable [_x, 7000, true];
 } forEach FactionGet(all,"vehiclesLightTanks");
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 13000, true];
-	};
+	server setVariable [_x, 13000, true];
 } forEach (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesTanks") + FactionGet(all,"vehiclesAA") + FactionGet(all,"vehiclesArtillery"));
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 15000, true];
-	};
+	server setVariable [_x, 15000, true];
 } forEach (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"));
 
 {
-	if (!(_x in _ignoreVehicles)) then {
-		server setVariable [_x, 20000, true];
-	};
+	server setVariable [_x, 20000, true];
 } forEach FactionGet(all,"vehiclesPlanesGunship");
+
+// Ensure this is last to prevent infinite money hacks
+{
+	server setVariable [_x, _y, true];
+} forEach A3A_rebelVehicleCosts;
 
 ///////////////////////
 //     GARRISONS    ///

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -684,6 +684,8 @@ server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 	server setVariable [_x, _y, true];
 } forEach A3A_rebelVehicleCosts;
 
+DECLARE_SERVER_VAR(A3A_rebelVehicles, keys A3A_rebelVehicleCosts);
+
 ///////////////////////
 //     GARRISONS    ///
 ///////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -571,31 +571,6 @@ private _groundVehicleThreat = createHashMap;
 // Rebel vehicle cost
 private _rebelVehicleCosts = createHashMap;
 
-private _fnc_setPriceIfValid =
-{
-	_this params ["_hashMap", "_className", "_price"];
-	private _configClass = configFile >> "CfgVehicles" >> _className;
-    if (isClass _configClass) then {
-		_hashMap set [_className, _price];
-	};
-};
-
-{ [_rebelVehicleCosts, _x, 100] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesBasic");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivCar") + FactionGet(reb, "vehiclesCivBoat");
-{ [_rebelVehicleCosts, _x, 600] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivTruck") + FactionGet(reb, "vehiclesMedical");
-{ [_rebelVehicleCosts, _x, 300] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesTruck");
-{ [_rebelVehicleCosts, _x, 200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightUnarmed");
-{ [_rebelVehicleCosts, _x, 800] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesLightArmed");
-{ [_rebelVehicleCosts, _x, 500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMGs") + FactionGet(reb, "vehiclesBoat");
-{ [_rebelVehicleCosts, _x, 1000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAT");
-{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticAA");
-{ [_rebelVehicleCosts, _x, 2500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "staticMortars");
-{ [_rebelVehicleCosts, _x, 1500] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAA");
-{ [_rebelVehicleCosts, _x, 1200] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesAT");
-{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesCivHeli");
-{ [_rebelVehicleCosts, _x, 5000] call _fnc_setPriceIfValid } forEach FactionGet(reb, "vehiclesPlane") + FactionGet(reb, "vehiclesCivPlane");
-
-
 // Template overrides
 private _overrides = FactionGet(Reb, "attributesVehicles") + FactionGet(Occ, "attributesVehicles") + FactionGet(Inv, "attributesVehicles");
 _overrides apply {

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -652,35 +652,35 @@ server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 } forEach A3A_rebelVehicleCosts;
 
 {
-	server setVariable [_x, 750, true];
+	server setVariable [_x, 1500, true];
 } forEach (FactionGet(all,"vehiclesLight") + OccAndInv("vehiclesTrucks") + OccAndInv("vehiclesCargoTrucks") + OccAndInv("vehiclesMilitiaTrucks") + FactionGet(reb,"vehiclesTruck"));
 
 {
-	server setVariable [_x, 1500, true];
+	server setVariable [_x, 3000, true];
 } forEach (FactionGet(all,"vehiclesBoats") + FactionGet(all,"vehiclesLightAPCs") + OccAndInv("vehiclesAmmoTrucks") + OccAndInv("vehiclesRepairTrucks") + OccAndInv("vehiclesFuelTrucks") + OccAndInv("vehiclesMedical"));
 
 {
-	server setVariable [_x, 2500, true];
+	server setVariable [_x, 5000, true];
 } forEach (FactionGet(all,"vehiclesAPCs") + FactionGet(all,"vehiclesIFVs") + FactionGet(all,"vehiclesHelisLightAttack") + FactionGet(all,"vehiclesTransportAir") + FactionGet(all,"vehiclesUAVs"));
 
 {
-	server setVariable [_x, 3000, true];
+	server setVariable [_x, 6000, true];
 } forEach FactionGet(all,"vehiclesHelisLight");
 
 {
-	server setVariable [_x, 3500, true];
+	server setVariable [_x, 7000, true];
 } forEach FactionGet(all,"vehiclesLightTanks");
 
 {
-	server setVariable [_x, 6500, true];
+	server setVariable [_x, 13000, true];
 } forEach (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesTanks") + FactionGet(all,"vehiclesAA") + FactionGet(all,"vehiclesArtillery"));
 
 {
-	server setVariable [_x, 7500, true];
+	server setVariable [_x, 15000, true];
 } forEach (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"));
 
 {
-	server setVariable [_x, 10000, true];
+	server setVariable [_x, 20000, true];
 } forEach FactionGet(all,"vehiclesPlanesGunship");
 
 ///////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -571,7 +571,7 @@ private _groundVehicleThreat = createHashMap;
 // Rebel vehicle cost
 private _rebelVehicleCosts = createHashMap;
 
-_fnc_setPriceIfValid =
+private _fnc_setPriceIfValid =
 {
 	_this params ["_hashMap", "_className", "_price"];
 	private _configClass = configFile >> "CfgVehicles" >> _className;
@@ -598,19 +598,20 @@ _fnc_setPriceIfValid =
 
 // Template overrides
 private _overrides = FactionGet(Reb, "attributesVehicles") + FactionGet(Occ, "attributesVehicles") + FactionGet(Inv, "attributesVehicles");
-{
-	private _vehType = _x select 0;
-	if !(_vehType in ((keys _vehicleResourceCosts) + (keys _rebelVehicleCosts))) then { continue };
-	{
-		if !(_x isEqualType []) then { continue };		// first entry is classname
-		_x params ["_attr", "_val"];
-		call {
-			if (_attr == "threat") exitWith { _groundVehicleThreat set [_vehType, _val] };
-			if (_attr == "cost") exitWith { _vehicleResourceCosts set [_vehType, _val] };
-			if (_attr == "rebCost") exitWith { _rebelVehicleCosts set [_vehType, _val] };
+_overrides apply {
+	private _override = _x;
+	_override params["_vehicleType"];
+
+	if (!(_vehicleType in _vehicleResourceCosts) && !(_vehicleType in _rebelVehicleCosts)) then { continue };
+	(_override select [1]) apply {
+		_x params["_key", "_value"];
+		switch _key do {
+			case "threat": { _groundVehicleThreat set[_vehicleType, _value] };
+			case "cost": { _vehicleResourceCosts set[_vehicleType, _value] };
+			case "rebCost": { _rebelVehicleCosts set[_vehicleType, _value] };
 		};
-	} forEach _x;
-} forEach _overrides;
+	};
+};
 
 DECLARE_SERVER_VAR(A3A_vehicleResourceCosts, _vehicleResourceCosts);
 DECLARE_SERVER_VAR(A3A_groundVehicleThreat, _groundVehicleThreat);

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -637,53 +637,26 @@ if (A3A_hasACRE && startWithLongRangeRadio) then {FactionGet(reb,"initialRebelEq
 ////////////////////////////////////
 Info("Creating pricelist");
 
-{server setVariable [_x,50,true]} forEach [FactionGet(reb,"unitRifle"), FactionGet(reb,"unitCrew")];
-{server setVariable [_x,75,true]} forEach [FactionGet(reb,"unitMG"), FactionGet(reb,"unitGL"), FactionGet(reb,"unitLAT")];
-{server setVariable [_x,100,true]} forEach [FactionGet(reb,"unitMedic"), FactionGet(reb,"unitExp"), FactionGet(reb,"unitEng")];
-{server setVariable [_x,150,true]} forEach [FactionGet(reb,"unitSL"), FactionGet(reb,"unitSniper")];
-{server setVariable [_x,500,true]} forEach [FactionGet(reb,"unitAT"), FactionGet(reb,"unitAA")];
+private _prices = [] call A3A_fnc_initPricingLists;
 
 //black market costs
-{server setVariable [_x select 0, _x select 1, true]} forEach (FactionGet(reb,"blackMarketStock"));
-
-server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
-
-{
-	server setVariable [_x, 1500, true];
-} forEach (FactionGet(all,"vehiclesLight") + OccAndInv("vehiclesTrucks") + OccAndInv("vehiclesCargoTrucks") + OccAndInv("vehiclesMilitiaTrucks") + FactionGet(reb,"vehiclesTruck"));
-
-{
-	server setVariable [_x, 3000, true];
-} forEach (FactionGet(all,"vehiclesBoats") + FactionGet(all,"vehiclesLightAPCs") + OccAndInv("vehiclesAmmoTrucks") + OccAndInv("vehiclesRepairTrucks") + OccAndInv("vehiclesFuelTrucks") + OccAndInv("vehiclesMedical"));
-
-{
-	server setVariable [_x, 5000, true];
-} forEach (FactionGet(all,"vehiclesAPCs") + FactionGet(all,"vehiclesIFVs") + FactionGet(all,"vehiclesHelisLightAttack") + FactionGet(all,"vehiclesTransportAir") + FactionGet(all,"vehiclesUAVs"));
-
-{
-	server setVariable [_x, 6000, true];
-} forEach FactionGet(all,"vehiclesHelisLight");
-
-{
-	server setVariable [_x, 7000, true];
-} forEach FactionGet(all,"vehiclesLightTanks");
-
-{
-	server setVariable [_x, 13000, true];
-} forEach (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesTanks") + FactionGet(all,"vehiclesAA") + FactionGet(all,"vehiclesArtillery"));
-
-{
-	server setVariable [_x, 15000, true];
-} forEach (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"));
-
-{
-	server setVariable [_x, 20000, true];
-} forEach FactionGet(all,"vehiclesPlanesGunship");
+FactionGet(reb,"blackMarketStock") apply {
+	_x params["_item", "_price"];
+	_prices set[_item, _price];
+};
 
 // Ensure this is last to prevent infinite money hacks
-{
-	server setVariable [_x, _y, true];
-} forEach A3A_rebelVehicleCosts;
+A3A_rebelVehicleCosts apply {
+	_prices set[_x, _y];
+};
+
+// Update server global variable
+_prices apply {
+	server setVariable[_x, _y];
+};
+
+// Network traffic once instead of for each and every `server setVariable` call
+publicVariable "server";
 
 ///////////////////////
 //     GARRISONS    ///

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -647,40 +647,58 @@ Info("Creating pricelist");
 
 server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 
+private _ignoreVehicles = keys A3A_rebelVehicleCosts;
+
 {
 	server setVariable [_x, _y, true];
 } forEach A3A_rebelVehicleCosts;
 
 {
-	server setVariable [_x, 1500, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 1500, true];
+	};
 } forEach (FactionGet(all,"vehiclesLight") + OccAndInv("vehiclesTrucks") + OccAndInv("vehiclesCargoTrucks") + OccAndInv("vehiclesMilitiaTrucks") + FactionGet(reb,"vehiclesTruck"));
 
 {
-	server setVariable [_x, 3000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 3000, true];
+	};
 } forEach (FactionGet(all,"vehiclesBoats") + FactionGet(all,"vehiclesLightAPCs") + OccAndInv("vehiclesAmmoTrucks") + OccAndInv("vehiclesRepairTrucks") + OccAndInv("vehiclesFuelTrucks") + OccAndInv("vehiclesMedical"));
 
 {
-	server setVariable [_x, 5000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 5000, true];
+	};
 } forEach (FactionGet(all,"vehiclesAPCs") + FactionGet(all,"vehiclesIFVs") + FactionGet(all,"vehiclesHelisLightAttack") + FactionGet(all,"vehiclesTransportAir") + FactionGet(all,"vehiclesUAVs"));
 
 {
-	server setVariable [_x, 6000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 6000, true];
+	};
 } forEach FactionGet(all,"vehiclesHelisLight");
 
 {
-	server setVariable [_x, 7000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 7000, true];
+	};
 } forEach FactionGet(all,"vehiclesLightTanks");
 
 {
-	server setVariable [_x, 13000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 13000, true];
+	};
 } forEach (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesTanks") + FactionGet(all,"vehiclesAA") + FactionGet(all,"vehiclesArtillery"));
 
 {
-	server setVariable [_x, 15000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 15000, true];
+	};
 } forEach (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"));
 
 {
-	server setVariable [_x, 20000, true];
+	if (!(_x in _ignoreVehicles)) then {
+		server setVariable [_x, 20000, true];
+	};
 } forEach FactionGet(all,"vehiclesPlanesGunship");
 
 ///////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -30,6 +30,8 @@ private _declareServerVariable = {
 #define ONLY_DECLARE_SERVER_VAR_FROM_VARIABLE(name) [name] call _declareServerVariable
 #define DECLARE_SERVER_VAR_FROM_VARIABLE(name, value) [name, value] call _declareServerVariable
 
+#define OccAndInv(VAR) (FactionGet(occ, VAR) + FactionGet(inv, VAR))
+
 ////////////////////////////////////////
 //     GENERAL SERVER VARIABLES      ///
 ////////////////////////////////////////
@@ -648,6 +650,38 @@ server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 {
 	server setVariable [_x, _y, true];
 } forEach A3A_rebelVehicleCosts;
+
+{
+	server setVariable [_x, 750, true];
+} forEach (FactionGet(all,"vehiclesLight") + OccAndInv("vehiclesTrucks") + OccAndInv("vehiclesCargoTrucks") + OccAndInv("vehiclesMilitiaTrucks") + FactionGet(reb,"vehiclesTruck"));
+
+{
+	server setVariable [_x, 1500, true];
+} forEach (FactionGet(all,"vehiclesBoats") + FactionGet(all,"vehiclesLightAPCs") + OccAndInv("vehiclesAmmoTrucks") + OccAndInv("vehiclesRepairTrucks") + OccAndInv("vehiclesFuelTrucks") + OccAndInv("vehiclesMedical"));
+
+{
+	server setVariable [_x, 2500, true];
+} forEach (FactionGet(all,"vehiclesAPCs") + FactionGet(all,"vehiclesIFVs") + FactionGet(all,"vehiclesHelisLightAttack") + FactionGet(all,"vehiclesTransportAir") + FactionGet(all,"vehiclesUAVs"));
+
+{
+	server setVariable [_x, 3000, true];
+} forEach FactionGet(all,"vehiclesHelisLight");
+
+{
+	server setVariable [_x, 3500, true];
+} forEach FactionGet(all,"vehiclesLightTanks");
+
+{
+	server setVariable [_x, 6500, true];
+} forEach (FactionGet(all,"vehiclesHelisAttack") + FactionGet(all,"vehiclesTanks") + FactionGet(all,"vehiclesAA") + FactionGet(all,"vehiclesArtillery"));
+
+{
+	server setVariable [_x, 7500, true];
+} forEach (FactionGet(all,"vehiclesPlanesCAS") + FactionGet(all,"vehiclesPlanesAA") + FactionGet(all,"vehiclesPlanesLargeAA") + FactionGet(all,"vehiclesPlanesLargeCAS"));
+
+{
+	server setVariable [_x, 10000, true];
+} forEach FactionGet(all,"vehiclesPlanesGunship");
 
 ///////////////////////
 //     GARRISONS    ///

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -685,8 +685,6 @@ server setVariable [FactionGet(reb,"rallyPoint"), 100, true];
 	server setVariable [_x, _y, true];
 } forEach A3A_rebelVehicleCosts;
 
-DECLARE_SERVER_VAR(A3A_rebelVehicles, keys A3A_rebelVehicleCosts);
-
 ///////////////////////
 //     GARRISONS    ///
 ///////////////////////


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Right now garage and look at -> sell vehicle prices are independently calculated using two separate functions. This PR changes how vehicle selling works to ensure that vehicle price is the same regardless of what method you use to sell it.
>
> There is a small caveat right now that the damage multiplier applied to vehicle price when selling by looking at it is not applied to the garage due to how the two methods work. So garaged vehicles do not include damage in the price calculation.

**How can your changes be tested, or reproduced?**

> 1. Load an antistasi mission before checking out this PR
> 2. Spawn a plane owned by the occupying faction
> 3. Garage it
> 4. Observe the vehicle price, you may find it only worth 500
> 5. If it was worth 500, take it out of the garage and sell it
> 6. Observe the value of the vehicle when sold this way, likely not 500
> 7. Repeat steps 1-6 after checking out this PR
> 8. Observe the values being identical for an undamaged vehicle

**Does this PR include changes not authored by you?**

- [x] No
- [ ] Yes (See below)

## Please verify the following (If possible).

`*` - Mandatory

- [x] These changes are my own, or I have written permission to use them. `*`
- [x] These changes are ready for review, or will be marked as a draft. `*`
- [x] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [x] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.