### PR TITLE
Fix constant suppression of hints

### DIFF
--- a/A3A/addons/core/functions/UI/fn_customHintDismiss.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintDismiss.sqf
@@ -37,6 +37,9 @@ if (_dismissAll) then {
         A3A_customHint_MSGs deleteAt _lastMSGIndex;
     };
 };
+
+hintSilent ""; //flush hints
+
 A3A_customHint_UpdateTime = serverTime;
 [] call A3A_fnc_customHintRender;  // Instant update will be preffered when user is dismissing notifications.
 true;

--- a/A3A/addons/core/functions/UI/fn_customHintRender.sqf
+++ b/A3A/addons/core/functions/UI/fn_customHintRender.sqf
@@ -29,9 +29,7 @@ private _filename = "fn_customHintRender.sqf";
 
 if (!hasInterface || !A3A_customHintEnable) exitWith {false;}; // Disabled for server & HC.
 
-if (A3A_customHint_MSGs isEqualTo []) then {
-    hintSilent "";
-} else{
+if (A3A_customHint_MSGs isNotEqualTo []) then {
     private _autoDismiss = 15;  // Number of seconds for message lifetime  // Constant Value
     if (serverTime - A3A_customHint_UpdateTime > _autoDismiss) exitWith {
         [true] call A3A_fnc_customHintDismiss;


### PR DESCRIPTION
Still gives priority to the Antistasi custom hint system but allows normal hints in between.

## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> Currently Antistasi suppress normal hints and silent hints in order to show custom hints. This suppression happens even when no custom hint is queued, and that can interfere with other mods.

**How can your changes be tested, or reproduced?**

> In console run a non-empty hint e.g. hint "Hello";
before: hint is removed when 15 frame window is expired
after: upon exiting the console, the hint is still shown. Attempt a fast travel somewhere, and the hint will be replaced by a custom hint.

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes (See below)

***If yes:***

- [ ] I confirm that I, and by extension this repository, can legally use these third-party changes. (Provide links or author attribution.)

> ...

## Please verify the following (If possible).

`*` - Mandatory

- [X] These changes are my own, or I have written permission to use them. `*`
- [X] These changes are ready for review, or will be marked as a draft. `*`
- [X] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).
This PR closes #XYZ.

## Notes

> ...