### PR TITLE
No more permanent spaghetti arms after self-revive

### DIFF
--- a/A3A/addons/core/functions/Revive/fn_selfRevive.sqf
+++ b/A3A/addons/core/functions/Revive/fn_selfRevive.sqf
@@ -34,6 +34,7 @@ player setVariable ["A3A_selfReviveTimeout", _timeout + time];
 [_hintTitle, localize "STR_A3A_selfRevive_success"] call A3A_fnc_customHint;
 
 private _aimCoef = missionNamespace getVariable ["A3A_selfReviveAimCoef", 3];
+player setVariable[QGVAR(restoreAimCoef), getCustomAimCoef player];
 player setCustomAimCoef _aimCoef;
 
 // Some bog standard desaturation

--- a/A3A/addons/core/functions/Revive/fn_selfReviveReset.sqf
+++ b/A3A/addons/core/functions/Revive/fn_selfReviveReset.sqf
@@ -36,4 +36,11 @@ if (!_instant && !isNil { player getVariable "A3A_selfReviveTimeout" }) then {
 };
 player setVariable ["A3A_selfReviveTimeout", nil];
 
+if !(isNil { player getVariable QGVAR(restoreAimCoef) }) exitWith {
+    private _coef = player getVariable QGVAR(restoreAimCoef);
+    player setVariable[QGVAR(restoreAimCoef), nil];
+    Debug_1("Restoring previous aim coefficient: %1",_coef);
+    player setCustomAimCoef _coef;
+};
+
 if (getCustomAimCoef player > 1) then { player setCustomAimCoef 1 };


### PR DESCRIPTION
## What type of PR is this?
- [X] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What have you changed, and why?

**Information:**

> This PR corrects the permanent arbitrary weapon sway set after a player self revives and instead uses the previous sway value.

**How can your changes be tested, or reproduced?**

> 1. Die
> 2. Self revive
> 3. Wait five minutes
> 4. Color effects and excessive sway should dissipate

**Does this PR include changes not authored by you?**

- [X] No
- [ ] Yes

## Please verify the following

- [X] These changes are my own.
- [X] These changes are ready for review.
- [ ] I have loaded the mission in LAN host.
- [ ] I have loaded the mission on a dedicated server.

Is further work needed?

- [ ] Needs further testing.
- [ ] Needs further changes.
- [ ] Needs to be converted to a draft.

## Please specify which Issue this PR Resolves (If Applicable).

[This](https://discord.com/channels/817005365740044289/1188501758859808788/1548086972633849857) Discord message.
